### PR TITLE
Feature/missing uploaders

### DIFF
--- a/app/admin/companies.rb
+++ b/app/admin/companies.rb
@@ -131,7 +131,6 @@ ActiveAdmin.register Company do
     column :id
     column :name
     column :isin
-    column('Sector ID') { |c| c.sector.id }
     column(:sector) { |c| c.sector.name }
     column :size
     column(:geography_iso) { |c| c.geography.iso }
@@ -176,7 +175,13 @@ ActiveAdmin.register Company do
 
   controller do
     def scoped_collection
-      super.includes(:geography, :headquarters_geography, :mq_assessments)
+      super.includes(:geography, :headquarters_geography, *csv_includes)
+    end
+
+    def csv_includes
+      return [] unless csv_format?
+
+      [:sector]
     end
 
     def destroy
@@ -189,6 +194,10 @@ ActiveAdmin.register Company do
                 end
 
       redirect_to admin_companies_path, message
+    end
+
+    def csv_format?
+      request[:format] == 'csv'
     end
   end
 end

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -1,7 +1,50 @@
 ActiveAdmin.register Event do
-  menu false
+  menu priority: 7
 
-  actions :index
+  decorate_with EventDecorator
+
+  filter :title_contains
+  filter :eventable_type, label: 'Eventable type'
+  filter :date
+
+  actions :all, except: [:new, :create]
+
+  show do
+    attributes_table do
+      row :id
+      row :title
+      row :url, &:url_link
+      row :description
+      row :date
+      row :created_at
+      row :updated_at
+    end
+
+    active_admin_comments
+  end
+
+  form html: {'data-controller' => 'check-modified'} do |f|
+    f.semantic_errors(*f.object.errors.keys)
+
+    f.inputs do
+      f.input :title
+      f.input :description
+      f.input :event_type, as: :select, collection: array_to_select_collection(f.object.event_types, :titleize)
+      f.input :date
+      f.input :url, as: :string
+    end
+
+    f.actions
+  end
+
+  index do
+    selectable_column
+    column :title, &:title_link
+    column :eventable
+    column :event_type
+    column :date
+    actions
+  end
 
   csv do
     column :id
@@ -15,12 +58,6 @@ ActiveAdmin.register Event do
   end
 
   controller do
-    def index
-      super do |format|
-        format.html { redirect_to admin_dashboard_path }
-      end
-    end
-
     def scoped_collection
       results = super.includes(:eventable)
 

--- a/app/admin/geographies.rb
+++ b/app/admin/geographies.rb
@@ -84,8 +84,18 @@ ActiveAdmin.register Geography do
   controller do
     include DiscardableController
 
+    def scoped_collection
+      return super.includes(:political_groups) if csv_format?
+
+      super
+    end
+
     def apply_filtering(chain)
       super(chain).distinct
+    end
+
+    def csv_format?
+      request[:format] == 'csv'
     end
   end
 end

--- a/app/admin/geographies.rb
+++ b/app/admin/geographies.rb
@@ -24,7 +24,7 @@ ActiveAdmin.register Geography do
          as: :check_boxes,
          collection: proc { PoliticalGroup.all }
 
-  data_export_sidebar 'Geographies'
+  data_export_sidebar 'Geographies', events: true
 
   show do
     tabs do

--- a/app/admin/geographies.rb
+++ b/app/admin/geographies.rb
@@ -66,6 +66,19 @@ ActiveAdmin.register Geography do
     actions
   end
 
+  csv do
+    column :id
+    column :name
+    column :iso
+    column :geography_type
+    column :region
+    column :legislative_process
+    column :federal
+    column :federal_details
+    column :political_groups, &:political_groups_string
+    column :visibility_status
+  end
+
   form partial: 'form'
 
   controller do

--- a/app/admin/legislations.rb
+++ b/app/admin/legislations.rb
@@ -107,6 +107,8 @@ ActiveAdmin.register Legislation do
     column(:geography_iso) { |l| l.geography.iso }
     column :frameworks, &:frameworks_string
     column :document_types, &:document_types_string
