### PR TITLE
Feature/litigation soft delete

### DIFF
--- a/app/admin/geographies.rb
+++ b/app/admin/geographies.rb
@@ -88,7 +88,7 @@ ActiveAdmin.register Geography do
                   {alert: 'Could not delete selected Geography'}
                 end
 
-      redirect_to admin_geographies_path(scope: current_scope.name), results
+      redirect_to admin_geographies_path, results
     end
   end
 end

--- a/app/admin/legislations.rb
+++ b/app/admin/legislations.rb
@@ -149,7 +149,7 @@ ActiveAdmin.register Legislation do
                   {alert: 'Could not delete selected Legislations'}
                 end
 
-      redirect_to admin_legislations_path(scope: current_scope.name), results
+      redirect_to admin_legislations_path, results
     end
   end
 end

--- a/app/admin/litigations.rb
+++ b/app/admin/litigations.rb
@@ -108,5 +108,17 @@ ActiveAdmin.register Litigation do
     def scoped_collection
       super.includes(:geography, :created_by, :updated_by)
     end
+
+    def destroy
+      destroy_command = ::Command::Destroy::Litigation.new(resource.object)
+
+      results = if destroy_command.call
+                  {notice: 'Successfully deleted selected Litigation'}
+                else
+                  {alert: 'Could not delete selected Litigation'}
+                end
+
+      redirect_to admin_litigations_path(scope: current_scope.name), results
+    end
   end
 end

--- a/app/admin/litigations.rb
+++ b/app/admin/litigations.rb
@@ -118,7 +118,7 @@ ActiveAdmin.register Litigation do
                   {alert: 'Could not delete selected Litigation'}
                 end
 
-      redirect_to admin_litigations_path(scope: current_scope.name), results
+      redirect_to admin_litigations_path, results
     end
   end
 end

--- a/app/commands/command/destroy/geography.rb
+++ b/app/commands/command/destroy/geography.rb
@@ -13,8 +13,6 @@ module Command
 
             r.litigations = []
             r.legislations = []
-
-            r.save!
           end
         end
       end

--- a/app/commands/command/destroy/legislation.rb
+++ b/app/commands/command/destroy/legislation.rb
@@ -15,10 +15,6 @@ module Command
 
             r.litigations = []
             r.targets = []
-
-            # Validation is false because it's possible that some precedent
-            # record (like geography) was removed earlier
-            r.save(validate: false)
           end
         end
       end

--- a/app/commands/command/destroy/legislation.rb
+++ b/app/commands/command/destroy/legislation.rb
@@ -15,7 +15,10 @@ module Command
 
             r.litigations = []
             r.targets = []
-            r.save!
+
+            # Validation is false because it's possible that some precedent
+            # record (like geography) was removed earlier
+            r.save(validate: false)
           end
         end
       end

--- a/app/commands/command/destroy/litigation.rb
+++ b/app/commands/command/destroy/litigation.rb
@@ -1,0 +1,26 @@
+module Command
+  module Destroy
+    class Litigation
+      def initialize(resource)
+        @resource = resource
+      end
+
+      def call
+        ActiveRecord::Base.transaction do
+          @resource.tap do |r|
+            r.discard
+
+            r.litigation_sides.discard_all
+            r.events.discard_all
+            r.documents.discard_all
+
+            r.legislations = []
+            r.external_legislations = []
+
+            r.save!
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/commands/command/destroy/litigation.rb
+++ b/app/commands/command/destroy/litigation.rb
@@ -17,7 +17,9 @@ module Command
             r.legislations = []
             r.external_legislations = []
 
-            r.save!
+            # Validation is false because it's possible that some precedent
+            # record (like geography) was removed earlier
+            r.save(validate: false)
           end
         end
       end

--- a/app/commands/command/destroy/litigation.rb
+++ b/app/commands/command/destroy/litigation.rb
@@ -16,10 +16,6 @@ module Command
 
             r.legislations = []
             r.external_legislations = []
-
-            # Validation is false because it's possible that some precedent
-            # record (like geography) was removed earlier
-            r.save(validate: false)
           end
         end
       end

--- a/app/models/litigation.rb
+++ b/app/models/litigation.rb
@@ -16,6 +16,7 @@
 #  visibility_status         :string           default("draft")
 #  created_by_id             :bigint
 #  updated_by_id             :bigint
