### PR TITLE
add missing legislation type to legislations

### DIFF
--- a/app/admin/legislations.rb
+++ b/app/admin/legislations.rb
@@ -8,7 +8,7 @@ ActiveAdmin.register Legislation do
   publishable_scopes
 
   permit_params :title, :date_passed, :description,
-                :geography_id, :law_id,
+                :geography_id, :law_id, :legislation_type,
                 :natural_hazards_string, :keywords_string,
                 :created_by_id, :updated_by_id, :visibility_status,
                 events_attributes: permit_params_for(:events),
@@ -19,6 +19,9 @@ ActiveAdmin.register Legislation do
   filter :title_contains, label: 'Title'
   filter :date_passed
   filter :description_contains, label: 'Description'
+  filter :legislation_type,
+         as: :select,
+         collection: proc { array_to_select_collection(Legislation::LEGISLATION_TYPES) }
   filter :geography
   filter :frameworks,
          as: :check_boxes,
@@ -30,6 +33,7 @@ ActiveAdmin.register Legislation do
   index do
     selectable_column
     column :title, &:title_summary_link
+    column :legislation_type
     column :date_passed
     column 'Frameworks', &:frameworks_string
     column :geography
@@ -54,6 +58,7 @@ ActiveAdmin.register Legislation do
           row :date_passed
           row :geography
           row :law_id
+          row :legislation_type
           row 'Frameworks', &:frameworks_string
           row :updated_at
           row :updated_by
@@ -95,6 +100,7 @@ ActiveAdmin.register Legislation do
     column :id
     column :law_id
     column :title
+    column(:legislation_type) { |l| l.legislation_type.downcase }
     column :date_passed
     column :description
     column(:geography) { |l| l.geography.name }

--- a/app/decorators/legislation_decorator.rb
+++ b/app/decorators/legislation_decorator.rb
@@ -20,6 +20,10 @@ class LegislationDecorator < Draper::Decorator
     model.date_passed.to_s(:date_short)
   end
 
+  def legislation_type
+    model.legislation_type.humanize
+  end
+
   def litigations_links
     return [] if model.litigations.empty?
 

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -26,6 +26,7 @@ class Legislation < ApplicationRecord
 
   friendly_id :title, use: :slugged, routes: :default
 
+  LEGISLATION_TYPES = %w[executive legislative].freeze
   EVENT_TYPES = %w[
     drafted
     approved
@@ -37,6 +38,8 @@ class Legislation < ApplicationRecord
   tag_with :document_types
   tag_with :keywords
   tag_with :natural_hazards
+
+  enum legislation_type: array_to_enum_hash(LEGISLATION_TYPES)
 
   belongs_to :geography
   has_many :documents, as: :documentable, dependent: :destroy

--- a/app/services/csv_import/legislations.rb
+++ b/app/services/csv_import/legislations.rb
@@ -39,6 +39,7 @@ module CSVImport
         date_passed: row[:date_passed],
         description: row[:description],
         geography: geographies[row[:geography_iso]],
+        legislation_type: row[:legislation_type].downcase,
         visibility_status: row[:visibility_status]
       }
     end

--- a/app/services/import/legislation.rb
+++ b/app/services/import/legislation.rb
@@ -62,6 +62,7 @@ module Import
         date_passed: find_date_passed(row),
         document_types: find_document_types(row),
         geography: Import::GeographyUtils.find_by_iso(row[:country_iso]),
+        legislation_type: row[:executive_legislative].downcase,
         documents: create_documents(row)
       }
     end

--- a/app/views/admin/legislations/_form.html.erb
+++ b/app/views/admin/legislations/_form.html.erb
@@ -15,6 +15,7 @@
         <%= f.inputs do %>
           <%= f.input :title %>
           <%= f.input :description, as: :trix %>
+          <%= f.input :legislation_type, as: :select %>
           <%= f.input :document_type_ids, label: 'Document', as: :tags, collection: DocumentType.all %>
           <%= f.input :instrument_ids, label: 'Instrument', as: :tags, collection: Instrument.all %>
           <%= f.input :governance_ids, label: 'Governance', as: :tags, collection: Governance.all %>

