### PR TITLE
(chart-api) fix for fetching sector benchmarks + clean up

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -60,9 +60,9 @@ class Company < ApplicationRecord
   end
 
   # Returns sector CP benchmarks:
-  # - if company has assessment      - from the last date before latest CP::Assessment date
-  # - if company has no assessments  - from latest benchmarks
-  # - if company has old assessments - from latest benchmarks
+  # - from the last date before latest CP::Assessment date
+  #   (if company latest CP::Assessment was after at least one benchmark)
+  # - from latest benchmarks otherwise
   #
   # @return [AssociationRelation [#<CP::Benchmark]
   #

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -72,20 +72,19 @@ class Company < ApplicationRecord
   # - if assessment date is 06.2017 - we take benchmarks from 04.2017
   def latest_sector_benchmarks_before_last_assessment
     last_assessment_date = latest_cp_assessment&.assessment_date
+
+    return sector.latest_released_benchmarks unless last_assessment_date
+
     sector_benchmarks_dates = sector.cp_benchmarks.pluck(:release_date).uniq.sort
 
-    if last_assessment_date
-      last_release_date_before_assessment =
-        sector_benchmarks_dates
-          .select { |d| d < last_assessment_date }
-          .last
+    last_release_date_before_assessment =
+      sector_benchmarks_dates
+        .select { |d| d < last_assessment_date }
+        .last
 
-      release_date =
-        last_release_date_before_assessment || sector_benchmarks_dates.last
+    release_date =
+      last_release_date_before_assessment || sector_benchmarks_dates.last
 
-      sector.cp_benchmarks.where(release_date: release_date)
-    else
-      sector.latest_released_benchmarks
-    end
+    sector.cp_benchmarks.where(release_date: release_date)
   end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -55,7 +55,29 @@ class Company < ApplicationRecord
     cp_assessments.order(:assessment_date).last
   end
 
-  def sector_benchmarks
-    sector.cp_benchmarks
+  def latest_sector_benchmarks
+    sector.latest_released_benchmarks
+  end
+
+  # Returns sector benchmarks:
+  # - if company has assessment - from the last date before latest CP::Assessment date
+  # - if company has no assessments - from latest benchmarks
+  #
+  # @example Company has assessment:
+  # - benchmarks available for 04.2017 and 05.2018
+  # - if assessment date is 06.2018 we take 05.2018 benchmarks
+  # - if assessment date is 06.2017 we take benchmarks for 04.2017
+  def latest_sector_benchmarks_before_last_assessment
+    last_assessment_date = latest_cp_assessment&.assessment_date
+    sector_benchmarks_dates = sector.cp_benchmarks.pluck(:release_date).uniq.sort
+
+    if last_assessment_date
+      last_release_date_before_assessment = sector_benchmarks_dates.select { |d| d < last_assessment_date }.last
+      release_date = last_release_date_before_assessment || sector_benchmarks_dates.last
+
+      sector.cp_benchmarks.where(release_date: release_date)
+    else
+      sector.latest_released_benchmarks
+    end
   end
 end

--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -19,4 +19,8 @@ class Sector < ApplicationRecord
 
   validates_presence_of :name, :slug
   validates_uniqueness_of :name, :slug
+
+  def latest_released_benchmarks
+    cp_benchmarks.group_by(&:release_date).max&.last || []
+  end
 end

--- a/app/services/api/charts/company.rb
+++ b/app/services/api/charts/company.rb
@@ -68,7 +68,7 @@ module Api
           .to_h
       end
 
-      # Returns average emission from all Companies from single year
+      # @return [Float] average emission from all Companies from single year
       def sector_average_emission_for_year(year)
         company_emissions = sector_all_emissions
           .map { |emissions| emissions[year.to_s] }
@@ -77,20 +77,22 @@ module Api
         (company_emissions.sum / company_emissions.count).round(2)
       end
 
+      # @return [Array] of years for which emissions was reported
       def years_with_reported_emissions
         last_reported_year = Time.new.year
 
         (sector_all_emission_years.min..last_reported_year).map.to_a
       end
 
