### PR TITLE
download events CSV for legislation and litigations

### DIFF
--- a/app/admin/documents.rb
+++ b/app/admin/documents.rb
@@ -49,24 +49,19 @@ ActiveAdmin.register Document do
     def scoped_collection
       results = super.includes(:documentable)
 
-      documentable_klass = find_documentable_klass
+      return results unless documentable_params
 
-      if documentable_klass.present? && documentable_params.present?
-        results = results.where(
-          documentable: documentable_klass.ransack(documentable_params).result
-        )
-      end
-
-      results
+      results.where(documentable: documentable_scope)
     end
 
     private
 
-    def find_documentable_klass
-      documentable_type = params.dig(:q, :documentable_type_eq)
-      return nil unless documentable_type
+    def documentable_scope
+      find_documentable_klass&.ransack(documentable_params)&.result
+    end
 
-      documentable_type.constantize
+    def find_documentable_klass
+      @documentable_klass ||= params.dig(:q, :documentable_type_eq)&.constantize
     rescue NameError => e
       raise "Can't find documentable class based on given 'documentable_type_eq' param: #{e.message}"
     end

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -22,24 +22,19 @@ ActiveAdmin.register Event do
     def scoped_collection
       results = super.includes(:eventable)
 
-      eventable_klass = find_eventable_klass
+      return results unless eventable_params
 
-      if eventable_klass.present? && eventable_params.present?
-        results = results.where(
-          eventable: eventable_klass.ransack(eventable_params).result
-        )
-      end
-
-      results
+      results.where(eventable: eventable_scope)
     end
 
     private
 
-    def find_eventable_klass
-      eventable_type = params.dig(:q, :eventable_type_eq)
-      return nil unless eventable_type
+    def eventable_scope
+      find_eventable_klass&.ransack(eventable_params)&.result
+    end
 
-      eventable_type.constantize
+    def find_eventable_klass
+      @eventable_klass ||= params.dig(:q, :eventable_type_eq)&.constantize
     rescue NameError => e
       raise "Can't find eventable class based on given 'eventable_type_eq' param: #{e.message}"
     end

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -1,0 +1,51 @@
+ActiveAdmin.register Event do
+  menu label: 'All Events', priority: 3, parent: 'Administration'
+
+  actions :all, except: [:update, :show, :destroy]
+
+  INDEX_COLUMNS_DEFINITION = proc do
+    column :id
+    column :eventable_type
+    column :eventable_id
+    column :event_type
+    column :title
+    column :description
+    column :date
+    column :url
+  end
+
+  index { instance_exec(&INDEX_COLUMNS_DEFINITION) }
+
+  csv { instance_exec(&INDEX_COLUMNS_DEFINITION) }
+
+  controller do
+    def scoped_collection
+      results = super.includes(:eventable)
+
+      eventable_klass = find_eventable_klass
+
+      if eventable_klass.present? && eventable_params.present?
+        results = results.where(
+          eventable: eventable_klass.ransack(eventable_params).result
+        )
+      end
+
+      results
+    end
+
+    private
+
+    def find_eventable_klass
+      eventable_type = params.dig(:q, :eventable_type_eq)
+      return nil unless eventable_type
+
+      eventable_type.constantize
+    rescue NameError => e
+      raise "Can't find eventable class based on given 'eventable_type_eq' param: #{e.message}"
+    end
+
+    def eventable_params
+      @eventable_params ||= params.dig(:q, :eventable)
+    end
+  end
+end

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -1,7 +1,7 @@
 ActiveAdmin.register Event do
   menu label: 'All Events', priority: 3, parent: 'Administration'
 
-  actions :all, except: [:update, :show, :destroy]
+  actions :all, except: [:new, :edit, :update, :show, :destroy]
 
   INDEX_COLUMNS_DEFINITION = proc do
     column :id

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -15,6 +15,12 @@ ActiveAdmin.register Event do
   end
 
   controller do
+    def index
+      super do |format|
+        format.html { redirect_to admin_dashboard_path }
+      end
+    end
+
     def scoped_collection
       results = super.includes(:eventable)
 

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -1,9 +1,9 @@
 ActiveAdmin.register Event do
-  menu label: 'All Events', priority: 3, parent: 'Administration'
+  menu false
 
-  actions :all, except: [:new, :edit, :update, :show, :destroy]
+  actions :index
 
-  INDEX_COLUMNS_DEFINITION = proc do
+  csv do
     column :id
     column :eventable_type
     column :eventable_id
@@ -13,10 +13,6 @@ ActiveAdmin.register Event do
     column :date
     column :url
   end
-
-  index { instance_exec(&INDEX_COLUMNS_DEFINITION) }
-
-  csv { instance_exec(&INDEX_COLUMNS_DEFINITION) }
 
   controller do
     def scoped_collection