+#  discarded_at              :datetime
 #
 
 class Litigation < ApplicationRecord

--- a/app/models/litigation.rb
+++ b/app/models/litigation.rb
@@ -23,6 +23,7 @@ class Litigation < ApplicationRecord
   include UserTrackable
   include Taggable
   include VisibilityStatus
+  include Discardable
   extend FriendlyId
 
   friendly_id :title, use: :slugged, routes: :default

--- a/app/models/litigation_side.rb
+++ b/app/models/litigation_side.rb
@@ -14,6 +14,8 @@
 #
 
 class LitigationSide < ApplicationRecord
+  include Discardable
+
   SIDE_TYPES = %w[a b c].freeze
   PARTY_TYPES = %w[
     government

--- a/db/migrate/20190917165449_add_discarded_at_to_litigations.rb
+++ b/db/migrate/20190917165449_add_discarded_at_to_litigations.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToLitigations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :litigations, :discarded_at, :datetime
+    add_index :litigations, :discarded_at
+  end
+end

--- a/db/migrate/20190917181907_add_discarded_at_to_litigation_sides.rb
+++ b/db/migrate/20190917181907_add_discarded_at_to_litigation_sides.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToLitigationSides < ActiveRecord::Migration[5.2]
+  def change
+    add_column :litigation_sides, :discarded_at, :datetime
+    add_index :litigation_sides, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_17_165449) do
+ActiveRecord::Schema.define(version: 2019_09_17_181907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -226,7 +226,9 @@ ActiveRecord::Schema.define(version: 2019_09_17_165449) do
     t.datetime "updated_at", null: false
     t.string "connected_entity_type"
     t.bigint "connected_entity_id"
+    t.datetime "discarded_at"
     t.index ["connected_entity_type", "connected_entity_id"], name: "index_litigation_sides_connected_entity"
+    t.index ["discarded_at"], name: "index_litigation_sides_on_discarded_at"
     t.index ["litigation_id"], name: "index_litigation_sides_on_litigation_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_16_190258) do
+ActiveRecord::Schema.define(version: 2019_09_17_165449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -244,7 +244,9 @@ ActiveRecord::Schema.define(version: 2019_09_16_190258) do
     t.string "visibility_status", default: "draft"
     t.bigint "created_by_id"
     t.bigint "updated_by_id"
+    t.datetime "discarded_at"
     t.index ["created_by_id"], name: "index_litigations_on_created_by_id"
+    t.index ["discarded_at"], name: "index_litigations_on_discarded_at"
     t.index ["document_type"], name: "index_litigations_on_document_type"
     t.index ["geography_id"], name: "index_litigations_on_geography_id"
     t.index ["jurisdiction_id"], name: "index_litigations_on_jurisdiction_id"

--- a/spec/controllers/admin/geographies_controller_spec.rb
+++ b/spec/controllers/admin/geographies_controller_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Admin::GeographiesController, type: :controller do
       end
 
       it 'redirects to index & renders alert message' do
-        expect(subject).to redirect_to(admin_geographies_path(scope: 'All'))
+        expect(subject).to redirect_to(admin_geographies_path)
         expect(flash[:alert]).to match('Could not delete selected Geography')
       end
     end

--- a/spec/controllers/admin/legislations_controller_spec.rb
+++ b/spec/controllers/admin/legislations_controller_spec.rb
@@ -125,8 +125,9 @@ RSpec.describe Admin::LegislationsController, type: :controller do
   end
 
   describe 'DELETE destroy' do
+    let!(:legislation_to_delete) { create(:legislation, discarded_at: nil) }
+
     context 'with valid params' do
-      let!(:legislation_to_delete) { create(:legislation, discarded_at: nil) }
       let!(:document) { create(:document, documentable: legislation_to_delete) }
       let!(:event) { create(:legislation_event, eventable: legislation_to_delete) }
 
@@ -157,6 +158,18 @@ RSpec.describe Admin::LegislationsController, type: :controller do
       it 'redirects to index & renders alert message' do
         expect(subject).to redirect_to(admin_legislations_path)
         expect(flash[:alert]).to match('Could not delete selected Legislations')
+      end
+    end
+
+    context 'when geography does not exist' do
+      subject { delete :destroy, params: {id: legislation_to_delete.id} }
+
+      before do
+        legislation_to_delete.geography.legislations = []
+      end
+
+      it 'soft-delete even if geography is nil' do
+        expect { subject }.to change { Legislation.count }.by(-1)
       end
     end
   end

--- a/spec/controllers/admin/litigations_controller_spec.rb
+++ b/spec/controllers/admin/litigations_controller_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Admin::LitigationsController, type: :controller do
       end
 
       it 'redirects to index & renders alert message' do
-        expect(subject).to redirect_to(admin_litigations_path(scope: 'All'))
+        expect(subject).to redirect_to(admin_litigations_path)
         expect(flash[:alert]).to match('Could not delete selected Litigation')
       end
     end

--- a/spec/controllers/admin/litigations_controller_spec.rb
+++ b/spec/controllers/admin/litigations_controller_spec.rb
@@ -130,6 +130,79 @@ RSpec.describe Admin::LitigationsController, type: :controller do
     end
   end
 
+  describe 'DELETE destroy' do
+    let!(:litigation) { create(:litigation, discarded_at: nil) }
+
+    context 'with valid params' do
+      let!(:litigation_side) { create(:litigation_side, litigation: litigation) }
+      let!(:event) { create(:litigation_event, eventable: litigation) }
+      let!(:document) { create(:document, documentable: litigation) }
+
+      let!(:legislation) { create(:legislation, litigations: [litigation]) }
+      let!(:external_legislation) do
+        create(:external_legislation, litigations: [litigation])
+      end
+
+      subject { delete :destroy, params: {id: litigation.id} }
+
+      before do
+        expect { subject }.to change { Litigation.count }.by(-1)
+      end
+
+      it 'discards litigation object' do
+        expect(Litigation.find_by_id(litigation.id)).to be_nil
+      end
+
+      it 'set discarded_at date to litigation object' do
+        expect(litigation.reload.discarded_at).to_not be_nil
+      end
+
+      it 'shows discarded litigations in all_discarded scope' do
+        expect(Litigation.all_discarded.find(litigation.id)).to_not be_nil
+      end
+
+      it 'discard all litigation sides' do
+        expect(LitigationSide.find_by_id(litigation_side.id)).to be_nil
+      end
+
+      it 'discard all events' do
+        expect(Event.find_by_id(event.id)).to be_nil
+      end
+
+      it 'discard all documents' do
+        expect(Document.find_by_id(document.id)).to be_nil
+      end
+
+      it 'removes discarded litigation from legislation' do
+        expect(legislation.reload.litigations).to be_empty
+      end
+
+      it 'removes discarded litigation from external_legislations' do
+        expect(external_legislation.reload.litigations).to be_empty
+      end
+
+      it 'shows proper notice' do
+        expect(flash[:notice]).to match('Successfully deleted selected Litigation')
+      end
+    end
+
+    context 'with invalid params' do
+      let(:command) { double }
+
+      subject { delete :destroy, params: {id: litigation.id} }
+
+      before do
+        expect(::Command::Destroy::Litigation).to receive(:new).and_return(command)
+        expect(command).to receive(:call).and_return(nil)
+      end
+
+      it 'redirects to index & renders alert message' do
+        expect(subject).to redirect_to(admin_litigations_path(scope: 'All'))
+        expect(flash[:alert]).to match('Could not delete selected Litigation')
+      end
+    end
+  end
+
   def last_litigation_created
     Litigation.order(:created_at).last
   end

--- a/spec/factories/litigations.rb
+++ b/spec/factories/litigations.rb
@@ -16,6 +16,7 @@
 #  visibility_status         :string           default("draft")
 #  created_by_id             :bigint
 #  updated_by_id             :bigint
+#  discarded_at              :datetime
 #
 
 FactoryBot.define do

--- a/spec/models/litigation_spec.rb
+++ b/spec/models/litigation_spec.rb
@@ -16,6 +16,7 @@
 #  visibility_status         :string           default("draft")
 #  created_by_id             :bigint
 #  updated_by_id             :bigint
+#  discarded_at              :datetime
 #
 
 require 'rails_helper'


### PR DESCRIPTION
1. Added discarded_at to `Litigation` model
2. Override `DESTROY` action using `::Command::Destroy::Litigation`
3. Added specs
4. Removed validation during soft-delete action in Litigation and also from Legislation because it's possible that some precedent record (like geography) was removed earlier. 