### PR TITLE
Feature/import mq assessments

### DIFF
--- a/app/admin/companies.rb
+++ b/app/admin/companies.rb
@@ -65,9 +65,9 @@ ActiveAdmin.register Company do
                 end
 
                 table_for a.questions do
-                  column(:level) { |q| q['level'] }
-                  column(:answer) { |q| q['answer'] }
-                  column(:question) { |q| q['question'] }
+                  column :level
+                  column :answer
+                  column :question
                 end
               end
             end

--- a/app/admin/cp_assessments.rb
+++ b/app/admin/cp_assessments.rb
@@ -43,7 +43,8 @@ ActiveAdmin.register CP::Assessment do
     column :id
     column(:company) { |a| a.company.name }
     column :assessment_date
-    column :publication_date
+    column :publication_date, &:publication_date_csv
+
     year_columns.map do |year|
       column year do |a|
         a.emissions[year]

--- a/app/admin/cp_assessments.rb
+++ b/app/admin/cp_assessments.rb
@@ -8,7 +8,7 @@ ActiveAdmin.register CP::Assessment do
   actions :all, except: [:new, :edit, :create, :update]
 
   filter :assessment_date
-  filter :publication_date
+  filter :publication_date, as: :select, collection: proc { CP::Assessment.all_publication_dates }
   filter :company
   filter :company_sector_id, as: :select, collection: proc { Sector.all }
 

--- a/app/admin/cp_benchmarks.rb
+++ b/app/admin/cp_benchmarks.rb
@@ -30,7 +30,7 @@ ActiveAdmin.register CP::Benchmark do
 
     column :id
     column(:sector) { |b| b.sector.name }
-    column(:release_date) { |b| b.release_date.strftime('%Y-%m') }
+    column(:release_date) { |b| b.release_date.to_s(:year_month) }
     column :scenario
 
     year_columns.map do |year|

--- a/app/admin/mq_assessments.rb
+++ b/app/admin/mq_assessments.rb
@@ -8,7 +8,7 @@ ActiveAdmin.register MQ::Assessment do
   actions :all, except: [:new, :edit, :create, :update]
 
   filter :assessment_date
-  filter :publication_date
+  filter :publication_date, as: :select, collection: proc { MQ::Assessment.all_publication_dates }
   filter :company
   filter :company_sector_id, as: :select, collection: proc { Sector.all }
   filter :level, as: :select, collection: MQ::Assessment::LEVELS
@@ -48,6 +48,26 @@ ActiveAdmin.register MQ::Assessment do
     column :publication_date
     column :level, &:status_description_short
     actions
+  end
+
+  csv do
+    question_column_names = collection.flat_map(&:all_questions_keys).uniq
+
+    column(:company) { |a| a.company.name }
+    column :assessment_date
+    column :publication_date
+    column :level
+
+    question_column_names.map do |question_column|
+      column question_column, humanize_name: false do |a|
+        answer = a.questions_by_key_hash[question_column]
+        if answer.present?
+          answer['answer']
+        else
+          'not applicable for this methodology'
+        end
+      end
+    end
   end
 
   controller do

--- a/app/admin/mq_assessments.rb
+++ b/app/admin/mq_assessments.rb
@@ -51,15 +51,10 @@ ActiveAdmin.register MQ::Assessment do
 
     panel 'Questions' do
       table_for resource.questions do
-        column :level do |q|
-          q['level']
-        end
-        column :answer do |q|
-          q['answer']
-        end
-        column :question do |q|
-          q['question']
-        end
+        column :number
+        column :level
+        column :answer
+        column :question
       end
     end
   end
@@ -73,7 +68,9 @@ ActiveAdmin.register MQ::Assessment do
   end
 
   csv do
-    question_column_names = collection.flat_map(&:all_questions_keys).uniq
+    question_column_names = collection.flat_map do |a|
+      a.questions.map(&:csv_column_name)
+    end.uniq
 
     column :id
     column(:company) { |a| a.company.name }
@@ -82,8 +79,10 @@ ActiveAdmin.register MQ::Assessment do
     column :level
 
     question_column_names.map do |question_column|
