### PR TITLE
(feature)add visibility_status to Legislation and Litigation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,4 @@ install:
 before_script:
   - bundle exec rake db:test:prepare
 script:
-  - bundle exec rubocop --fail-fast
-  - bundle exec rspec
+  - yarn test

--- a/app/admin/legislations.rb
+++ b/app/admin/legislations.rb
@@ -81,7 +81,6 @@ ActiveAdmin.register Legislation do
     f.inputs do
       f.input :title
       f.input :description, as: :trix
-      f.input :law_id
       f.input :document_type_ids,
               label: 'Document Types',
               as: :tags,
@@ -93,6 +92,9 @@ ActiveAdmin.register Legislation do
           f.input :framework,
                   as: :select,
                   collection: array_to_select_collection(Legislation::FRAMEWORKS)
+        end
+        column do
+          f.input :visibility_status, as: :select
         end
       end
     end

--- a/app/admin/legislations.rb
+++ b/app/admin/legislations.rb
@@ -7,6 +7,7 @@ ActiveAdmin.register Legislation do
 
   scope('All', &:all)
   scope('Draft', &:draft)
+  scope('Pending', &:pending)
   scope('Published', &:published)
   scope('Archived', &:archived)
 

--- a/app/admin/legislations.rb
+++ b/app/admin/legislations.rb
@@ -1,12 +1,14 @@
 ActiveAdmin.register Legislation do
+  config.remove_batch_action :destroy
   config.sort_order = 'date_passed_desc'
 
   menu parent: 'Laws', priority: 1
 
   decorate_with LegislationDecorator
 
-  permit_params :title, :date_passed, :description, :framework,
-                :location_id, :law_id, document_type_ids: []
+  permit_params :title, :date_passed, :description,
+                :framework, :location_id, :law_id,
+                :visibility_status, document_type_ids: []
 
   filter :title_contains, label: 'Title'
   filter :date_passed
@@ -24,8 +26,15 @@ ActiveAdmin.register Legislation do
     column :framework
     column :location
     column :document_types
+    tag_column :visibility_status
 
     actions
+  end
+
+  sidebar 'Publishing Status', only: :show do
+    attributes_table do
+      tag_row :visibility_status, interactive: true
+    end
   end
 
   show do

--- a/app/admin/legislations.rb
+++ b/app/admin/legislations.rb
@@ -1,5 +1,4 @@
 ActiveAdmin.register Legislation do
-  config.remove_batch_action :destroy
   config.sort_order = 'date_passed_desc'
 
   menu parent: 'Laws', priority: 1

--- a/app/admin/legislations.rb
+++ b/app/admin/legislations.rb
@@ -5,6 +5,9 @@ ActiveAdmin.register Legislation do
 
   decorate_with LegislationDecorator
 
+  scope('All') { |legislations| legislations.all }
+  scope('Published') { |legislations| legislations.where(visibility_status: 'published') }
+
   permit_params :title, :date_passed, :description,
                 :framework, :location_id, :law_id,
                 :visibility_status, document_type_ids: []

--- a/app/admin/legislations.rb
+++ b/app/admin/legislations.rb
@@ -5,8 +5,10 @@ ActiveAdmin.register Legislation do
 
   decorate_with LegislationDecorator
 
-  scope('All') { |legislations| legislations.all }
-  scope('Published') { |legislations| legislations.where(visibility_status: 'published') }
+  scope('All', &:all)
+  scope('Draft', &:draft)
+  scope('Published', &:published)
+  scope('Archived', &:archived)
 
   permit_params :title, :date_passed, :description,
                 :framework, :location_id, :law_id,

--- a/app/admin/litigations.rb
+++ b/app/admin/litigations.rb
@@ -3,7 +3,14 @@ ActiveAdmin.register Litigation do
 
   decorate_with LitigationDecorator
 
-  permit_params :title, :location_id, :jurisdiction_id, :document_type, :summary, :core_objective,
+  scope('All', &:all)
+  scope('Draft', &:draft)
+  scope('Pending', &:pending)
+  scope('Published', &:published)
+  scope('Archived', &:archived)
+
+  permit_params :title, :location_id, :jurisdiction_id, :document_type,
+                :visibility_status, :summary, :core_objective,
                 litigation_sides_attributes: [
                   :id, :_destroy, :name, :side_type, :party_type, :connected_with
                 ],
@@ -26,7 +33,15 @@ ActiveAdmin.register Litigation do
     column :document_type
     column :location
     column :citation_reference_number
+    tag_column :visibility_status
+
     actions
