### PR TITLE
friendlyid unify admin routes

### DIFF
--- a/app/admin/companies.rb
+++ b/app/admin/companies.rb
@@ -175,9 +175,5 @@ ActiveAdmin.register Company do
     def scoped_collection
       super.includes(:location, :headquarter_location, :mq_assessments)
     end
-
-    def find_resource
-      scoped_collection.friendly.find(params[:id])
-    end
   end
 end

--- a/app/admin/legislations.rb
+++ b/app/admin/legislations.rb
@@ -116,9 +116,5 @@ ActiveAdmin.register Legislation do
     def scoped_collection
       super.includes(:location, :document_types)
     end
-
-    def find_resource
-      scoped_collection.friendly.find(params[:id])
-    end
   end
 end

--- a/app/admin/litigations.rb
+++ b/app/admin/litigations.rb
@@ -82,9 +82,5 @@ ActiveAdmin.register Litigation do
     def scoped_collection
       super.includes(:location)
     end
-
-    def find_resource
-      scoped_collection.friendly.find(params[:id])
-    end
   end
 end

--- a/app/admin/locations.rb
+++ b/app/admin/locations.rb
@@ -82,10 +82,6 @@ ActiveAdmin.register Location do
   end
 
   controller do
-    def find_resource
-      scoped_collection.friendly.find(params[:id])
-    end
-
     def apply_filtering(chain)
       super(chain).distinct
     end

--- a/app/admin/sectors.rb
+++ b/app/admin/sectors.rb
@@ -62,10 +62,4 @@ ActiveAdmin.register Sector do
 
     f.actions
   end
-
-  controller do
-    def find_resource
-      scoped_collection.friendly.find(params[:id])
-    end
-  end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -17,7 +17,7 @@
 
 class Company < ApplicationRecord
   extend FriendlyId
-  friendly_id :name, use: :slugged
+  friendly_id :name, use: :slugged, routes: :default
 
   SIZES = %w[small medium large].freeze
   VISIBILITY = %w[draft pending published archived].freeze

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -18,7 +18,7 @@ class Legislation < ApplicationRecord
   include Taggable
   extend FriendlyId
 
-  friendly_id :title, use: :slugged
+  friendly_id :title, use: :slugged, routes: :default
 
   FRAMEWORKS = %w[mitigation adaptation mitigation_and_adaptation no].freeze
   VISIBILITY = %w[draft pending published archived].freeze

--- a/app/models/litigation.rb
+++ b/app/models/litigation.rb
@@ -18,7 +18,7 @@
 
 class Litigation < ApplicationRecord
   extend FriendlyId
-  friendly_id :title, use: :slugged
+  friendly_id :title, use: :slugged, routes: :default
 
   DOCUMENT_TYPES = %w[case investigation inquiry].freeze
   VISIBILITY = %w[draft pending published archived].freeze

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -20,7 +20,7 @@ class Location < ApplicationRecord
   include Taggable
   extend FriendlyId
 
-  friendly_id :name, use: :slugged
+  friendly_id :name, use: :slugged, routes: :default
 
   TYPES = %w[country].freeze
   VISIBILITY = %w[draft pending published archived].freeze

--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -11,7 +11,7 @@
 
 class Sector < ApplicationRecord
   extend FriendlyId
-  friendly_id :name, use: :slugged
+  friendly_id :name, use: :slugged, routes: :default
 
   has_many :companies
   has_many :cp_benchmarks, class_name: 'CP::Benchmark'


### PR DESCRIPTION
Better to have unified resources retrieval by id in the admin panel. Some slugs are long and not that friendly for admin panel that's why I'm changing resource retrieval to be by `id`.

We have to think if we need `friendly_id` at all, if only for slug generation then that's overkill. We may need to track slug history change in the future though.