### PR TITLE
Moved shared published functionality to concern

### DIFF
--- a/app/admin/companies.rb
+++ b/app/admin/companies.rb
@@ -2,11 +2,7 @@ ActiveAdmin.register Company do
   menu priority: 0, parent: 'TPI'
   config.sort_order = 'name_asc'
 
-  scope('All', &:all)
-  scope('Draft', &:draft)
-  scope('Pending', &:pending)
-  scope('Published', &:published)
-  scope('Archived', &:archived)
+  publishable_scopes
 
   permit_params :name, :isin, :sector_id, :location_id, :headquarter_location_id,
                 :ca100, :size, :visibility_status

--- a/app/admin/companies.rb
+++ b/app/admin/companies.rb
@@ -3,6 +3,7 @@ ActiveAdmin.register Company do
   config.sort_order = 'name_asc'
 
   publishable_scopes
+  publishable_sidebar only: :show
 
   permit_params :name, :isin, :sector_id, :location_id, :headquarter_location_id,
                 :ca100, :size, :visibility_status
@@ -16,12 +17,6 @@ ActiveAdmin.register Company do
          collection: proc { array_to_select_collection(Company::SIZES) }
 
   config.batch_actions = false
-
-  sidebar 'Publishing Status', only: :show do
-    attributes_table do
-      tag_row :visibility_status, interactive: true
-    end
-  end
 
   sidebar 'Details', only: :show do
     attributes_table do

--- a/app/admin/legislations.rb
+++ b/app/admin/legislations.rb
@@ -36,11 +36,7 @@ ActiveAdmin.register Legislation do
     actions
   end
 
-  sidebar 'Publishing Status', only: :show do
-    attributes_table do
-      tag_row :visibility_status, interactive: true
-    end
-  end
+  publishable_sidebar only: :show
 
   show do
     tabs do

--- a/app/admin/legislations.rb
+++ b/app/admin/legislations.rb
@@ -5,11 +5,7 @@ ActiveAdmin.register Legislation do
 
   decorate_with LegislationDecorator
 
-  scope('All', &:all)
-  scope('Draft', &:draft)
-  scope('Pending', &:pending)
-  scope('Published', &:published)
-  scope('Archived', &:archived)
+  publishable_scopes
 
   permit_params :title, :date_passed, :description,
                 :location_id, :law_id,

--- a/app/admin/litigations.rb
+++ b/app/admin/litigations.rb
@@ -4,6 +4,7 @@ ActiveAdmin.register Litigation do
   decorate_with LitigationDecorator
 
   publishable_scopes
+  publishable_sidebar only: :show
 
   permit_params :title, :location_id, :jurisdiction_id, :document_type,
                 :visibility_status, :summary, :core_objective,
@@ -35,12 +36,6 @@ ActiveAdmin.register Litigation do
     tag_column :visibility_status
 
     actions
-  end
-
-  sidebar 'Publishing Status', only: :show do
-    attributes_table do
-      tag_row :visibility_status, interactive: true
-    end
   end
 
   show do

--- a/app/admin/litigations.rb
+++ b/app/admin/litigations.rb
@@ -3,11 +3,7 @@ ActiveAdmin.register Litigation do
 
   decorate_with LitigationDecorator
 
-  scope('All', &:all)
-  scope('Draft', &:draft)
-  scope('Pending', &:pending)
-  scope('Published', &:published)
-  scope('Archived', &:archived)
+  publishable_scopes
 
   permit_params :title, :location_id, :jurisdiction_id, :document_type,
                 :visibility_status, :summary, :core_objective,

--- a/app/admin/locations.rb
+++ b/app/admin/locations.rb
@@ -5,6 +5,7 @@ ActiveAdmin.register Location do
   decorate_with LocationDecorator
 
   publishable_scopes
+  publishable_sidebar only: :show
 
   permit_params :name, :iso, :region, :federal, :federal_details,
                 :legislative_process, :location_type, :indc_url,
@@ -21,12 +22,6 @@ ActiveAdmin.register Location do
          collection: proc { PoliticalGroup.all }
 
   config.batch_actions = false
-
-  sidebar 'Publishing Status', only: :show do
-    attributes_table do
-      tag_row :visibility_status, interactive: true
-    end
-  end
 
   show do
     tabs do

--- a/app/admin/locations.rb
+++ b/app/admin/locations.rb
@@ -4,11 +4,7 @@ ActiveAdmin.register Location do
 
   decorate_with LocationDecorator
 