+    column :keywords, &:keywords_string
+    column :natural_hazards, &:natural_hazards_string
     column :visibility_status
   end
 
@@ -140,7 +142,15 @@ ActiveAdmin.register Legislation do
     include DiscardableController
 
     def scoped_collection
-      super.includes(:geography, :frameworks, :document_types, :created_by, :updated_by)
+      super.includes(
+        :geography,
+        :frameworks,
+        :keywords,
+        :natural_hazards,
+        :document_types,
+        :created_by,
+        :updated_by
+      )
     end
   end
 end

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -1,6 +1,10 @@
 class EventDecorator < Draper::Decorator
   delegate_all
 
+  def title_link
+    h.link_to model.title, h.admin_event_path(model)
+  end
+
   def url_link
     return unless model.url.present?
 

--- a/app/models/data_upload.rb
+++ b/app/models/data_upload.rb
@@ -17,6 +17,7 @@ class DataUpload < ApplicationRecord
     CPAssessments
     CPBenchmarks
     Companies
+    Events
     Geographies
     Legislations
     LitigationSides

--- a/app/models/data_upload.rb
+++ b/app/models/data_upload.rb
@@ -17,9 +17,10 @@ class DataUpload < ApplicationRecord
     CPAssessments
     CPBenchmarks
     Companies
+    Geographies
     Legislations
-    Litigations
     LitigationSides
+    Litigations
     MQAssessments
     Targets
   ].freeze

--- a/app/services/concerns/uploader_helpers.rb
+++ b/app/services/concerns/uploader_helpers.rb
@@ -31,6 +31,12 @@ module UploaderHelpers
     end
   end
 
+  def political_groups
+    @political_groups ||= Hash.new do |hash, keyword|
+      hash[keyword] = PoliticalGroup.find_or_initialize_by(name: keyword)
+    end
+  end
+
   def parse_tags(row_tags, tag_collection)
     return [] if row_tags.nil?
 

--- a/app/services/csv_import/events.rb
+++ b/app/services/csv_import/events.rb
@@ -1,0 +1,46 @@
+module CSVImport
+  class Events < BaseImporter
+    include UploaderHelpers
+
+    def import
+      import_each_csv_row(csv) do |row|
+        event = prepare_event(row)
+        event.assign_attributes(event_attributes(row))
+
+        was_new_record = event.new_record?
+        any_changes = event.changed?
+
+        event.save!
+
+        update_import_results(was_new_record, any_changes)
+      end
+    end
+
+    private
+
+    def resource_klass
+      Event
+    end
+
+    def prepare_event(row)
+      find_record_by(:id, row) ||
+        Event.find_or_initialize_by(
+          eventable_id: row[:eventable],
+          eventable_type: row[:eventable_type],
+          title: row[:title]
+        )
+    end
+
+    def event_attributes(row)
+      {
+        eventable_id: row[:eventable],
+        eventable_type: row[:eventable_type],
+        event_type: row[:event_type],
+        title: row[:title],
+        description: row[:description],
+        date: row[:date],
+        url: row[:url]
+      }
+    end
+  end
+end