+      key = question_column.split('|').first
+
       column question_column, humanize_name: false do |a|
-        a.questions_by_key_hash[question_column]['answer']
+        a.questions_by_key_hash[key].answer
       end
     end
   end

--- a/app/admin/mq_assessments.rb
+++ b/app/admin/mq_assessments.rb
@@ -28,7 +28,7 @@ ActiveAdmin.register MQ::Assessment do
       end
 
       li do
-        upload_label = "<strong>Upload</strong> MQ Assessments".html_safe
+        upload_label = '<strong>Upload</strong> MQ Assessments'.html_safe
         upload_path = new_admin_data_upload_path(data_upload: {uploader: 'MQAssessments'})
 
         link_to upload_label, upload_path

--- a/app/admin/mq_assessments.rb
+++ b/app/admin/mq_assessments.rb
@@ -68,10 +68,6 @@ ActiveAdmin.register MQ::Assessment do
   end
 
   csv do
-    question_column_names = collection.flat_map do |a|
-      a.questions.map(&:csv_column_name)
-    end.uniq
-
     column :id
     column(:company) { |a| a.company.name }
     column :assessment_date
@@ -79,11 +75,11 @@ ActiveAdmin.register MQ::Assessment do
     column :level
     column :notes
 
-    question_column_names.map do |question_column|
-      key = question_column.split('|').first
-
-      column question_column, humanize_name: false do |a|
-        a.questions_by_key_hash[key].answer
+    # we can take first assessment questions "schema"
+    # since it is already filtered by publication date
+    collection.first.questions.map do |mq_question|
+      column mq_question.csv_column_name, humanize_name: false do |assessment|
+        assessment.find_answer_by_key(mq_question.key)
       end
     end
   end

--- a/app/admin/mq_assessments.rb
+++ b/app/admin/mq_assessments.rb
@@ -29,7 +29,7 @@ ActiveAdmin.register MQ::Assessment do
 
       li do
         upload_label = "<strong>Upload</strong> MQ Assessments".html_safe
-        upload_path = new_admin_data_upload_path(data_upload: {uploader: 'MQAssessment'})
+        upload_path = new_admin_data_upload_path(data_upload: {uploader: 'MQAssessments'})
 
         link_to upload_label, upload_path
       end
@@ -75,8 +75,9 @@ ActiveAdmin.register MQ::Assessment do
     column :id
     column(:company) { |a| a.company.name }
     column :assessment_date
-    column :publication_date
+    column :publication_date, &:publication_date_csv
     column :level
+    column :notes
 
     question_column_names.map do |question_column|
       key = question_column.split('|').first

--- a/app/decorators/cp/assessment_decorator.rb
+++ b/app/decorators/cp/assessment_decorator.rb
@@ -12,4 +12,12 @@ class CP::AssessmentDecorator < Draper::Decorator
   def assessment_date
     model.assessment_date || 'No date'
   end
+
+  def publication_date
+    model.publication_date.to_s(:month_name_and_year)
+  end
+
+  def publication_date_csv
+    model.publication_date.to_s(:year_month)
+  end
 end

--- a/app/decorators/mq/assessment_decorator.rb
+++ b/app/decorators/mq/assessment_decorator.rb
@@ -18,6 +18,10 @@ class MQ::AssessmentDecorator < Draper::Decorator
   end
 
   def publication_date
-    model.publication_date.to_s(:month_and_year)
+    model.publication_date.to_s(:month_name_and_year)
+  end
+
+  def publication_date_csv
+    model.publication_date.to_s(:year_month)
   end
 end

--- a/app/models/cp/assessment.rb
+++ b/app/models/cp/assessment.rb
@@ -22,5 +22,9 @@ module CP
     scope :latest_first, -> { order(assessment_date: :desc) }
 
     validates_presence_of :publication_date
+
+    def self.all_publication_dates
+      distinct.order(publication_date: :desc).pluck(:publication_date)
+    end
   end
 end

--- a/app/models/cp/assessment.rb
+++ b/app/models/cp/assessment.rb
@@ -20,11 +20,8 @@ module CP
     belongs_to :company
 
     scope :latest_first, -> { order(assessment_date: :desc) }