-  scope('All', &:all)
-  scope('Draft', &:draft)
-  scope('Pending', &:pending)
-  scope('Published', &:published)
-  scope('Archived', &:archived)
+  publishable_scopes
 
   permit_params :name, :iso, :region, :federal, :federal_details,
                 :legislative_process, :location_type, :indc_url,

--- a/app/admin/targets.rb
+++ b/app/admin/targets.rb
@@ -3,11 +3,7 @@ ActiveAdmin.register Target do
 
   decorate_with TargetDecorator
 
-  scope('All', &:all)
-  scope('Draft', &:draft)
-  scope('Pending', &:pending)
-  scope('Published', &:published)
-  scope('Archived', &:archived)
+  publishable_scopes
 
   permit_params :description, :sector_id, :location_id, :single_year, :target_scope_id,
                 :year, :base_year_period, :ghg_target, :target_type,

--- a/app/admin/targets.rb
+++ b/app/admin/targets.rb
@@ -4,6 +4,7 @@ ActiveAdmin.register Target do
   decorate_with TargetDecorator
 
   publishable_scopes
+  publishable_sidebar only: :show
 
   permit_params :description, :sector_id, :location_id, :single_year, :target_scope_id,
                 :year, :base_year_period, :ghg_target, :target_type,
@@ -19,12 +20,6 @@ ActiveAdmin.register Target do
          collection: proc { array_to_select_collection(Target::TYPES) }
 
   config.batch_actions = false
-
-  sidebar 'Publishing Status', only: :show do
-    attributes_table do
-      tag_row :visibility_status, interactive: true
-    end
-  end
 
   index do
     id_column

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -18,13 +18,12 @@
 
 class Company < ApplicationRecord
   extend FriendlyId
+  include Publishable
   friendly_id :name, use: :slugged, routes: :default
 
   SIZES = %w[small medium large].freeze
-  VISIBILITY = %w[draft pending published archived].freeze
 
   enum size: array_to_enum_hash(SIZES)
-  enum visibility_status: array_to_enum_hash(VISIBILITY)
 
   belongs_to :sector
   belongs_to :location
@@ -39,7 +38,7 @@ class Company < ApplicationRecord
            to: :latest_assessment, prefix: :mq, allow_nil: true
 
   validates :ca100, inclusion: {in: [true, false]}
-  validates_presence_of :name, :slug, :isin, :size, :visibility_status
+  validates_presence_of :name, :slug, :isin, :size
   validates_uniqueness_of :slug, :isin
 
   def latest_assessment

--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -1,0 +1,11 @@
+module Publishable
+  extend ActiveSupport::Concern
+
+  VISIBILITY = %w[draft pending published archived].freeze
+
+  included do
+    enum visibility_status: array_to_enum_hash(VISIBILITY)
+
+    validates_presence_of :visibility_status
+  end
+end

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -17,13 +17,10 @@
 class Legislation < ApplicationRecord
   include UserTrackable
   include Taggable
+  include Publishable
   extend FriendlyId
 
   friendly_id :title, use: :slugged, routes: :default
-
-  VISIBILITY = %w[draft pending published archived].freeze
-
-  enum visibility_status: array_to_enum_hash(VISIBILITY)
 
   tag_with :frameworks
   tag_with :document_types
@@ -34,6 +31,6 @@ class Legislation < ApplicationRecord
   has_and_belongs_to_many :targets
   has_and_belongs_to_many :litigations
 
-  validates_presence_of :title, :slug, :date_passed, :visibility_status
+  validates_presence_of :title, :slug, :date_passed
   validates_uniqueness_of :slug
 end

--- a/app/models/litigation.rb
+++ b/app/models/litigation.rb
@@ -22,16 +22,15 @@
 class Litigation < ApplicationRecord
   include UserTrackable
   include Taggable
+  include Publishable
 
   extend FriendlyId
 
   friendly_id :title, use: :slugged, routes: :default
 
   DOCUMENT_TYPES = %w[case investigation inquiry].freeze
-  VISIBILITY = %w[draft pending published archived].freeze
 
   enum document_type: array_to_enum_hash(DOCUMENT_TYPES)
-  enum visibility_status: array_to_enum_hash(VISIBILITY)
 
   tag_with :keywords
 
@@ -44,5 +43,5 @@ class Litigation < ApplicationRecord
   accepts_nested_attributes_for :documents, allow_destroy: true
   accepts_nested_attributes_for :litigation_sides, allow_destroy: true
 
-  validates_presence_of :title, :slug, :document_type, :visibility_status
+  validates_presence_of :title, :slug, :document_type
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -21,12 +21,12 @@
 class Location < ApplicationRecord
   include UserTrackable
   include Taggable