+  end
+
+  sidebar 'Publishing Status', only: :show do
+    attributes_table do
+      tag_row :visibility_status, interactive: true
+    end
   end
 
   show do

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -86,6 +86,21 @@ fieldset.actions .cancel a {
   }
 }
 
+// Status
+$draft-color: #9fc881;
+$pending-color: #ffb434;
+$published-color: #4ba532;
+$archived-color: #c4c0c0;
+$unset-color: #979494;
+
+.status_tag {
+  &.draft { background: $draft-color; }
+  &.pending { background: $pending-color; }
+  &.published { background: $published-color; }
+  &.archived { background: $archived-color; }
+  &.unset { background: $unset-color; }
+}
+
 // Tables
 
 table.cell-padding-sm {
@@ -174,6 +189,8 @@ form {
     flex-grow: 1;
   }
 }
+
+// Resource specific styles
 
 .litigation-sides-fields {
   li[id*=side_type] {

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -32,6 +32,6 @@ class Legislation < ApplicationRecord
   has_and_belongs_to_many :targets
   has_and_belongs_to_many :litigations
 
-  validates_presence_of :title, :framework, :slug, :date_passed
+  validates_presence_of :title, :framework, :slug, :date_passed, :visibility_status
   validates_uniqueness_of :slug
 end

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -21,7 +21,7 @@ class Legislation < ApplicationRecord
   friendly_id :title, use: :slugged
 
   FRAMEWORKS = %w[mitigation adaptation mitigation_and_adaptation no].freeze
-  VISIBILITY = %w[draft pending published archived]
+  VISIBILITY = %w[draft pending published archived].freeze
 
   enum framework: array_to_enum_hash(FRAMEWORKS)
   enum visibility_status: array_to_enum_hash(VISIBILITY)

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -21,8 +21,10 @@ class Legislation < ApplicationRecord
   friendly_id :title, use: :slugged
 
   FRAMEWORKS = %w[mitigation adaptation mitigation_and_adaptation no].freeze
+  VISIBILITY = %w[draft pending published archived]
 
   enum framework: array_to_enum_hash(FRAMEWORKS)
+  enum visibility_status: array_to_enum_hash(VISIBILITY)
 
   tag_with :document_types
 

--- a/app/models/litigation.rb
+++ b/app/models/litigation.rb
@@ -21,8 +21,10 @@ class Litigation < ApplicationRecord
   friendly_id :title, use: :slugged
 
   DOCUMENT_TYPES = %w[case investigation inquiry].freeze
+  VISIBILITY = %w[draft pending published archived].freeze
 
   enum document_type: array_to_enum_hash(DOCUMENT_TYPES)
+  enum visibility_status: array_to_enum_hash(VISIBILITY)
 
   belongs_to :location
   belongs_to :jurisdiction, class_name: 'Location'
@@ -33,5 +35,5 @@ class Litigation < ApplicationRecord
   accepts_nested_attributes_for :documents, allow_destroy: true
   accepts_nested_attributes_for :litigation_sides, allow_destroy: true
 
-  validates_presence_of :title, :slug, :document_type
+  validates_presence_of :title, :slug, :document_type, :visibility_status
 end

--- a/app/views/admin/litigations/_form.html.erb
+++ b/app/views/admin/litigations/_form.html.erb
@@ -21,6 +21,7 @@
           <%= f.input :summary, as: :trix %>
           <%= f.input :core_objective, as: :trix %>
           <%= f.input :legislation_ids, as: :selected_list, label: 'Connected Legislations', fields: [:title], display_name: :title, order: 'title_asc' %>
+          <%= f.input :visibility_status, as: :select %>
         <% end %>
       </div>
 

--- a/db/migrate/20190801123408_add_visibility_status_to_legislation.rb
+++ b/db/migrate/20190801123408_add_visibility_status_to_legislation.rb
@@ -1,5 +1,5 @@
 class AddVisibilityStatusToLegislation < ActiveRecord::Migration[5.2]
   def change
-    add_column :legislations, :visibility_status, :string
+    add_column :legislations, :visibility_status, :string, index: true
   end
 end

--- a/db/migrate/20190801123408_add_visibility_status_to_legislation.rb
+++ b/db/migrate/20190801123408_add_visibility_status_to_legislation.rb
@@ -1,0 +1,5 @@
+class AddVisibilityStatusToLegislation < ActiveRecord::Migration[5.2]
+  def change
+    add_column :legislations, :visibility_status, :string
+  end
+end

--- a/db/migrate/20190801123408_add_visibility_status_to_legislation.rb
+++ b/db/migrate/20190801123408_add_visibility_status_to_legislation.rb
@@ -1,5 +1,5 @@
 class AddVisibilityStatusToLegislation < ActiveRecord::Migration[5.2]
   def change
-    add_column :legislations, :visibility_status, :string, index: true
+    add_column :legislations, :visibility_status, :string, index: true, default: 'draft'
   end
 end

--- a/db/migrate/20190802113528_add_visibility_status_to_litigation.rb
+++ b/db/migrate/20190802113528_add_visibility_status_to_litigation.rb
@@ -1,0 +1,5 @@
+class AddVisibilityStatusToLitigation < ActiveRecord::Migration[5.2]
+  def change
+    add_column :litigations, :visibility_status, :string, index: true, default: 'draft'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2019_08_01_123408) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -124,7 +124,7 @@ ActiveRecord::Schema.define(version: 2019_08_01_123408) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.date "date_passed"
-    t.string "visibility_status"
+    t.string "visibility_status", default: "draft"
     t.index ["location_id"], name: "index_legislations_on_location_id"
     t.index ["slug"], name: "index_legislations_on_slug", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_01_123408) do
