### PR TITLE
add not archived as active admin default scope

### DIFF
--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -4,6 +4,8 @@ module Publishable
   VISIBILITY = %w[draft pending published archived].freeze
 
   included do
+    scope :not_archived, -> { where.not(visibility_status: 'archived') }
+
     enum visibility_status: array_to_enum_hash(VISIBILITY)
 
     validates_presence_of :visibility_status

--- a/lib/extensions/active_admin/active_admin_publishable.rb
+++ b/lib/extensions/active_admin/active_admin_publishable.rb
@@ -1,11 +1,11 @@
 module ActiveAdminPublishable
   module Scopes
     def publishable_scopes
-      scope('All', &:all)
-      scope('Draft', &:draft)
-      scope('Pending', &:pending)
-      scope('Published', &:published)
-      scope('Archived', &:archived)
+      scope 'All', :not_archived, default: true
+      scope 'Draft', :draft
+      scope 'Pending', :pending
+      scope 'Published', :published
+      scope 'Archived', :archived
     end
 
     def publishable_sidebar(*args)


### PR DESCRIPTION
Adding default AA scope to be `All`, and `All` scope will not include archived records.