### PR TITLE
fixing mq assessment order, adding more colors

### DIFF
--- a/app/admin/companies.rb
+++ b/app/admin/companies.rb
@@ -25,7 +25,7 @@ ActiveAdmin.register Company do
   sidebar 'Details', only: :show do
     attributes_table do
       row :company, &:name
-      row :level, &:mq_status_description_short
+      row :level, &:mq_level_tag
       row :updated_at
     end
   end
@@ -43,7 +43,7 @@ ActiveAdmin.register Company do
           row :headquarters_geography
           row :ca100
           row :size
-          row 'Management Quality Level', &:mq_status_description_short
+          row 'Management Quality Level', &:mq_level_tag
           row :created_at
           row :updated_at
         end
@@ -59,7 +59,7 @@ ActiveAdmin.register Company do
             resource.mq_assessments.latest_first.decorate.map do |a|
               panel a.title, class: 'mq_assessment' do
                 attributes_table_for a do
-                  row :level, &:status_description_short
+                  row :level, &:level_tag
                   row :publication_date
                   row :assessment_date
                 end
@@ -119,7 +119,7 @@ ActiveAdmin.register Company do
     column(:name) { |company| link_to company.name, admin_company_path(company) }
     column :isin, &:isin_as_tags
     column(:size) { |company| company.size.humanize }
-    column :level, &:mq_status_description_short
+    column :level, &:mq_level_tag
     column :geography
     column :headquarters_geography
     tag_column :visibility_status

--- a/app/admin/mq_assessments.rb
+++ b/app/admin/mq_assessments.rb
@@ -41,7 +41,7 @@ ActiveAdmin.register MQ::Assessment do
     attributes_table do
       row :id
       row :company
-      row :level, &:status_description_short
+      row :level, &:level_tag
       row :assessment_date
       row :publication_date
       row :notes
@@ -65,7 +65,7 @@ ActiveAdmin.register MQ::Assessment do
     column :title, &:title_link
     column :assessment_date
     column :publication_date
-    column :level, &:status_description_short
+    column :level, &:level_tag
     actions
   end
 

--- a/app/assets/stylesheets/admin/base.scss
+++ b/app/assets/stylesheets/admin/base.scss
@@ -62,6 +62,17 @@ fieldset.actions .cancel a {
   &.published { background: $published-color; }
   &.archived { background: $archived-color; }
   &.unset { background: $unset-color; }
+
+  &.mq-new { background: $mq-new-color; }
+  &.mq-unchanged { background: $mq-unchanged-color; }
+  &.mq-up { background: $mq-up-color; }
+  &.mq-down { background: $mq-down-color; }
+}
+
+.mq-status {
+  span {
+    margin-left: 5px;
+  }
 }
 
 #search_status_sidebar_section {

--- a/app/assets/stylesheets/admin/settings.scss
+++ b/app/assets/stylesheets/admin/settings.scss
@@ -19,6 +19,12 @@ $published-color: #6d9f71;;
 $archived-color: #d0a088;
 $unset-color: $dusty-gray;
 
+// Assessment status colors
+$mq-new-color: $yellow-orange;
+$mq-unchanged-color: $malibu;
+$mq-up-color: $apple;
+$mq-down-color: $red;
+
 // Yes / No
 $flag-true-color: #8fbb93;
 $flag-false-color: #b7b6b6;

--- a/app/decorators/company_decorator.rb
+++ b/app/decorators/company_decorator.rb
@@ -4,4 +4,10 @@ class CompanyDecorator < Draper::Decorator
   def isin_as_tags
     isin.split(',')
   end
+
+  def mq_level_tag
+    return if model.latest_mq_assessment.nil?
+
+    model.latest_mq_assessment.decorate.level_tag
+  end
 end

--- a/app/decorators/mq/assessment_decorator.rb
+++ b/app/decorators/mq/assessment_decorator.rb
@@ -24,4 +24,11 @@ class MQ::AssessmentDecorator < Draper::Decorator
   def publication_date_csv
     model.publication_date.to_s(:year_month)
   end
+
+  def level_tag
+    h.content_tag :div, class: 'mq-status' do
+      h.content_tag(:strong, model.level) <<
+        h.content_tag(:span, model.status, class: "status_tag mq-#{model.status}")
+    end
+  end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -36,14 +36,14 @@ class Company < ApplicationRecord
   has_many :litigations, through: :litigation_sides
 
   delegate :level, :status, :status_description_short,
-           to: :latest_assessment, prefix: :mq, allow_nil: true
+           to: :latest_mq_assessment, prefix: :mq, allow_nil: true
 
   validates :ca100, inclusion: {in: [true, false]}
   validates_presence_of :name, :slug, :isin, :size
   validates_uniqueness_of :slug, :isin, :name
 
-  def latest_assessment
-    mq_assessments.first
+  def latest_mq_assessment
+    mq_assessments.order(:assessment_date).last
   end
 
   def to_s

--- a/app/models/mq/assessment.rb
+++ b/app/models/mq/assessment.rb
@@ -21,7 +21,6 @@ module MQ
     belongs_to :company, inverse_of: :mq_assessments
 
     scope :latest_first, -> { order(assessment_date: :desc) }
-    scope :by_assessment_date, -> { order(:assessment_date) }
     scope :all_publication_dates, -> { distinct.order(publication_date: :desc).pluck(:publication_date) }
 
     validates :level, inclusion: {in: LEVELS}
@@ -44,7 +43,7 @@ module MQ
     end
 
     def status_description_short
-      "#{level} (#{status})"
+      "#{level} (#{status.upcase})"
     end
 
     def questions

--- a/spec/controllers/admin/targets_controller_spec.rb
+++ b/spec/controllers/admin/targets_controller_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Admin::TargetsController, type: :controller do
           expect(t.geography_id).to eq(geography.id)
           expect(t.sector_id).to eq(sector.id)
           expect(t.target_scope_id).to eq(target_scope.id)
-          expect(t.legislation_ids).to eq(legislations.pluck(:id))
+          expect(t.legislation_ids.sort).to eq(legislations.pluck(:id).sort)
           expect(
             t.events.order(:date).pluck(:title, :event_type, :description, :url)
           ).to eq(expected_events_attrs)


### PR DESCRIPTION
`latest_assessment` for a company was not always the latest one, because order by date was missing somehow. That affected current company level, but now should be fixed. Also I added more colors to the backend (not sure if my idea is good lol)

![image](https://user-images.githubusercontent.com/1286444/65704722-5606be00-e087-11e9-9ece-17cfd8f72e4e.png)