--- a/app/services/csv_import/events.rb
+++ b/app/services/csv_import/events.rb
@@ -35,7 +35,7 @@ module CSVImport
       {
         eventable_id: row[:eventable],
         eventable_type: row[:eventable_type],
-        event_type: row[:event_type],
+        event_type: row[:event_type].downcase,
         title: row[:title],
         description: row[:description],
         date: row[:date],

--- a/app/services/csv_import/geographies.rb
+++ b/app/services/csv_import/geographies.rb
@@ -1,0 +1,46 @@
+module CSVImport
+  class Geographies < BaseImporter
+    include UploaderHelpers
+
+    def import
+      import_each_csv_row(csv) do |row|
+        geography = prepare_geography(row)
+        geography.political_groups = parse_tags(row[:political_groups], political_groups)
+
+        geography.assign_attributes(geography_attributes(row))
+
+        was_new_record = geography.new_record?
+        any_changes = geography.changed?
+
+        geography.save!
+
+        update_import_results(was_new_record, any_changes)
+      end
+    end
+
+    private
+
+    def resource_klass
+      Geography
+    end
+
+    def prepare_geography(row)
+      find_record_by(:id, row) ||
+        find_record_by(:iso, row) ||
+        resource_klass.new
+    end
+
+    def geography_attributes(row)
+      {
+        name: row[:name],
+        region: row[:region],
+        iso: row[:iso],
+        federal: row[:federal],
+        federal_details: row[:federal_details],
+        legislative_process: row[:legislative_process],
+        geography_type: row[:geography_type].downcase,
+        visibility_status: row[:visibility_status]
+      }
+    end
+  end
+end

--- a/app/services/csv_import/legislations.rb
+++ b/app/services/csv_import/legislations.rb
@@ -7,6 +7,8 @@ module CSVImport
         legislation = prepare_legislation(row)
         legislation.frameworks = parse_tags(row[:frameworks], frameworks)
         legislation.document_types = parse_tags(row[:document_types], document_types)
+        legislation.keywords = parse_tags(row[:keywords], keywords)
+        legislation.natural_hazards = parse_tags(row[:natural_hazards], natural_hazards)
 
         legislation.assign_attributes(legislation_attributes(row))
 

--- a/app/services/csv_import/litigations.rb
+++ b/app/services/csv_import/litigations.rb
@@ -38,8 +38,16 @@ module CSVImport
         jurisdiction: geographies[row[:jurisdiction_iso]],
         citation_reference_number: row[:citation_reference_number],
         core_objective: row[:core_objective],
-        summary: row[:summary]
+        summary: row[:summary],
+        visibility_status: row[:visibility_status]&.downcase,
+        legislation_ids: legislation_ids(row)
       }
+    end
+
+    def legislation_ids(row)
+      return [] unless row[:legislation_ids].present?
+
+      row[:legislation_ids].split(',').map(&:to_i)
     end
   end
 end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -47,8 +47,8 @@ ActiveAdmin.setup do |config|
       menu.add label: 'Geographies', priority: 1
       menu.add label: 'Laws', priority: 2
       menu.add label: 'TPI', priority: 3
-      menu.add label: 'Tags', priority: 7
-      menu.add label: 'Administration', priority: 8
+      menu.add label: 'Tags', priority: 8
+      menu.add label: 'Administration', priority: 9
     end
   end
   #

--- a/spec/commands/csv_data_upload_spec.rb
+++ b/spec/commands/csv_data_upload_spec.rb
@@ -52,10 +52,12 @@ describe 'CsvDataUpload (integration)' do
 
     legislation = Legislation.find_by(title: 'Climate Law')
 
-    expect(legislation.legislation_type).to eq('legislative')
-    expect(legislation.description).to eq('Description')
+    expect(legislation).to have_attributes(
+      legislation_type: 'legislative',
+      description: 'Description',
+      visibility_status: 'pending'
+    )
     expect(legislation.document_types_list).to include('Law')
-    expect(legislation.visibility_status).to eq('pending')
     expect(legislation.geography.iso).to eq('POL')
     expect(legislation.frameworks.size).to eq(2)
     expect(legislation.frameworks_list).to include('Mitigation', 'Adaptation')
@@ -86,15 +88,17 @@ describe 'CsvDataUpload (integration)' do
 
     litigation = Litigation.find_by(title: 'Litigation number 1')
 
+    expect(litigation).to have_attributes(
+      citation_reference_number: 'EWHC 2752',
+      summary: 'Lyle requested judicial review',
+      core_objective: 'Objectives',
+      visibility_status: 'pending',
+      document_type: 'case'
+    )
     expect(litigation.jurisdiction.iso).to eq('GBR')
     expect(litigation.geography.iso).to eq('GBR')