+    scope :all_publication_dates, -> { distinct.order(publication_date: :desc).pluck(:publication_date) }
 
     validates_presence_of :publication_date
-
-    def self.all_publication_dates
-      distinct.order(publication_date: :desc).pluck(:publication_date)
-    end
   end
 end

--- a/app/models/data_upload.rb
+++ b/app/models/data_upload.rb
@@ -16,9 +16,10 @@ class DataUpload < ApplicationRecord
   UPLOADERS = %w[
     CPAssessments
     CPBenchmarks
+    Companies
     Legislations
     Litigations
-    Companies
+    MQAssessments
     Targets
   ].freeze
 

--- a/app/models/mq/assessment.rb
+++ b/app/models/mq/assessment.rb
@@ -47,19 +47,18 @@ module MQ
     end
 
     def questions
-      self[:questions].each_with_index.map do |q_hash, index|
+      @questions ||= self[:questions].each_with_index.map do |q_hash, index|
         MQ::Question.new(q_hash.merge(number: index + 1))
       end
     end
 
-    def questions_by_key_hash
-      questions.reduce({}) do |acc, question|
-        acc.merge(question.key => question)
-      end
+    def questions=(value)
+      @questions = nil
+      super
     end
 
-    def all_questions_keys
-      questions.map(&:key)
+    def find_answer_by_key(key)
+      questions.find { |q| q.key == key }.answer
     end
 
     class << self

--- a/app/models/mq/assessment.rb
+++ b/app/models/mq/assessment.rb
@@ -46,22 +46,26 @@ module MQ
       "#{level} (#{status})"
     end
 
-    def questions_by_key_hash
-      questions.each_with_index.reduce({}) do |acc, (question, index)|
-        question_text = question['question']
-        level = question['level']
-        key = "Q#{index}L#{level}|#{question_text}"
+    def questions
+      self[:questions].each_with_index.map do |q_hash, index|
+        MQ::Question.new(q_hash.merge(number: index + 1))
+      end
+    end
 
-        acc.merge(key => question)
+    def questions_by_key_hash
+      questions.reduce({}) do |acc, question|
+        acc.merge(question.key => question)
       end
     end
 
     def all_questions_keys
-      questions_by_key_hash.keys
+      questions.map(&:key)
     end
 
-    def self.all_publication_dates
-      distinct.order(publication_date: :desc).pluck(:publication_date)
+    class << self
+      def all_publication_dates
+        distinct.order(publication_date: :desc).pluck(:publication_date)
+      end
     end
   end
 end

--- a/app/models/mq/assessment.rb
+++ b/app/models/mq/assessment.rb
@@ -45,5 +45,23 @@ module MQ
     def status_description_short
       "#{level} (#{status})"
     end
+
+    def questions_by_key_hash
+      questions.each_with_index.reduce({}) do |acc, (question, index)|
+        question_text = question['question']
+        level = question['level']
+        key = "Q#{index}L#{level}|#{question_text}"
+
+        acc.merge(key => question)
+      end
+    end
+
+    def all_questions_keys
+      questions_by_key_hash.keys
+    end
+
+    def self.all_publication_dates
+      distinct.order(publication_date: :desc).pluck(:publication_date)
+    end
   end
 end

--- a/app/models/mq/assessment.rb
+++ b/app/models/mq/assessment.rb
@@ -22,6 +22,7 @@ module MQ
 
     scope :latest_first, -> { order(assessment_date: :desc) }
     scope :by_assessment_date, -> { order(:assessment_date) }
+    scope :all_publication_dates, -> { distinct.order(publication_date: :desc).pluck(:publication_date) }
 
     validates :level, inclusion: {in: LEVELS}
     validates_presence_of :assessment_date, :publication_date, :level
@@ -59,12 +60,6 @@ module MQ
 
     def find_answer_by_key(key)
       questions.find { |q| q.key == key }.answer
-    end
-
-    class << self
-      def all_publication_dates
-        distinct.order(publication_date: :desc).pluck(:publication_date)
-      end
     end
   end
 end