+      # @return [Array] unique array of years as numbers
       def sector_all_emission_years
         sector_all_emissions
-          .flat_map(&:keys) # just .keys?
+          .flat_map(&:keys)
           .map(&:to_i)
           .uniq
       end
 
-      # Returns array of emissions ({ year => value }) from all Companies from current Sector
+      # @return [Array<Hash>] list of { year => value } pairs from all Companies from current Sector
       def sector_all_emissions
         @sector_all_emissions ||= @company.sector
           .companies

--- a/app/services/api/charts/cp_benchmark.rb
+++ b/app/services/api/charts/cp_benchmark.rb
@@ -3,7 +3,7 @@ module Api
     class CPBenchmark
       # Calculate companies stats grouped by CP benchmark in multiple series.
       #
-      # @return [Array<Hash> chart data
+      # @return [Array<Hash>] chart data
       # @example
       #   [
       #     {

--- a/app/services/api/charts/cp_benchmark.rb
+++ b/app/services/api/charts/cp_benchmark.rb
@@ -73,16 +73,12 @@ module Api
       # @example
       #   {"Airlines": {"Below 2 Degrees": 110, "2 Degrees": 101}}
       def sectors_scenario_emissions
-        sectors = {}
-
-        ::Sector.all.includes(:cp_benchmarks, companies: [:cp_assessments]).each do |sector|
-          sectors[sector] = {}
-          get_last_cp_benchmarks(sector).each do |benchmark|
-            sectors[sector][benchmark.scenario] = benchmark.emissions[current_year]
+        all_sectors.each_with_object({}) do |sector, sectors_hash|
+          sectors_hash[sector] = {}
+          sector.latest_released_benchmarks.each do |benchmark|
+            sectors_hash[sector][benchmark.scenario] = benchmark.emissions[current_year]
           end
         end
-
-        sectors
       end
 
       # Get company emission for current year or for the latest assessment
@@ -112,16 +108,11 @@ module Api
         scenarios_with_greater_emission.min_by { |_s, value| value - company_emission }.first
       end
 
-      # Get list of last CPBenchmarks for sector
+      # Get all Sectors
       #
-      # @param sector [Sector]
-      # @return [Array<CPBenchmark>]
-      def get_last_cp_benchmarks(sector)
-        cp_benchmarks = sector.cp_benchmarks
-
-        return [] if cp_benchmarks.empty?
-
-        cp_benchmarks.group_by(&:release_date).max[1]
+      # @return [Sector::ActiveRecord_Relation]
+      def all_sectors
+        ::Sector.includes(:cp_benchmarks, companies: [:cp_assessments])
       end
 
       # @return [String] string with current year

--- a/app/services/api/charts/sector.rb
+++ b/app/services/api/charts/sector.rb
@@ -43,16 +43,18 @@ module Api
 
       # Returns companies emissions, which includes:
       # - companies emissions
-      # - current Sector "scenario" emissions
+      # - current Sector "scenarios" emissions
       #
       # Returns data in multiple series.
       #
       # @return [Array]
       # @example
       #   [
-      #     { name: 'WizzAir', data: { '2014' => 111.0, '2015' => 112.0 } },
+      #     { name: 'WizzAir',   data: { '2014' => 111.0, '2015' => 112.0 } },
       #     { name: 'Air China', data: { .. } },
-      #     { name: '2 Degrees (High Efficiency)', data: { .. } }
+      #     ..
+      #
+      #     { name: '2 Degrees', data: { .. } }
       #   ]
       #
       def companies_emissions_data
@@ -73,13 +75,11 @@ module Api
       def emissions_data_from_companies
         @company_scope
           .includes(:mq_assessments, :cp_assessments)
-          .map { |company| company_emissions_series_options(company) }
+          .map { |company| emissions_data_from_company(company) }
       end
 
       def emissions_data_from_sector_benchmarks
