### PR TITLE
Dynamic admin tag pages

### DIFF
--- a/app/admin/frameworks.rb
+++ b/app/admin/frameworks.rb
@@ -1,9 +1,0 @@
-ActiveAdmin.register Framework do
-  config.sort_order = 'name_asc'
-
-  menu parent: 'Tags'
-
-  permit_params :name
-
-  filter :name_contains, label: 'Name'
-end

--- a/app/admin/keywords.rb
+++ b/app/admin/keywords.rb
@@ -1,9 +1,0 @@
-ActiveAdmin.register Keyword do
-  config.sort_order = 'name_asc'
-
-  menu parent: 'Tags'
-
-  permit_params :name
-
-  filter :name_contains, label: 'Name'
-end

--- a/app/admin/natural_hazards.rb
+++ b/app/admin/natural_hazards.rb
@@ -1,9 +1,0 @@
-ActiveAdmin.register NaturalHazard do
-  config.sort_order = 'name_asc'
-
-  menu parent: 'Tags'
-
-  permit_params :name
-
-  filter :name_contains, label: 'Name'
-end

--- a/app/admin/political_groups.rb
+++ b/app/admin/political_groups.rb
@@ -1,9 +1,0 @@
-ActiveAdmin.register PoliticalGroup do
-  config.sort_order = 'name_asc'
-
-  menu parent: 'Tags'
-
-  permit_params :name
-
-  filter :name_contains, label: 'Name'
-end

--- a/app/admin/tags.rb
+++ b/app/admin/tags.rb
@@ -1,0 +1,47 @@
+%w[
+  PoliticalGroup
+  NaturalHazard
+  Keyword
+  Framework
+].each do |tag_class|
+  ActiveAdmin.register tag_class.constantize do
+    config.sort_order = 'name_asc'
+
+    menu parent: 'Tags'
+
+    permit_params :name
+
+    filter :name_contains, label: 'Name'
+
+    index do
+      id_column
+      column :name do |tag|
+        link_to tag.name, resource_path(tag)
+      end
+      column :created_at
+      column :updated_at
+      column 'Actions' do |tag|
+        div class: 'table_actions' do
+          span link_to 'Edit', resource_path(tag)
+          span link_to 'Delete', resource_path(tag),
+                       method: :delete,
+                       data: { confirm: 'Are you sure?' }
+        end
+      end
+    end
+
+    controller do
+      def show
+        redirect_to send("edit_admin_#{resource.class.name.underscore}_path")
+      end
+
+      def create
+        create! { collection_path }
+      end
+
+      def update
+        update! { collection_path }
+      end
+    end
+  end
+end

--- a/app/admin/tags.rb
+++ b/app/admin/tags.rb
@@ -25,7 +25,7 @@
           span link_to 'Edit', resource_path(tag)
           span link_to 'Delete', resource_path(tag),
                        method: :delete,
-                       data: { confirm: 'Are you sure?' }
+                       data: {confirm: 'Are you sure?'}
         end
       end
     end


### PR DESCRIPTION
I removed single tag pages which are not now created dynamically. Show page is redirecting to Edit page, also `View` action was removed from the menu on the index page.