--- a/app/models/mq/question.rb
+++ b/app/models/mq/question.rb
@@ -1,0 +1,15 @@
+module MQ
+  class Question
+    include ActiveModel::Model
+
+    attr_accessor :level, :question, :answer, :number
+
+    def key
+      "Q#{number}L#{level}"
+    end
+
+    def csv_column_name
+      "#{key}|#{question}"
+    end
+  end
+end

--- a/app/services/csv_import/base_importer.rb
+++ b/app/services/csv_import/base_importer.rb
@@ -38,6 +38,19 @@ module CSVImport
       resource_klass.find_by(attr_name.to_sym => row[attr_name]&.strip)
     end
 
+    protected
+
+    def header_converters
+      [:symbol]
+    end
+
+    def csv_converters
+      hard_space_converter = ->(f) { f&.gsub(160.chr('UTF-8'), 32.chr) }
+      strip_converter = ->(field, _) { field&.strip }
+
+      [hard_space_converter, strip_converter]
+    end
+
     private
 
     def reset_import_results
@@ -55,18 +68,11 @@ module CSVImport
         headers: true,
         skip_blanks: true,
         converters: csv_converters,
-        header_converters: [:symbol]
+        header_converters: header_converters
       ).delete_if { |row| row.to_hash.values.all?(&:blank?) }
     rescue CSV::MalformedCSVError => e
       errors.add(:base, e)
       false
-    end
-
-    def csv_converters
-      hard_space_converter = ->(f) { f&.gsub(160.chr('UTF-8'), 32.chr) }
-      strip_converter = ->(field, _) { field&.strip }
-
-      [hard_space_converter, strip_converter]
     end
 
     def import_each_csv_row(csv)

--- a/app/services/csv_import/cp_assessments.rb
+++ b/app/services/csv_import/cp_assessments.rb
@@ -26,7 +26,7 @@ module CSVImport
       find_record_by(:id, row) ||
         CP::Assessment.find_or_initialize_by(
           company: find_company!(row),
-          assessment_date: parse_date(row[:assessment_date])
+          assessment_date: assessment_date(row)
         )
     end
 
@@ -38,15 +38,15 @@ module CSVImport
 
     def assessment_attributes(row)
       {
-        assessment_date: parse_date(row[:assessment_date]),
-        publication_date: parse_date(row[:publication_date]),
+        assessment_date: assessment_date(row),
+        publication_date: Import::DateUtils.safe_parse(row[:publication_date], ['%Y-%m']),
         assumptions: row[:assumptions],
         emissions: parse_emissions(row)
       }
     end
 
-    def parse_date(date)
-      Import::DateUtils.safe_parse(date, ['%Y-%m', '%Y-%m-%d'])
+    def assessment_date(row)
+      Import::DateUtils.safe_parse(row[:assessment_date], ['%Y-%m-%d'])
     end
   end
 end

--- a/app/services/csv_import/cp_assessments.rb
+++ b/app/services/csv_import/cp_assessments.rb
@@ -39,7 +39,7 @@ module CSVImport
     def assessment_attributes(row)
       {
         assessment_date: assessment_date(row),
-        publication_date: Import::DateUtils.safe_parse(row[:publication_date], ['%Y-%m']),
+        publication_date: publication_date(row),
         assumptions: row[:assumptions],
         emissions: parse_emissions(row)
       }
@@ -47,6 +47,10 @@ module CSVImport
 
     def assessment_date(row)
       Import::DateUtils.safe_parse(row[:assessment_date], ['%Y-%m-%d'])
+    end
+
+    def publication_date(row)
+      Import::DateUtils.safe_parse(row[:publication_date], ['%Y-%m'])
     end
   end
 end