+ActiveRecord::Schema.define(version: 2019_08_02_113528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -169,6 +169,7 @@ ActiveRecord::Schema.define(version: 2019_08_01_123408) do
     t.text "keywords"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "visibility_status", default: "draft"
     t.index ["document_type"], name: "index_litigations_on_document_type"
     t.index ["jurisdiction_id"], name: "index_litigations_on_jurisdiction_id"
     t.index ["location_id"], name: "index_litigations_on_location_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_01_105940) do
-
+ActiveRecord::Schema.define(version: 2019_08_01_123408) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -124,6 +123,7 @@ ActiveRecord::Schema.define(version: 2019_08_01_105940) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.date "date_passed"
+    t.string "visibility_status"
     t.index ["location_id"], name: "index_legislations_on_location_id"
     t.index ["slug"], name: "index_legislations_on_slug", unique: true
   end

--- a/spec/factories/legislations.rb
+++ b/spec/factories/legislations.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
     date_passed { 2.years.ago }
     sequence(:law_id)
     framework { Legislation::FRAMEWORKS.sample }
+    visibility_status { Legislation::VISIBILITY.sample }
 
     association :location
   end

--- a/spec/factories/litigations.rb
+++ b/spec/factories/litigations.rb
@@ -27,6 +27,7 @@ FactoryBot.define do
     summary { 'Summary Lorem ipsum dolor dalej nie pamietam' }
     core_objective { 'Core objectives Lorem ipsumumum' }
     keywords { 'adaption, mitigation, great litigation' }
+    visibility_status { Litigation::VISIBILITY.sample }
 
     trait :with_sides do
       after(:create) do |l|

--- a/spec/models/legislation_spec.rb
+++ b/spec/models/legislation_spec.rb
@@ -40,4 +40,9 @@ RSpec.describe Legislation, type: :model do
     subject.date_passed = nil
     expect(subject).to have(1).errors_on(:date_passed)
   end
+
+  it 'should be invalid if visibility_status is nil' do
+    subject.visibility_status = nil
+    expect(subject).to have(1).errors_on(:visibility_status)
+  end
 end

--- a/spec/models/litigation_spec.rb
+++ b/spec/models/litigation_spec.rb
@@ -32,4 +32,9 @@ RSpec.describe Litigation, type: :model do
     subject.document_type = nil
     expect(subject).to have(1).errors_on(:document_type)
   end
+
+  it 'should be invalid if visibility_status is nil' do
+    subject.visibility_status = nil
+    expect(subject).to have(1).errors_on(:visibility_status)
+  end
 end


### PR DESCRIPTION
### Summary

- add `visibility_status` to **Legislation** and **Litigation** resources. options: `draft | pending | published | archived`, default `draft`
- I've added list scopes (above the list), so I'm not including a new filter in the sidebar
- added sidebar on show page - use can edit 'visibility_status' from this place directly

#### index page
<img width="1065" alt="Zrzut ekranu 2019-08-02 o 11 42 09" src="https://user-images.githubusercontent.com/10665/62361101-9aa82a00-b51a-11e9-9672-b6f7555bdeac.png">

#### show page
- use can edit status directly from here:
<img width="348" alt="Zrzut ekranu 2019-08-01 o 16 16 00" src="https://user-images.githubusercontent.com/10665/62300782-af7fb180-b477-11e9-9816-1d1f2894256c.png">

<img width="1424" alt="Zrzut ekranu 2019-08-01 o 16 04 13" src="https://user-images.githubusercontent.com/10665/62300640-72b3ba80-b477-11e9-85ab-6e52e7e86c62.png">
