### PR TITLE
add last reported year to cp assessments

### DIFF
--- a/app/admin/cp_assessments.rb
+++ b/app/admin/cp_assessments.rb
@@ -20,6 +20,7 @@ ActiveAdmin.register CP::Assessment do
       row :company
       row :assessment_date
       row :publication_date
+      row :last_reported_year
       row :assumptions
       row :created_at
       row :updated_at
@@ -47,6 +48,7 @@ ActiveAdmin.register CP::Assessment do
     column(:company) { |a| a.company.name }
     column :assessment_date
     column :publication_date, &:publication_date_csv
+    column :last_reported_year
 
     year_columns.map do |year|
       column year do |a|

--- a/app/models/cp/assessment.rb
+++ b/app/models/cp/assessment.rb
@@ -2,15 +2,16 @@
 #
 # Table name: cp_assessments
 #
-#  id               :bigint           not null, primary key
-#  company_id       :bigint
-#  publication_date :date             not null
-#  assessment_date  :date
-#  emissions        :jsonb
-#  assumptions      :text
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  discarded_at     :datetime
+#  id                 :bigint           not null, primary key
+#  company_id         :bigint
+#  publication_date   :date             not null
+#  assessment_date    :date
+#  emissions          :jsonb
+#  assumptions        :text
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  discarded_at       :datetime
+#  last_reported_year :integer
 #
 
 module CP

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -15,6 +15,7 @@
 #  created_by_id     :bigint
 #  updated_by_id     :bigint
 #  discarded_at      :datetime
+#  legislation_type  :string           not null
 #
 
 class Legislation < ApplicationRecord

--- a/app/services/csv_import/cp_assessments.rb
+++ b/app/services/csv_import/cp_assessments.rb
@@ -41,7 +41,8 @@ module CSVImport
         assessment_date: assessment_date(row),
         publication_date: publication_date(row),
         assumptions: row[:assumptions],
-        emissions: parse_emissions(row)
+        emissions: parse_emissions(row),
+        last_reported_year: row[:last_reported_year]
       }
     end
 

--- a/db/migrate/20191006152145_add_last_reported_year_to_cp_assessments.rb
+++ b/db/migrate/20191006152145_add_last_reported_year_to_cp_assessments.rb
@@ -1,0 +1,5 @@
+class AddLastReportedYearToCpAssessments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :cp_assessments, :last_reported_year, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_02_083102) do
+ActiveRecord::Schema.define(version: 2019_10_06_152145) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,6 +95,7 @@ ActiveRecord::Schema.define(version: 2019_10_02_083102) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "discarded_at"
+    t.integer "last_reported_year"
     t.index ["company_id"], name: "index_cp_assessments_on_company_id"
     t.index ["discarded_at"], name: "index_cp_assessments_on_discarded_at"
   end

--- a/spec/commands/csv_data_upload_spec.rb
+++ b/spec/commands/csv_data_upload_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+# TODO: Extract all importers tests from here to separate files
+
 describe 'CsvDataUpload (integration)' do
   let(:legislations_csv) { fixture_file('legislations.csv') }
   let(:litigations_csv) { fixture_file('litigations.csv') }
@@ -88,7 +90,7 @@ describe 'CsvDataUpload (integration)' do
   end
 
   it 'imports CSV files with CP Assessments data' do
-    create(:company, name: 'ACME')
+    acme_company = create(:company, name: 'ACME')
     create(:company, name: 'ACME Materials')
 
     expect_data_upload_results(
@@ -101,6 +103,21 @@ describe 'CsvDataUpload (integration)' do
       CP::Assessment,
       cp_assessments_csv,
       new_records: 0, not_changed_records: 2, rows: 2, updated_records: 0
+    )
+
+    assessment = acme_company.cp_assessments.last
+
+    expect(assessment.assessment_date).to eq(Date.parse('2019-01-04'))
+    expect(assessment.publication_date).to eq(Date.parse('2019-02-01'))
+    expect(assessment.last_reported_year).to eq(2018)
+    expect(assessment.emissions).to eq(
+      '2014' => 101,
+      '2015' => 101,
+      '2016' => 100,
+      '2017' => 101,
+      '2018' => 100,
+      '2019' => 99,
+      '2020' => 98
     )
   end
 

--- a/spec/factories/cp_assessment.rb
+++ b/spec/factories/cp_assessment.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
 
     assessment_date { 1.year.ago }
     publication_date { 11.months.ago }
+    last_reported_year { 2020 }
 
     assumptions { 'Assumptions about the assessment' }
 

--- a/spec/factories/legislations.rb
+++ b/spec/factories/legislations.rb
@@ -15,6 +15,7 @@
 #  created_by_id     :bigint
 #  updated_by_id     :bigint
 #  discarded_at      :datetime
+#  legislation_type  :string           not null
 #
 
 FactoryBot.define do

--- a/spec/models/cp/assessment_spec.rb
+++ b/spec/models/cp/assessment_spec.rb
@@ -2,15 +2,16 @@
 #
 # Table name: cp_assessments
 #
-#  id               :bigint           not null, primary key
-#  company_id       :bigint
-#  publication_date :date             not null
-#  assessment_date  :date
-#  emissions        :jsonb
-#  assumptions      :text
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  discarded_at     :datetime
+#  id                 :bigint           not null, primary key
+#  company_id         :bigint
+#  publication_date   :date             not null
+#  assessment_date    :date
+#  emissions          :jsonb
+#  assumptions        :text
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  discarded_at       :datetime
+#  last_reported_year :integer
 #
 
 require 'rails_helper'

--- a/spec/models/legislation_spec.rb
+++ b/spec/models/legislation_spec.rb
@@ -15,6 +15,7 @@
 #  created_by_id     :bigint
 #  updated_by_id     :bigint
 #  discarded_at      :datetime
+#  legislation_type  :string           not null
 #
 
 require 'rails_helper'

--- a/spec/support/fixtures/files/cp_assessments.csv
+++ b/spec/support/fixtures/files/cp_assessments.csv
@@ -1,3 +1,3 @@
-Id,Company,Assessment date,Publication date,2013,2014,2015,2016,2017,2018,2019,2020,2021,2022,2023,2024,2025,2026,2027,2028,2029,2030,Assumptions
-,ACME,2019-01-04,2019-02-01,,101,101,100,101,100,99,98,,,,,,,,,,,Assumptions for ACME
-,ACME Materials,2019-01-04,2019-02-01,,,,,,,,,,,,,,,,,,,Assumptions for ACME Materials
+Id,Company,Assessment date,Publication date,Last Reported Year,2013,2014,2015,2016,2017,2018,2019,2020,2021,2022,2023,2024,2025,2026,2027,2028,2029,2030,Assumptions
+,ACME,2019-01-04,2019-02-01,2018,,101,101,100,101,100,99,98,,,,,,,,,,,Assumptions for ACME
+,ACME Materials,2019-01-04,2019-02-01,2019,,,,,,,,,,,,,,,,,,,Assumptions for ACME Materials


### PR DESCRIPTION
Small PR to add last reported year to CP::Assessment model. This year is a boundary between reported and targeted emission data.