### PR TITLE
Feature/add documents to legislations

### DIFF
--- a/app/admin/legislations.rb
+++ b/app/admin/legislations.rb
@@ -11,7 +11,10 @@ ActiveAdmin.register Legislation do
                 :geography_id, :law_id,
                 :natural_hazards_string, :keywords_string,
                 :created_by_id, :updated_by_id,
-                :visibility_status, framework_ids: [], document_type_ids: []
+                :visibility_status, framework_ids: [], document_type_ids: [],
+                                    documents_attributes: [
+                                      :id, :_destroy, :name, :language, :external_url, :type, :file
+                                    ]
 
   filter :title_contains, label: 'Title'
   filter :date_passed
@@ -78,36 +81,43 @@ ActiveAdmin.register Legislation do
   form html: {'data-controller' => 'check-modified'} do |f|
     f.semantic_errors(*f.object.errors.keys)
 
-    f.inputs do
-      f.input :title
-      f.input :description, as: :trix
-      f.input :document_type_ids,
-              label: 'Document Types',
-              as: :tags,
-              collection: DocumentType.all
-      columns do
-        column { f.input :geography }
-        column { f.input :date_passed }
-        column do
-          f.input :framework_ids,
-                  label: 'Frameworks',
+    tabs do
+      tab :details do
+        f.inputs do
+          f.input :title
+          f.input :description, as: :trix
+          f.input :document_type_ids,
+                  label: 'Document Types',
                   as: :tags,
-                  collection: Framework.all
-        end
-        column do
-          f.input :visibility_status, as: :select
+                  collection: DocumentType.all
+          columns do
+            column { f.input :geography }
+            column { f.input :date_passed }
+            column do
+              f.input :framework_ids,
+                      label: 'Frameworks',
+                      as: :tags,
+                      collection: Framework.all
+            end
+            column do
+              f.input :visibility_status, as: :select
+            end
+          end
+          f.input :natural_hazards_string,
+                  label: 'Natural Hazards',
+                  hint: t('hint.tag'),
+                  as: :tags,
+                  collection: NaturalHazard.all.pluck(:name)
+          f.input :keywords_string,
+                  label: 'Keywords',
+                  hint: t('hint.tag'),
+                  as: :tags,
+                  collection: Keyword.all.pluck(:name)
         end
       end
-      f.input :natural_hazards_string,
-              label: 'Natural Hazards',
-              hint: t('hint.tag'),
-              as: :tags,
-              collection: NaturalHazard.all.pluck(:name)
-      f.input :keywords_string,
-              label: 'Keywords',
-              hint: t('hint.tag'),
-              as: :tags,
-              collection: Keyword.all.pluck(:name)
+
+      tab :documents do
+      end
     end
 
     f.actions

--- a/app/admin/legislations.rb
+++ b/app/admin/legislations.rb
@@ -81,43 +81,36 @@ ActiveAdmin.register Legislation do
   form html: {'data-controller' => 'check-modified'} do |f|
     f.semantic_errors(*f.object.errors.keys)
 
-    tabs do
-      tab :details do
-        f.inputs do
-          f.input :title
-          f.input :description, as: :trix
-          f.input :document_type_ids,
-                  label: 'Document Types',
+    f.inputs do
+      f.input :title
+      f.input :description, as: :trix
+      f.input :document_type_ids,
+              label: 'Document Types',
+              as: :tags,
+              collection: DocumentType.all
+      columns do
+        column { f.input :geography }
+        column { f.input :date_passed }
+        column do
+          f.input :framework_ids,
+                  label: 'Frameworks',
                   as: :tags,
-                  collection: DocumentType.all
-          columns do
-            column { f.input :geography }
-            column { f.input :date_passed }
-            column do
-              f.input :framework_ids,
-                      label: 'Frameworks',
-                      as: :tags,
-                      collection: Framework.all
-            end
-            column do
-              f.input :visibility_status, as: :select
-            end
-          end
-          f.input :natural_hazards_string,
-                  label: 'Natural Hazards',
-                  hint: t('hint.tag'),
-                  as: :tags,
-                  collection: NaturalHazard.all.pluck(:name)
-          f.input :keywords_string,
-                  label: 'Keywords',
-                  hint: t('hint.tag'),
-                  as: :tags,
-                  collection: Keyword.all.pluck(:name)
+                  collection: Framework.all
+        end
+        column do
+          f.input :visibility_status, as: :select
         end
       end