-    expect(litigation.citation_reference_number).to eq('EWHC 2752')
-    expect(litigation.summary).to eq('Lyle requested judicial review')
     expect(litigation.keywords.size).to eq(2)
     expect(litigation.keywords_list).to include('keyword1', 'keyword2')
-    expect(litigation.core_objective).to eq('Objectives')
-    expect(litigation.visibility_status).to eq('pending')
-    expect(litigation.document_type).to eq('case')
     expect(litigation.legislation_ids).to include(legislation1.id, legislation2.id)
   end
 
@@ -164,17 +168,20 @@ describe 'CsvDataUpload (integration)' do
     litigation_event.reload
     created_event = legislation.events.first
 
-    expect(litigation_event.event_type).to eq('case_decided')
-    expect(litigation_event.title).to eq('Changed title')
-    expect(litigation_event.description).to eq('Changed description')
-    expect(litigation_event.date).to eq(Date.parse('2020-12-30'))
-    expect(litigation_event.url).to eq('https://example.com')
-
-    expect(created_event.event_type).to eq('approved')
-    expect(created_event.title).to eq('title')
-    expect(created_event.description).to eq('description')
-    expect(created_event.date).to eq(Date.parse('2019-02-20'))
-    expect(created_event.url).to be_nil
+    expect(litigation_event).to have_attributes(
+      event_type: 'case_decided',
+      title: 'Changed title',
+      description: 'Changed description',
+      date: Date.parse('2020-12-30'),
+      url: 'https://example.com'
+    )
+    expect(created_event).to have_attributes(
+      event_type: 'approved',
+      title: 'title',
+      description: 'description',
+      date: Date.parse('2019-02-20'),
+      url: nil
+    )
   end
 
   it 'imports CSV files with Company data' do
@@ -310,8 +317,8 @@ describe 'CsvDataUpload (integration)' do
     file_path = "#{Rails.root}/spec/support/fixtures/files/#{filename}"
 
     if content.present?
-      file_path = "#{Rails.root}/tmp/litigation_sides.csv"
-      File.write('tmp/litigation_sides.csv', content)
+      file_path = "#{Rails.root}/tmp/#{filename}"
+      File.write(file_path, content)
     end
 
     Rack::Test::UploadedFile.new(

--- a/spec/commands/csv_data_upload_spec.rb
+++ b/spec/commands/csv_data_upload_spec.rb
@@ -50,6 +50,20 @@ describe 'CsvDataUpload (integration)' do
       legislations_csv,
       new_records: 2, not_changed_records: 0, rows: 2, updated_records: 0
     )
+
+    legislation = Legislation.find_by(title: 'Climate Law')
+
+    expect(legislation.legislation_type).to eq('legislative')
+    expect(legislation.description).to eq('Description')
+    expect(legislation.document_types_list).to include('Law')
+    expect(legislation.visibility_status).to eq('pending')
+    expect(legislation.geography.iso).to eq('POL')
+    expect(legislation.frameworks.size).to eq(2)
+    expect(legislation.frameworks_list).to include('Mitigation', 'Adaptation')
+    expect(legislation.keywords.size).to eq(2)
+    expect(legislation.keywords_list).to include('keyword1', 'keyword3')
+    expect(legislation.natural_hazards.size).to eq(2)
+    expect(legislation.natural_hazards_list).to include('sharkinados', 'flooding')
   end
 
   it 'imports CSV files with Litigation data' do

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -18,7 +18,19 @@ RSpec.describe Admin::EventsController, type: :controller do
   describe 'GET index' do
     subject { get :index }
 