--- a/app/admin/legislations.rb
+++ b/app/admin/legislations.rb
@@ -46,7 +46,7 @@ ActiveAdmin.register Legislation do
 
   publishable_sidebar only: :show
 
-  data_export_sidebar 'Legislations', documents: true
+  data_export_sidebar 'Legislations', documents: true, events: true
 
   show do
     tabs do

--- a/app/admin/litigations.rb
+++ b/app/admin/litigations.rb
@@ -30,7 +30,7 @@ ActiveAdmin.register Litigation do
     array_to_select_collection(Litigation::DOCUMENT_TYPES)
   }
 
-  data_export_sidebar 'Litigations', documents: true
+  data_export_sidebar 'Litigations', documents: true, events: true
 
   index do
     column :title, class: 'max-width-300', &:title_link

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -6,7 +6,7 @@ ActiveAdmin.setup do |config|
   # Set the title that is displayed on the main layout
   # for each of the active admin pages.
   #
-  config.site_title = "Laws And Pathways"
+  config.site_title = 'Laws And Pathways'
 
   # Set the link url for the title. For example, to take
   # users to your main site. Defaults to no link.
@@ -41,16 +41,16 @@ ActiveAdmin.setup do |config|
   # a namespace block. For example, to change the site title
   # within a namespace:
   #
-    config.namespace :admin do |admin|
-      # admin.site_title = "Custom Admin Title"
-      admin.build_menu do |menu|
-        menu.add label: 'Geographies', priority: 1
-        menu.add label: 'Laws', priority: 2
-        menu.add label: 'TPI', priority: 3
-        menu.add label: 'Tags', priority: 7
-        menu.add label: 'Administration', priority: 8
-      end
+  config.namespace :admin do |admin|
+    # admin.site_title = "Custom Admin Title"
+    admin.build_menu do |menu|
+      menu.add label: 'Geographies', priority: 1
+      menu.add label: 'Laws', priority: 2
+      menu.add label: 'TPI', priority: 3
+      menu.add label: 'Tags', priority: 7
+      menu.add label: 'Administration', priority: 8
     end
+  end
   #
   # This will ONLY change the title for the admin section. Other
   # namespaces will continue to use the main "site_title" configuration.

--- a/lib/extensions/active_admin/active_admin_csv_download.rb
+++ b/lib/extensions/active_admin/active_admin_csv_download.rb
@@ -1,13 +1,16 @@
+# rubocop:disable Metrics/AbcSize, Metrics/MethodLength
 module ActiveAdminCsvDownload
   #
   # Generates Export Data sidebar section.
   #
   # Sidebar contains CSV download links to:
   # - current resource list
-  # - related Documents list (optional, if :documents option is passed)
+  # - related Document list (optional, if :documents option is passed)
+  # - related Event list (optional, if :events options is passed)
   #
   def data_export_sidebar(resource_name, options = {})
-    documents_export_link = options.fetch(:documents) { false }
+    export_link_for_documents = options.fetch(:documents) { false }
+    export_link_for_events = options.fetch(:events) { false }
 
     sidebar 'Export data', if: -> { collection.any? }, only: :index do
       ul do
@@ -19,16 +22,27 @@ module ActiveAdminCsvDownload
             )
         end
 
-        if documents_export_link
+        if export_link_for_documents
           li do
-            a 'Download related Documents CSV',
-              href: admin_documents_path(
-                format: 'csv',
-                q: {
-                  documentable_type_eq: resource_name.singularize,
-                  documentable: request.query_parameters[:q]
-                }
-              )
+            a 'Download related Documents CSV', href: admin_documents_path(
+              format: 'csv',
+              q: {
+                documentable_type_eq: resource_name.singularize,
+                documentable: request.query_parameters[:q]
+              }
+            )
+          end
+        end
+
+        if export_link_for_events
+          li do
+            a 'Download related Events CSV', href: admin_events_path(
+              format: 'csv',
+              q: {
+                eventable_type_eq: resource_name.singularize,
+                eventable: request.query_parameters[:q]
+              }
+            )
           end
         end
       end
@@ -36,3 +50,4 @@ module ActiveAdminCsvDownload
     end
   end
 end
+# rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/spec/controllers/admin/documents_controller_spec.rb
+++ b/spec/controllers/admin/documents_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Admin::DocumentsController, type: :controller do
       get :index,
           params: {
             q: {
-              # should narrow down results to 'Doc1'
+              # should narrow down results to document1
               documentable: {visibility_status_eq: 'published'},
               documentable_type_eq: 'Legislation'
             }
@@ -61,8 +61,8 @@ RSpec.describe Admin::DocumentsController, type: :controller do
       expect(csv.to_a.size).to eq(2)
 
       # check filtered data
-      expect(csv[0]['Name']).to eq('Doc1')
-      expect(csv[0]['Documentable type']).to eq('Legislation')
+      expect(csv[0]['Name']).to eq(document1.name)
+      expect(csv[0]['Documentable type']).to eq(document1.documentable_type)
 
       # only single data row
       expect(csv[1]).to be_nil

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+require 'csv'
+
+RSpec.describe Admin::EventsController, type: :controller do
+  let(:admin) { create(:admin_user) }
+  let!(:legislation1) { create(:legislation, visibility_status: 'published') }
+  let!(:legislation2) { create(:legislation, visibility_status: 'pending') }
+  let!(:litigation1) { create(:litigation, visibility_status: 'published') }
+  let!(:litigation2) { create(:litigation, visibility_status: 'draft') }
+
+  let!(:event1) { create(:legislation_event, title: 'Event1', eventable: legislation1) } # with published documentable
+  let!(:event2) { create(:legislation_event, title: 'Event2', eventable: legislation2) }
+  let!(:event3) { create(:litigation_event, title: 'Event3', eventable: litigation1) } # with published documentable
+  let!(:event4) { create(:litigation_event, title: 'Event4', eventable: litigation2) }
+
+  before { sign_in admin }
+
+  describe 'GET index' do
+    subject { get :index }
+
+    it { is_expected.to be_successful }
+  end
+
+  describe 'GET index with .csv format' do
+    before :each do
+      get :index, format: 'csv'
+    end
+
+    it('returns CSV file') do
+      expect(response.header['Content-Type']).to include('text/csv')
+    end
+
+    it('returns all events') do
+      csv = response_as_csv
+
+      expect(csv.by_col[4].sort).to eq(%w[Event1 Event2 Event3 Event4])
+    end
+  end
+
+  describe 'GET index with .csv format (query, results present)' do
+    before :each do
+      get :index,
+          params: {
+            q: {
+              # should narrow down results to 'Event1'
+              eventable: {visibility_status_eq: 'published'},
+              eventable_type_eq: 'Legislation'
+            }
+          },
+          format: 'csv'
+    end
+
+    it('returns CSV file') do
+      expect(response.header['Content-Type']).to include('text/csv')
+    end
+
+    it('returns filtered events list') do
+      csv = response_as_csv
+
+      # returned CSV must contain only result row + header
+      expect(csv.to_a.size).to eq(2)
+
+      # check filtered data
+      expect(csv[0]['Title']).to eq(event1.title)
+      expect(csv[0]['Description']).to eq(event1.description)
+      expect(csv[0]['Event type']).to eq(event1.event_type)
+
+      # only single data row
+      expect(csv[1]).to be_nil
+    end
+  end
+
+  describe 'GET index with .csv format (query, no results)' do
+    before :each do
+      get :index,
+          params: {
+            q: {
+              # should return no results for that query!
+              eventable: {visibility_status_eq: 'pending'},
+              eventable_type_eq: 'Litigation'
+            }
+          },
+          format: 'csv'
+    end
+
+    it('returns CSV file') do
+      expect(response.header['Content-Type']).to include('text/csv')
+    end
+
+    it('returns empty CSV file (only header)') do
+      csv = response_as_csv
+
+      # only header expected
+      expected_columns = [
+        'Id', 'Eventable type', 'Eventable', 'Event type',
+        'Title', 'Description', 'Date', 'Url'
+      ]
+      expect(csv.to_a).to eq([expected_columns])
+    end
+  end
+
+  def response_as_csv
+    CSV.parse(response.body, headers: true)
+  end
+end

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Admin::EventsController, type: :controller do
   describe 'GET index' do
     subject { get :index }
 
-    it { is_expected.to be_successful }
+    it { is_expected.to redirect_to(admin_dashboard_path) }
   end
 
   describe 'GET index with .csv format' do

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -23,5 +23,12 @@ FactoryBot.define do
       event_type { 'case_started' }
       eventable { |e| e.association(:litigation) }
     end
+
+    factory :legislation_event do
+      title { 'Some law was approved' }
+      description { 'Description of approved law' }
+      event_type { 'approved' }
+      eventable { |e| e.association(:legislation) }
+    end
   end
 end


### PR DESCRIPTION
### Events CSV download

- Added basic active admin's `events` resource, the whole index pages isn't required (I think) however I needed index controller action (with proper routes). Not sure if I can keep only this.

![Zrzut ekranu 2019-09-01 o 15 29 53](https://user-images.githubusercontent.com/10665/64081097-a004ba00-ccfc-11e9-8fe7-657f8b5271ff.png)
<img width="272" alt="Zrzut ekranu 2019-09-01 o 21 08 25" src="https://user-images.githubusercontent.com/10665/64081116-d5a9a300-ccfc-11e9-8655-24e21ba0fc25.png">
<img width="1292" alt="Zrzut ekranu 2019-09-01 o 21 09 35" src="https://user-images.githubusercontent.com/10665/64081118-d5a9a300-ccfc-11e9-804a-b918caf47688.png">