-
-      tab :documents do
-      end
+      f.input :natural_hazards_string,
+              label: 'Natural Hazards',
+              hint: t('hint.tag'),
+              as: :tags,
+              collection: NaturalHazard.all.pluck(:name)
+      f.input :keywords_string,
+              label: 'Keywords',
+              hint: t('hint.tag'),
+              as: :tags,
+              collection: Keyword.all.pluck(:name)
     end
 
     f.actions

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -188,6 +188,10 @@ form {
 
 // Resource specific styles
 
+form.litigation {
+  min-width: 600px;
+}
+
 .litigation-sides-fields {
   li[id*=side_type] {
     min-width: 150px;

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -31,6 +31,8 @@ class Document < ApplicationRecord
 
   validates_presence_of :name, :type
 
+  scope :from_documentable, ->(documentable) { where(documentable_type: documentable) }
+
   def url
     return file_url if uploaded?
 
@@ -46,6 +48,6 @@ class Document < ApplicationRecord
   end
 
   def set_last_verified_on
-    self.last_verified_on = Time.zone.now.to_date
+    self.last_verified_on ||= Time.zone.now.to_date
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -37,10 +37,6 @@ class Document < ApplicationRecord
     external_url
   end
 
-  def external?
-    !uploaded?
-  end
-
   private
 
   def file_url

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -30,8 +30,11 @@ class Legislation < ApplicationRecord
   tag_with :natural_hazards
 
   belongs_to :geography
+  has_many :documents, as: :documentable, dependent: :destroy
   has_and_belongs_to_many :targets
   has_and_belongs_to_many :litigations
+
+  accepts_nested_attributes_for :documents, allow_destroy: true
 
   validates_presence_of :title, :slug, :date_passed
   validates_uniqueness_of :slug

--- a/app/views/admin/documents/_fields.html.erb
+++ b/app/views/admin/documents/_fields.html.erb
@@ -4,7 +4,7 @@
   <%= form.input :type, as: :hidden, input_html: { value: form.object.type } %>
   <div style="width: 33%;">
     <% if form.object.external? %>
-      <%= form.input :external_url, as: :string, label: 'Provide external url' %>
+      <%= form.input :external_url, as: :string, label: 'External url' %>
     <% else %>
       <%= form.input :file, as: :file, hint: preview_file_tag(form.object.file) %>
     <% end %>

--- a/spec/controllers/admin/legislations_controller_spec.rb
+++ b/spec/controllers/admin/legislations_controller_spec.rb
@@ -5,13 +5,6 @@ RSpec.describe Admin::LegislationsController, type: :controller do
   let(:geography) { create(:geography) }
 
   let!(:legislation) { create(:legislation) }
-  let(:valid_attributes) {
-    attributes_for(:legislation).merge(
-      geography_id: geography.id
-    )
-  }
-
-  let(:invalid_attributes) { valid_attributes.merge(title: nil) }
 
   before { sign_in admin }
 
@@ -41,18 +34,48 @@ RSpec.describe Admin::LegislationsController, type: :controller do
 
   describe 'POST create' do
     context 'with valid params' do
+      let(:valid_attributes) {
+        attributes_for(:legislation).merge(
+          title: 'Legislation POST title',
+          description: 'Legislation POST description',
+          date_passed: Date.parse('2/4/2004'),
+          law_id: 1001,
+          visibility_status: 'pending',
+          geography_id: geography.id,
+          documents_attributes: [
+            attributes_for(:document).merge(
+              name: 'doc 1', language: 'en', external_url: 'http://test.com/file.pdf'
+            ),
+            attributes_for(:document_uploaded).merge(
+              name: 'doc 2', language: 'pl'
+            )
+          ]
+        )
+      }
       subject { post :create, params: {legislation: valid_attributes} }
 
       it 'creates a new Legislation' do
         expect { subject }.to change(Legislation, :count).by(1)
+
+        last_legislation_created.tap do |l|
+          expect(l.title).to eq('Legislation POST title')
+          expect(l.description).to eq('Legislation POST description')
+          expect(l.visibility_status).to eq('pending')
+          expect(l.law_id).to eq(1001)
+          expect(l.date_passed).to eq(Date.parse('2/4/2004'))
+          expect(l.geography_id).to eq(geography.id)
+          expect(l.documents.pluck(:name, :language, :external_url).sort)
+            .to eq([['doc 1', 'en', 'http://test.com/file.pdf'], ['doc 2', 'pl', '']])
+        end
       end
 
       it 'redirects to the created Legislation' do
-        expect(subject).to redirect_to(admin_legislation_path(Legislation.order(:created_at).last))
+        expect(subject).to redirect_to(admin_legislation_path(last_legislation_created))
       end
     end
 
     context 'with invalid params' do
+      let(:invalid_attributes) { attributes_for(:legislation).merge(title: nil) }
       subject { post :create, params: {legislation: invalid_attributes} }
 
       it { is_expected.to be_successful }
@@ -61,5 +84,9 @@ RSpec.describe Admin::LegislationsController, type: :controller do
         expect { subject }.not_to change(Legislation, :count)
       end
     end
+  end
+
+  def last_legislation_created
+    Legislation.order(:created_at).last
   end
 end

--- a/spec/controllers/admin/legislations_controller_spec.rb
+++ b/spec/controllers/admin/legislations_controller_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe Admin::LegislationsController, type: :controller do
           ]
         )
       }
+
       subject { post :create, params: {legislation: valid_attributes} }
 
       it 'creates a new Legislation' do
@@ -76,6 +77,7 @@ RSpec.describe Admin::LegislationsController, type: :controller do
 
     context 'with invalid params' do
       let(:invalid_attributes) { attributes_for(:legislation).merge(title: nil) }
+
       subject { post :create, params: {legislation: invalid_attributes} }
 
       it { is_expected.to be_successful }


### PR DESCRIPTION
#### Summary
- update model relations
- update controller to allow saving documents within legislations
- update controller specs to check if all data was properly saved (legislations, litigations)
- update importer to create documents from `source_text_links` column

UI form changes will be in another PR.

after `be rake import:legislation`:
<img width="1049" alt="Zrzut ekranu 2019-08-14 o 13 20 38" src="https://user-images.githubusercontent.com/10665/63017350-662b5b00-be96-11e9-9a6f-297f0cfb71d6.png">
