### PR TITLE
Feature/edit mq assessments vol1

### DIFF
--- a/app/admin/mq_assessments.rb
+++ b/app/admin/mq_assessments.rb
@@ -5,7 +5,7 @@ ActiveAdmin.register MQ::Assessment do
 
   decorate_with MQ::AssessmentDecorator
 
-  actions :all, except: [:new, :edit, :create, :update]
+  permit_params :assessment_date, :publication_date, :company_id, :notes, :level
 
   filter :assessment_date
   filter :publication_date, as: :select, collection: proc { MQ::Assessment.all_publication_dates }
@@ -60,6 +60,8 @@ ActiveAdmin.register MQ::Assessment do
 
     active_admin_comments
   end
+
+  form partial: 'form'
 
   index do
     column :title, &:title_link

--- a/app/admin/mq_assessments.rb
+++ b/app/admin/mq_assessments.rb
@@ -5,6 +5,8 @@ ActiveAdmin.register MQ::Assessment do
 
   decorate_with MQ::AssessmentDecorator
 
+  actions :all, except: [:new, :create]
+
   permit_params :assessment_date, :publication_date, :company_id, :notes, :level
 
   filter :assessment_date

--- a/app/models/mq/assessment.rb
+++ b/app/models/mq/assessment.rb
@@ -48,6 +48,8 @@ module MQ
     end
 
     def questions
+      return unless self[:questions].present?
+
       @questions ||= self[:questions].each_with_index.map do |q_hash, index|
         MQ::Question.new(q_hash.merge(number: index + 1))
       end

--- a/app/views/admin/mq_assessments/_form.html.erb
+++ b/app/views/admin/mq_assessments/_form.html.erb
@@ -1,0 +1,16 @@
+<%= semantic_form_for [:admin, resource], builder: ActiveAdmin::FormBuilder, html: {'data-controller' => 'check-modified'} do |f| %>
+  <%= f.semantic_errors(*f.object.errors.keys) %>
+
+  <%= f.inputs do %>
+    <%= f.input :company %>
+    <%= f.input :assessment_date %>
+    <%= f.input :publication_date %>
+    <%= f.input :level, as: :select, collection: MQ::Assessment::LEVELS %>
+    <%= f.input :notes %>
+  <% end %>
+
+  <%= f.actions do %>
+    <%= f.action :submit %>
+    <%= f.action :cancel, :wrapper_html => { :class => 'cancel' } %>
+  <% end %>
+<% end %>

--- a/spec/controllers/admin/mq_assessments_controller_spec.rb
+++ b/spec/controllers/admin/mq_assessments_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Admin::MQAssessmentsController, type: :controller do
     it { is_expected.to be_successful }
   end
 
-  describe 'GET new' do
+  xdescribe 'GET new' do
     subject { get :new }
 
     it { is_expected.to be_successful }
@@ -31,7 +31,7 @@ RSpec.describe Admin::MQAssessmentsController, type: :controller do
     it { is_expected.to be_successful }
   end
 
-  describe 'POST create' do
+  xdescribe 'POST create' do
     context 'with valid params' do
       let(:valid_attributes) { attributes_for(:mq_assessment, company_id: company.id) }
 

--- a/spec/controllers/admin/mq_assessments_controller_spec.rb
+++ b/spec/controllers/admin/mq_assessments_controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Admin::MQAssessmentsController, type: :controller do
   let(:admin) { create(:admin_user) }
+  let(:company) { create(:company) }
   let!(:mq_assessment) { create(:mq_assessment) }
 
   before { sign_in admin }
@@ -16,5 +17,50 @@ RSpec.describe Admin::MQAssessmentsController, type: :controller do
     subject { get :show, params: {id: mq_assessment.id} }
 
     it { is_expected.to be_successful }
+  end
+
+  describe 'GET new' do
+    subject { get :new }
+
+    it { is_expected.to be_successful }
+  end
+
+  describe 'GET edit' do
+    subject { get :edit, params: {id: mq_assessment.id} }
+
+    it { is_expected.to be_successful }
+  end
+
+  describe 'POST create' do
+    context 'with valid params' do
+      let(:valid_attributes) { attributes_for(:mq_assessment, company_id: company.id) }
+
+      subject { post :create, params: {mq_assessment: valid_attributes} }
+
+      it 'creates a new Assessment' do
+        expect { subject }.to change(MQ::Assessment, :count).by(1)
+
+        last_created = MQ::Assessment.order(:created_at).last
+
+        # for now update everything except questions
+        expect(last_created).to have_attributes(valid_attributes.except(:questions))
+      end
+
+      it 'redirects to the created Assessment' do
+        expect(subject).to redirect_to(admin_mq_assessment_path(MQ::Assessment.order(:created_at).last))
+      end
+    end
+
+    context 'with invalid params' do
+      let(:invalid_attributes) { attributes_for(:mq_assessment, company_id: company.id, publication_date: nil) }
+
+      subject { post :create, params: {mq_assessment: invalid_attributes} }
+
+      it { is_expected.to be_successful }
+
+      it 'invalid_attributes do not create a Assessment' do
+        expect { subject }.not_to change(MQ::Assessment, :count)
+      end
+    end
   end
 end

--- a/spec/factories/mq_assessments.rb
+++ b/spec/factories/mq_assessments.rb
@@ -18,8 +18,8 @@ FactoryBot.define do
   factory :mq_assessment, class: MQ::Assessment do
     association :company
 
-    assessment_date { 1.year.ago }
-    publication_date { 11.months.ago }
+    assessment_date { 1.year.ago.to_date }
+    publication_date { 11.months.ago.to_date }
 
     level { '1' }
     notes { 'Some notes' }


### PR DESCRIPTION
You can change the level, notes and dates for `MQAssessment`.

Changing questions with answers will be in another PR, as this might require more work.