-        # TODO: take last released benchmarks only
-        # (similar as in Api::Charts::CPBenchmark#get_last_cp_benchmarks)
-        @company_scope.first.sector_benchmarks.map do |benchmark|
+        @company_scope.first.latest_sector_benchmarks.map do |benchmark|
           {
             type: 'area',
             fillOpacity: 0.1,
@@ -89,7 +89,7 @@ module Api
         end
       end
 
-      def company_emissions_series_options(company)
+      def emissions_data_from_company(company)
         {
           name: company.name,
           data: company.latest_cp_assessment&.emissions,

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -86,4 +86,63 @@ RSpec.describe Company, type: :model do
       expect(company.latest_mq_assessment.assessment_date.to_s).to eq('2019-05-01')
     end
   end
+
+  describe '#latest_sector_benchmarks_before_last_assessment' do
+    let(:sector_cp_benchmarks) do
+      [
+        create(:cp_benchmark, release_date: '2013-05-01', scenario: 'Below 2'),    # previous benchmarks
+        create(:cp_benchmark, release_date: '2013-05-01', scenario: 'Paris'),      # - should be ignored
+        create(:cp_benchmark, release_date: '2013-05-01', scenario: '2 degrees'),
+
+        create(:cp_benchmark, release_date: '2016-05-01', scenario: 'Below 2'),    # last benchmarks
+        create(:cp_benchmark, release_date: '2016-05-01', scenario: 'Paris'),      # before latest CP assessment
+        create(:cp_benchmark, release_date: '2016-05-01', scenario: '2 degrees'),  # - OK
+
+        create(:cp_benchmark, release_date: '2019-05-01', scenario: 'Below 2'),    # most recent benchmarks,
+        create(:cp_benchmark, release_date: '2019-05-01', scenario: 'Paris'),      # but without CP assessment
+        create(:cp_benchmark, release_date: '2019-05-01', scenario: '2 degrees')   # - should be ignored
+      ]
+    end
+    let(:company_assessments) do
+      [
+        create(:cp_assessment, assessment_date: '2012-05-01'),
+        create(:cp_assessment, assessment_date: '2013-05-01'),
+        create(:cp_assessment, assessment_date: '2018-05-01') # <- last assessment date
+      ]
+    end
+    let(:older_company_assessments) do
+      [
+        create(:cp_assessment, assessment_date: '2011-05-01'),
+        create(:cp_assessment, assessment_date: '2012-05-01')
+      ]
+    end
+
+    it 'returns latest CP benchmarks with release date smaller than latest CP Assessment assessment date' do
+      company = create(:company,
+                       sector: create(:sector, cp_benchmarks: sector_cp_benchmarks),
+                       cp_assessments: company_assessments)
+
+      # last assessment year is 2018, so we should take benchmarks from 2016
+      expect(company.latest_sector_benchmarks_before_last_assessment.pluck(:release_date, :scenario))
+        .to eq([
+                 [Date.parse('2016-05-01'), 'Below 2'],
+                 [Date.parse('2016-05-01'), 'Paris'],
+                 [Date.parse('2016-05-01'), '2 degrees']
+               ])
+    end
+
+    it 'returns latest CP benchmarks with last release date if all CP Assessments are older' do
+      company = create(:company,
+                       sector: create(:sector, cp_benchmarks: sector_cp_benchmarks),
+                       cp_assessments: older_company_assessments)
+
+      # last assessment year is 2012 - before oldest bechmark, so we just take most recent benchmark
+      expect(company.latest_sector_benchmarks_before_last_assessment.pluck(:release_date, :scenario))
+        .to eq([
+                 [Date.parse('2019-05-01'), 'Below 2'],
+                 [Date.parse('2019-05-01'), 'Paris'],
+                 [Date.parse('2019-05-01'), '2 degrees']
+               ])
+    end
+  end
 end


### PR DESCRIPTION
Extracted query helpers:
- `Sector#latest_released_benchmarks`
- `Company#latest_sector_benchmarks`
- `Company#latest_sector_benchmarks_before_last_assessment`

Also, updated docs.