--- a/db/migrate/20191002083102_add_legislation_type_to_legislation.rb
+++ b/db/migrate/20191002083102_add_legislation_type_to_legislation.rb
@@ -1,0 +1,7 @@
+class AddLegislationTypeToLegislation < ActiveRecord::Migration[5.2]
+  def change
+    # at this stage, no production yet and the development data on staging should be reimported anyway
+    add_column :legislations, :legislation_type, :string, null: false, default: 'legislative'
+    change_column_default(:legislations, :legislation_type, from: 'legislative', to: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_30_143410) do
+ActiveRecord::Schema.define(version: 2019_10_02_083102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -250,6 +250,7 @@ ActiveRecord::Schema.define(version: 2019_09_30_143410) do
     t.bigint "created_by_id"
     t.bigint "updated_by_id"
     t.datetime "discarded_at"
+    t.string "legislation_type", null: false
     t.index ["created_by_id"], name: "index_legislations_on_created_by_id"
     t.index ["discarded_at"], name: "index_legislations_on_discarded_at"
     t.index ["geography_id"], name: "index_legislations_on_geography_id"

--- a/spec/controllers/admin/legislations_controller_spec.rb
+++ b/spec/controllers/admin/legislations_controller_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Admin::LegislationsController, type: :controller do
           date_passed: Date.parse('2/4/2004'),
           law_id: 1001,
           visibility_status: 'pending',
+          legislation_type: 'legislative',
           geography_id: geography.id,
           documents_attributes: [
             attributes_for(:document).merge(
@@ -98,6 +99,7 @@ RSpec.describe Admin::LegislationsController, type: :controller do
           expect(l.law_id).to eq(1001)
           expect(l.date_passed).to eq(Date.parse('2/4/2004'))
           expect(l.geography_id).to eq(geography.id)
+          expect(l.legislative?).to be(true)
           expect(l.documents.pluck(:name, :language, :external_url).sort)
             .to eq([['doc 1', 'en', 'http://test.com/file.pdf'], ['doc 2', 'pl', '']])
           expect(

--- a/spec/factories/legislations.rb
+++ b/spec/factories/legislations.rb
@@ -24,6 +24,7 @@ FactoryBot.define do
     date_passed { 2.years.ago }
     sequence(:law_id)
     visibility_status { Legislation::VISIBILITY.first }
+    legislation_type { 'executive' }
     discarded_at { nil }
 
     association :created_by, factory: :admin_user

--- a/spec/models/legislation_spec.rb
+++ b/spec/models/legislation_spec.rb
@@ -43,4 +43,10 @@ RSpec.describe Legislation, type: :model do
     subject.visibility_status = nil
     expect(subject).to have(2).errors_on(:visibility_status)
   end
+
+  it 'should be invalid if legislation_type is wrong' do
+    expect {
+      subject.legislation_type = 'WRONG'
+    }.to raise_error(ArgumentError)
+  end
 end

--- a/spec/support/fixtures/files/legislations.csv
+++ b/spec/support/fixtures/files/legislations.csv
@@ -1,3 +1,3 @@
-"Id","Law","Title","Date passed","Description","Geography","Geography iso","Frameworks","Document types","Visibility status"
-"10","101","Finance Act 2011","01 Jan 2012","Description","United Kingdom","GBR","","Law","draft"
-"20","102","Climate Law","15 Jan 2015","Description","Poland","POL","","Law","pending"
+"Id","Law","Legislation type","Title","Date passed","Description","Geography","Geography iso","Frameworks","Document types","Visibility status"
+"10","101","executive","Finance Act 2011","01 Jan 2012","Description","United Kingdom","GBR","","Law","draft"
+"20","102","legislative","Climate Law","15 Jan 2015","Description","Poland","POL","","Law","pending"


### PR DESCRIPTION
Missing legislation type for Legislation model as per [Pivotal Story](https://www.pivotaltracker.com/story/show/168509300)

Please reimport dev data (still old AWS)
```
rake import:legislation
```