+  include Publishable
   extend FriendlyId
 
   friendly_id :name, use: :slugged, routes: :default
 
   TYPES = %w[country].freeze
-  VISIBILITY = %w[draft pending published archived].freeze
 
   REGIONS = [
     'East Asia & Pacific',
@@ -39,14 +39,13 @@ class Location < ApplicationRecord
   ].freeze
 
   enum location_type: array_to_enum_hash(TYPES)
-  enum visibility_status: array_to_enum_hash(VISIBILITY)
 
   tag_with :political_groups
 
   has_many :litigations
 
   validates_uniqueness_of :slug, :iso
-  validates_presence_of :name, :slug, :iso, :location_type, :visibility_status
+  validates_presence_of :name, :slug, :iso, :location_type
   validates :federal, inclusion: {in: [true, false]}
   validates :region, inclusion: {in: REGIONS}
   validates :indc_url, url: true

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -19,6 +19,7 @@
 
 class Target < ApplicationRecord
   include UserTrackable
+  include Publishable
 
   TYPES = %w[
     base_year_target
@@ -29,10 +30,8 @@ class Target < ApplicationRecord
     no_document_submitted
     trajectory_target
   ].freeze
-  VISIBILITY = %w[draft pending published archived].freeze
 
   enum target_type: array_to_enum_hash(TYPES)
-  enum visibility_status: array_to_enum_hash(VISIBILITY)
 
   belongs_to :location
   belongs_to :sector
@@ -41,7 +40,6 @@ class Target < ApplicationRecord
 
   validates :ghg_target, inclusion: {in: [true, false]}
   validates :single_year, inclusion: {in: [true, false]}
-  validates_presence_of :visibility_status
 
   def to_s
     "Target #{id}"

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -1,3 +1,5 @@
+Dir[Rails.root.join('lib/extensions/active_admin/*.rb')].each { |f| require f }
+
 ActiveAdmin.setup do |config|
   # == Site Title
   #
@@ -327,15 +329,9 @@ ActiveAdmin.setup do |config|
   # config.order_clause = MyOrderClause
 end
 
-class ActiveAdmin::ResourceDSL
-  include SelectHelper
-end
+Rails.configuration.to_prepare do
+  ActiveAdmin::ResourceDSL.send :include, SelectHelper
+  ActiveAdmin::ResourceDSL.send :include, ActiveAdminPublishable::Scopes
 
-ActiveAdmin::Views::Header.class_eval do
-  alias original_build build
-
-  def build(*args)
-    original_build(*args)
-    render 'admin/custom_header'
-  end
+  ActiveAdmin::Views::Header.send :prepend, ActiveAdminCustomHeader
 end

--- a/lib/extensions/active_admin/active_admin_custom_header.rb
+++ b/lib/extensions/active_admin/active_admin_custom_header.rb
@@ -1,0 +1,6 @@
+module ActiveAdminCustomHeader
+  def build(*args)
+    super(*args)
+    render 'admin/custom_header'
+  end
+end

--- a/lib/extensions/active_admin/active_admin_publishable.rb
+++ b/lib/extensions/active_admin/active_admin_publishable.rb
@@ -1,0 +1,11 @@
+module ActiveAdminPublishable
+  module Scopes
+    def publishable_scopes
+      scope('All', &:all)
+      scope('Draft', &:draft)
+      scope('Pending', &:pending)
+      scope('Published', &:published)
+      scope('Archived', &:archived)
+    end
+  end
+end

--- a/lib/extensions/active_admin/active_admin_publishable.rb
+++ b/lib/extensions/active_admin/active_admin_publishable.rb
@@ -7,5 +7,13 @@ module ActiveAdminPublishable
       scope('Published', &:published)
       scope('Archived', &:archived)
     end
+
+    def publishable_sidebar(*args)
+      sidebar 'Publishing Status', *args do
+        attributes_table do
+          tag_row :visibility_status, interactive: true
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR extracts the visibility status usage to a concern to be shared by different models.

I haven't done the same to the Admin pages under `app/admin` as I wasn't able to find a lot of guidance. I thought about extracting the scopes into a new concern for the admin bits, but not sure if it's worth it.

One example I found on Stack Overflow mentions using `extend` instead of include, because it seems that Active Admin doesn't support the ActiveSupport::Concern: https://stackoverflow.com/questions/27325605/dry-ing-up-activeadmin

Also found this word of warning: https://tmichel.github.io/2015/02/22/sharing-code-between-activeadmin-resources/