-    it { is_expected.to redirect_to(admin_dashboard_path) }
+    it { is_expected.to be_successful }
+  end
+
+  describe 'GET show' do
+    subject { get :show, params: {id: event1.id} }
+
+    it { is_expected.to be_successful }
+  end
+
+  describe 'GET edit' do
+    subject { get :edit, params: {id: event1.id} }
+
+    it { is_expected.to be_successful }
   end
 
   describe 'GET index with .csv format' do
@@ -63,7 +75,7 @@ RSpec.describe Admin::EventsController, type: :controller do
       # check filtered data
       expect(csv[0]['Title']).to eq(event1.title)
       expect(csv[0]['Description']).to eq(event1.description)
-      expect(csv[0]['Event type']).to eq(event1.event_type)
+      expect(csv[0]['Event type']).to eq(event1.event_type.titleize)
 
       # only single data row
       expect(csv[1]).to be_nil

--- a/spec/support/fixtures/files/geographies.csv
+++ b/spec/support/fixtures/files/geographies.csv
@@ -1,0 +1,3 @@
+Id,Name,Iso,Geography type,Region,Legislative process,Federal,Federal details,Political groups,Visibility status
+,Afghanistan,AFG,Country,South Asia,Legislative process Afghanistan,false,,"G77, LDC",draft
+,United States of America,USA,Country,North America,Legislative process USA,true,"50 states, 1 federal district; 16 territories","OECD, G20",draft

--- a/spec/support/fixtures/files/legislations.csv
+++ b/spec/support/fixtures/files/legislations.csv
@@ -1,3 +1,3 @@
-"Id","Law","Legislation type","Title","Date passed","Description","Geography","Geography iso","Frameworks","Document types","Visibility status"
-"10","101","executive","Finance Act 2011","01 Jan 2012","Description","United Kingdom","GBR","","Law","draft"
-"20","102","legislative","Climate Law","15 Jan 2015","Description","Poland","POL","","Law","pending"
+"Id","Law","Legislation type","Title","Date passed","Description","Geography","Geography iso","Frameworks","Document types","Keywords","Natural hazards","Visibility status"
+"10","101","executive","Finance Act 2011","01 Jan 2012","Description","United Kingdom","GBR","","Law","keyword1,keyword2","tsunami","draft"
+"20","102","legislative","Climate Law","15 Jan 2015","Description","Poland","POL","Mitigation,Adaptation","Law","keyword1,keyword3","flooding,sharkinados","pending"

--- a/spec/support/fixtures/files/litigations.csv
+++ b/spec/support/fixtures/files/litigations.csv
@@ -1,5 +1,0 @@
-"Id","Title","Document type","Geography iso","Geography","Jurisdiction iso","Jurisdiction","Citation reference number","Summary","Keywords","Core objective","Visibility status","Legislation ids"
-"125","R. on the application of Tate & Lyle Industries Ltd v. Secretary of State for Energy","Case","GBR","United Kingdom","GBR","United Kingdom","[2010] EWHC 2752","Lyle requested judicial review ..","","","Draft",""
-"103","In the Matter of An Application by Brian Quinn and Michael Quinn","Case","GBR","United Kingdom","GBR","United Kingdom","[2013] NIQB 24","The applicants were brothers ...","","","Draft",""
-"93","R. on the application of Corbett v. Cornwall Council","Case","GBR","United Kingdom","GBR","United Kingdom","[2013] EWHC 3958","Local council granted approval ...","","Challenge the permit approval for the construction of a wind farm","Draft",""
-"92","R. on the application of Griffin v. Newham London Borough Council","Case","GBR","United Kingdom","GBR","United Kingdom","[2011] EWHC 53","Fight the Fights, ..","","To challenge local council decision granting consent to increased flights","Draft",""


### PR DESCRIPTION
I was planning to get rid of AWS in this PR, but I will do that tomorrow in a separate one.

Couple things here:
- data uploader for geographies and changing the default CSV export template
- missing keywords and natural hazards import/export for legislations
- Events uploader
- Events index page and also show/edit/delete
- Add visibility status and legislation ids to Litigation importer