### PR TITLE
Feature/enable multiple isins

### DIFF
--- a/app/admin/companies.rb
+++ b/app/admin/companies.rb
@@ -34,7 +34,7 @@ ActiveAdmin.register Company do
           row :name
           row :slug
           row :sector
-          row :isin
+          row :isin, &:isin_string
           row :geography
           row :headquarters_geography
           row :ca100
@@ -119,7 +119,7 @@ ActiveAdmin.register Company do
     column :name do |company|
       link_to company.name, admin_company_path(company)
     end
-    column :isin
+    column :isin, &:isin_string
     column :size do |company|
       company.size.humanize
     end
@@ -136,7 +136,7 @@ ActiveAdmin.register Company do
     f.inputs do
       columns do
         column { f.input :name }
-        column { f.input :isin }
+        column { f.input :isin, as: :tags }
       end
 
       columns do

--- a/app/admin/companies.rb
+++ b/app/admin/companies.rb
@@ -1,5 +1,8 @@
 ActiveAdmin.register Company do
   menu priority: 0, parent: 'TPI'
+
+  decorate_with CompanyDecorator
+
   config.sort_order = 'name_asc'
 
   publishable_scopes
@@ -34,7 +37,7 @@ ActiveAdmin.register Company do
           row :name
           row :slug
           row :sector
-          row :isin, &:isin_string
+          row :isin, &:isin_as_tags
           row :geography
           row :headquarters_geography
           row :ca100
@@ -119,7 +122,7 @@ ActiveAdmin.register Company do
     column :name do |company|
       link_to company.name, admin_company_path(company)
     end
-    column :isin, &:isin_string
+    column :isin, &:isin_as_tags
     column :size do |company|
       company.size.humanize
     end

--- a/app/decorators/company_decorator.rb
+++ b/app/decorators/company_decorator.rb
@@ -1,0 +1,7 @@
+class CompanyDecorator < Draper::Decorator
+  delegate_all
+
+  def isin_as_tags
+    isin.split(',')
+  end
+end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -48,8 +48,4 @@ class Company < ApplicationRecord
   def to_s
     name
   end
-
-  def isin_string
-    isin.split(',')
-  end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -48,4 +48,8 @@ class Company < ApplicationRecord
   def to_s
     name
   end
+
+  def isin_string
+    isin.split(',')
+  end
 end

--- a/app/services/import/companies.rb
+++ b/app/services/import/companies.rb
@@ -19,8 +19,11 @@ module Import
       import_each_with_logging(csv, FILEPATH) do |row|
         company = Company.find_or_initialize_by(name: row[:company_name])
 
-        company.isin = company.isin.present? ?
-          (company.isin.split(',') + [row[:isin]]).uniq.join(",") : row[:isin]
+        company.isin = if company.isin.present?
+                         (company.isin.split(',') + [row[:isin]]).uniq.join(',')
+                       else
+                         row[:isin]
+                       end
 
         company.update!(company_attributes(row))
 

--- a/app/services/import/companies.rb
+++ b/app/services/import/companies.rb
@@ -17,7 +17,11 @@ module Import
 
     def import
       import_each_with_logging(csv, FILEPATH) do |row|
-        company = Company.find_or_initialize_by(isin: row[:isin])
+        company = Company.find_or_initialize_by(name: row[:company_name])
+
+        company.isin = company.isin.present? ?
+          (company.isin.split(',') + [row[:isin]]).uniq.join(",") : row[:isin]
+
         company.update!(company_attributes(row))
 
         create_mq_assessment!(row, company)
@@ -28,6 +32,7 @@ module Import
     def cleanup
       MQ::Assessment.destroy_all
       CP::Assessment.destroy_all
+      Company.destroy_all
     end
 
     def csv
@@ -67,7 +72,6 @@ module Import
       geography = Import::GeographyUtils.find_by_iso(fix_iso(row[:country_code]))
 
       {
-        name: row[:company_name],
         ca100: row[:ca100_company?] == 'Yes',
         geography: geography,
         headquarters_geography: geography,


### PR DESCRIPTION
This small PR allows the input of multiple isin codes for the same company.

- render as strings;
- using a tags input to manage them;
- updating the importer to allow saving multiple isins, matching the import on the company name.