### PR TITLE
make tabs URL addressable

### DIFF
--- a/app/admin/companies.rb
+++ b/app/admin/companies.rb
@@ -65,15 +65,9 @@ ActiveAdmin.register Company do
                 end
 
                 table_for a.questions do
-                  column :level do |q|
-                    q['level']
-                  end
-                  column :answer do |q|
-                    q['answer']
-                  end
-                  column :question do |q|
-                    q['question']
-                  end
+                  column(:level) { |q| q['level'] }
+                  column(:answer) { |q| q['answer'] }
+                  column(:question) { |q| q['question'] }
                 end
               end
             end
@@ -120,17 +114,14 @@ ActiveAdmin.register Company do
   end
 
   index do
-    column :name do |company|
-      link_to company.name, admin_company_path(company)
-    end
+    column(:name) { |company| link_to company.name, admin_company_path(company) }
     column :isin, &:isin_as_tags
-    column :size do |company|
-      company.size.humanize
-    end
+    column(:size) { |company| company.size.humanize }
     column :level, &:mq_status_description_short
     column :geography
     column :headquarters_geography
     tag_column :visibility_status
+
     actions
   end
 

--- a/app/admin/documents.rb
+++ b/app/admin/documents.rb
@@ -29,6 +29,7 @@ ActiveAdmin.register Document do
 
   index do
     column 'Name', &:document_page_link
+    column 'Resource', :documentable_type
     column 'Attached To', :documentable
     column :last_verified_on
     column :language

--- a/app/admin/documents.rb
+++ b/app/admin/documents.rb
@@ -29,8 +29,8 @@ ActiveAdmin.register Document do
 
   index do
     column 'Name', &:document_page_link
-    column 'Resource', :documentable_type
-    column 'Attached To', :documentable
+    column 'Resource Type', :documentable_type
+    column 'Resource Details', :documentable
     column :last_verified_on
     column :language
     actions

--- a/app/admin/documents.rb
+++ b/app/admin/documents.rb
@@ -29,8 +29,8 @@ ActiveAdmin.register Document do
 
   index do
     column 'Name', &:document_page_link
-    column 'Resource Type', :documentable_type
-    column 'Resource Details', :documentable
+    column 'Attached To', :documentable_type
+    column 'Details', :documentable
     column :last_verified_on
     column :language
     actions

--- a/app/javascript/admin/controllers/tabs_controller.js
+++ b/app/javascript/admin/controllers/tabs_controller.js
@@ -22,7 +22,8 @@ export default class extends Controller {
   }
 
   _selectTab(tabName) {
-    window.location.hash = tabName;
+    history.replaceState({}, '', tabName);
+
     if (this.hasActiveTabTarget) {
       this.activeTabTarget.value = tabName;
     }

--- a/app/javascript/admin/controllers/tabs_controller.js
+++ b/app/javascript/admin/controllers/tabs_controller.js
@@ -8,17 +8,23 @@ export default class extends Controller {
 
     $(this.element.querySelectorAll('.nav-tabs a')).on('click', (event) => {
       event.preventDefault();
-      this._changeActiveTabTo(event.target.hash);
+      this._selectTab(event.target.hash);
     });
 
-    const activeTab = this.activeTabTarget.value;
-    if (activeTab) {
-      $(this.element).find(`.nav-tabs a[href="${activeTab}"]`).click();
+    if (this.hasActiveTabTarget) {
+      const activeTab = this.activeTabTarget.value;
+      this._clickTab(activeTab)
     }
   }
 
-  _changeActiveTabTo(hash) {
-    window.location.hash = hash;
-    this.activeTabTarget.value = hash;
+  _clickTab(tabName) {
+    $(this.element).find(`.nav-tabs a[href="${tabName}"]`).click();
+  }
+
+  _selectTab(tabName) {
+    window.location.hash = tabName;
+    if (this.hasActiveTabTarget) {
+      this.activeTabTarget.value = tabName;
+    }
   }
 }

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -335,5 +335,8 @@ Rails.configuration.to_prepare do
   ActiveAdmin::ResourceDSL.send :include, ActiveAdminPublishable::Scopes
   ActiveAdmin::ResourceDSL.send :include, ActiveAdminCsvDownload
 
+  # extensions for 'show' context
+  ActiveAdmin::Views::Pages::Show.send :include, ActiveAdminAddressableTabs
+
   ActiveAdmin::Views::Header.send :prepend, ActiveAdminCustomHeader
 end

--- a/lib/extensions/active_admin/active_admin_addressable_tabs.rb
+++ b/lib/extensions/active_admin/active_admin_addressable_tabs.rb
@@ -1,0 +1,8 @@
+module ActiveAdminAddressableTabs
+  # Creates tabs component which enables stimulus tabs_controller
+  def tabs(&block)
+    div 'data-controller': 'tabs' do
+      super(&block)
+    end
+  end
+end


### PR DESCRIPTION
Tabs on all 'show' pages are now URL-addressable, which means switching tabs => updating URL via stimulus `tabs_controller`.

Please note that we still have a problem that both tabs and main headers have same `#id`, so for bigger site content, page scrolls down to tab **content** header, which can be annoying sometimes.