--- a/app/services/csv_import/mq_assessments.rb
+++ b/app/services/csv_import/mq_assessments.rb
@@ -49,7 +49,7 @@ module CSVImport
     def assessment_attributes(row)
       {
         assessment_date: assessment_date(row),
-        publication_date: Import::DateUtils.safe_parse(row[:publication_date], ['%Y-%m']),
+        publication_date: publication_date(row),
         level: row[:level],
         notes: row[:notes],
         questions: get_questions(row)
@@ -58,6 +58,10 @@ module CSVImport
 
     def assessment_date(row)
       Import::DateUtils.safe_parse(row[:assessment_date], ['%Y-%m-%d'])
+    end
+
+    def publication_date(row)
+      Import::DateUtils.safe_parse(row[:publication_date], ['%Y-%m'])
     end
 
     def get_questions(row)

--- a/app/services/csv_import/mq_assessments.rb
+++ b/app/services/csv_import/mq_assessments.rb
@@ -1,0 +1,87 @@
+module CSVImport
+  class MQAssessments < BaseImporter
+    include UploaderHelpers
+
+    def import
+      import_each_csv_row(csv) do |row|
+        assessment = prepare_assessment(row)
+        assessment.assign_attributes(assessment_attributes(row))
+
+        was_new_record = assessment.new_record?
+        any_changes = assessment.changed?
+
+        assessment.save!
+
+        update_import_results(was_new_record, any_changes)
+      end
+    end
+
+    private
+
+    def header_converters
+      lambda do |h|
+        return h if h.strip.end_with?('?')
+
+        CSV::HeaderConverters[:symbol].call(h)
+      end
+    end
+
+    def resource_klass
+      MQ::Assessment
+    end
+
+    def prepare_assessment(row)
+      find_record_by(:id, row) ||
+        MQ::Assessment.find_or_initialize_by(
+          company: find_company!(row),
+          assessment_date: parse_date(row[:assessment_date])
+        )
+    end
+
+    def find_company!(row)
+      return unless row[:company].present?
+
+      Company.where('lower(name) = ?', row[:company].downcase).first!
+    end
+
+    def assessment_attributes(row)
+      {
+        assessment_date: parse_date(row[:assessment_date]),
+        publication_date: parse_date(row[:publication_date]),
+        level: row[:level],
+        notes: row[:notes],
+        questions: get_questions(row)
+      }
+    end
+
+    def get_questions(row)
+      question_headers = row.headers.map(&:to_s)
+        .select { |h| h.strip.start_with?('Q') }
+
+      question_headers.map do |q_header|
+        answer = row[q_header]
+
+        next if answer.nil?
+
+        parse_question(q_header).merge(answer: answer)
+      end.compact
+    end
+
+    def parse_question(question)
+      return unless question.present?
+
+      matches = question.match(/Q\d+L(\d+)\|(.+)/)
+      level = matches[1]
+      text = matches[2]
+
+      {
+        question: text,
+        level: level
+      }
+    end
+
+    def parse_date(date)
+      Import::DateUtils.safe_parse(date, ['%Y-%m', '%Y-%m-%d'])
+    end
+  end
+end

--- a/config/initializers/time_date_formats.rb
+++ b/config/initializers/time_date_formats.rb
@@ -1,5 +1,8 @@
-Date::DATE_FORMATS[:month_and_year] = '%B %Y'
-Time::DATE_FORMATS[:month_and_year] = '%B %Y'
+Date::DATE_FORMATS[:month_name_and_year] = '%B %Y'
+Time::DATE_FORMATS[:month_name_and_year] = '%B %Y'
+
+Date::DATE_FORMATS[:year_month] = '%Y-%m'
+Time::DATE_FORMATS[:year_month] = '%Y-%m'
 
 Date::DATE_FORMATS[:date_short] = '%d %b %Y'
 Time::DATE_FORMATS[:date_short] = '%d %b %Y'

--- a/spec/support/fixtures/files/mq_assessments.csv
+++ b/spec/support/fixtures/files/mq_assessments.csv
@@ -1,0 +1,3 @@
+Id,Company,Assessment date,Publication date,Level,Notes,"Q1L0|Question one, level 0?","Q2L1|Question two, level 1?","Q3L2|Question 3, level 2"
+,ACME,2018-01-25,2018-12,2,notes,Yes,Yes,Yes
+,ACME Materials,2017-10-20,2018-12,4,notes,Yes,Yes,Yes


### PR DESCRIPTION
Importing/Exporting MQ Assessments

- we can only export MQ Assessment for one publication date (different publication dates could have different question sets, we don't want to mix question's sets in one CSV file)
- questions are imported from header column with a pattern like `Q[number]L[level]|[question_text]` with the answer in the cell.