### PR TITLE
Chore/upload import cleanup

### DIFF
--- a/app/forms/data_upload_form.rb
+++ b/app/forms/data_upload_form.rb
@@ -8,6 +8,7 @@ class DataUploadForm
 
   def initialize(attributes)
     @data_upload = DataUpload.new
+
     super(attributes)
   end
 
@@ -17,6 +18,7 @@ class DataUploadForm
     ActiveRecord::Base.transaction do
       imported = import_data
       data_upload.save! if imported
+
       return imported
     end
 
@@ -26,18 +28,18 @@ class DataUploadForm
   private
 
   def import_data
-    imported = service.call
-    self.details = service.details
-    promote_errors(service.errors) unless imported
+    imported = import_service.call
+    self.details = import_service.import_results
+    promote_errors(import_service.errors) unless imported
 
     imported
   end
 
-  def service
-    return @service if defined?(@service)
+  def import_service
+    return @import_service if defined?(@import_service)
 
-    service_class = "Upload::#{uploader}".constantize
-    @service ||= service_class.new(file.download.force_encoding('UTF-8'))
+    service_class = "CSVImport::#{uploader}".constantize
+    @import_service ||= service_class.new(file.download.force_encoding('UTF-8'))
   end
 
   def validate_data_upload

--- a/app/services/csv_import/base_importer.rb
+++ b/app/services/csv_import/base_importer.rb
@@ -6,7 +6,7 @@ module CSVImport
 
     def initialize(file)
       @file = file
-      @import_results ||= {
+      @import_results = {
         new_records: 0,
         updated_records: 0,
         not_changed_records: 0,

--- a/app/services/csv_import/base_importer.rb
+++ b/app/services/csv_import/base_importer.rb
@@ -2,18 +2,16 @@ module CSVImport
   class BaseImporter
     include ActiveModel::Model
 
-    DEFAULT_IMPORT_RESULTS = {
-      new_records: 0,
-      updated_records: 0,
-      not_changed_records: 0,
-      rows: 0
-    }.freeze
-
     attr_reader :file, :import_results
 
     def initialize(file)
       @file = file
-      @import_results ||= DEFAULT_IMPORT_RESULTS
+      @import_results ||= {
+        new_records: 0,
+        updated_records: 0,
+        not_changed_records: 0,
+        rows: 0
+      }
     end
 
     def call

--- a/app/services/csv_import/base_importer.rb
+++ b/app/services/csv_import/base_importer.rb
@@ -15,7 +15,7 @@ module CSVImport
     end
 
     def call
-      return false unless parse_csv
+      return false unless csv
 
       import_results[:rows] = csv.count
 
@@ -31,11 +31,11 @@ module CSVImport
       raise NotImplementedError
     end
 
-    private
-
     def csv
       @csv ||= parse_csv
     end
+
+    private
 
     def parse_csv
       CSV.parse(

--- a/app/services/csv_import/litigations.rb
+++ b/app/services/csv_import/litigations.rb
@@ -1,9 +1,9 @@
-module Upload
-  class Litigations < BaseUploader
+module CSVImport
+  class Litigations < BaseImporter
     include UploaderHelpers
 
     def import
-      import_each_with_logging(csv) do |row|
+      import_each_csv_row(csv) do |row|
         litigation = find_litigation(row) || Litigation.new
         litigation.keywords = parse_tags(row[:keywords], keywords)
         litigation.assign_attributes(litigation_attributes(row))
@@ -13,7 +13,7 @@ module Upload
 
         litigation.save!
 
-        update_stats(was_new_record, any_changes)
+        update_import_results(was_new_record, any_changes)
       end
     end
 


### PR DESCRIPTION
#### Summary

- rename `BaseUploader` to `BaseImporter`
- rename & unify `details/stats` to `upload_results`
- rename `import_each_with_logging` to `import_each_csv_row `
- do not call `parse_csv` twice during import