### PR TITLE
Feature/ocd fixes

### DIFF
--- a/app/models/governance.rb
+++ b/app/models/governance.rb
@@ -21,6 +21,6 @@ class Governance < ApplicationRecord
   validates_presence_of :name
 
   def self.to_select
-    self.pluck(Arel.sql("CONCAT('[', governance_types.name, '] ', governances.name)"), :id)
+    pluck(Arel.sql("CONCAT('[', governance_types.name, '] ', governances.name)"), :id)
   end
 end

--- a/app/models/governance.rb
+++ b/app/models/governance.rb
@@ -16,5 +16,11 @@ class Governance < ApplicationRecord
   belongs_to :governance_type
   has_and_belongs_to_many :legislations
 
+  scope :ordered_with_parent, -> { joins(:governance_type).order('governance_types.name ASC, governances.name ASC') }
+
   validates_presence_of :name
+
+  def self.to_select
+    self.pluck(Arel.sql("CONCAT('[', governance_types.name, '] ', governances.name)"), :id)
+  end
 end

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -21,6 +21,6 @@ class Instrument < ApplicationRecord
   validates_presence_of :name
 
   def self.to_select
-    self.pluck(Arel.sql("CONCAT('[', instrument_types.name, '] ', instruments.name)"), :id)
+    pluck(Arel.sql("CONCAT('[', instrument_types.name, '] ', instruments.name)"), :id)
   end
 end

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -16,5 +16,11 @@ class Instrument < ApplicationRecord
   belongs_to :instrument_type
   has_and_belongs_to_many :legislations
 
+  scope :ordered_with_parent, -> { joins(:instrument_type).order('instrument_types.name ASC, instruments.name ASC') }
+
   validates_presence_of :name
+
+  def self.to_select
+    self.pluck(Arel.sql("CONCAT('[', instrument_types.name, '] ', instruments.name)"), :id)
+  end
 end

--- a/app/views/admin/legislations/_form.html.erb
+++ b/app/views/admin/legislations/_form.html.erb
@@ -18,7 +18,7 @@
           <%= f.input :legislation_type, as: :select %>
           <%= f.input :sector %>
           <%= f.input :document_type_ids, label: 'Document', as: :tags,
-            collection: DocumentType.order('LOWER(name) ASC') %>
+            collection: DocumentType.order(Arel.sql('LOWER(name) ASC')) %>
           <%= f.input :instrument_ids, label: 'Instrument', as: :select,
             collection: Instrument.ordered_with_parent.to_select, input_html: { multiple: true } %>
           <%= f.input :governance_ids, label: 'Governance', as: :select,
@@ -38,9 +38,9 @@
             end
           %>
         <%= f.input :natural_hazards_string, label: 'Natural Hazards', hint: t('hint.tag'), as: :tags,
-          collection: NaturalHazard.order('LOWER(name)').pluck(:name) %>
+          collection: NaturalHazard.order(Arel.sql('LOWER(name)')).pluck(:name) %>
         <%= f.input :keywords_string, label: 'Keywords', hint: t('hint.tag'), as: :tags,
-          collection: Keyword.order('LOWER(name) ASC').pluck(:name) %>
+          collection: Keyword.order(Arel.sql('LOWER(name) ASC')).pluck(:name) %>
         <% end %>
       </div>
 

--- a/app/views/admin/legislations/_form.html.erb
+++ b/app/views/admin/legislations/_form.html.erb
@@ -17,9 +17,12 @@
           <%= f.input :description, as: :trix %>
           <%= f.input :legislation_type, as: :select %>
           <%= f.input :sector %>
-          <%= f.input :document_type_ids, label: 'Document', as: :tags, collection: DocumentType.all %>
-          <%= f.input :instrument_ids, label: 'Instrument', as: :tags, collection: Instrument.all %>
-          <%= f.input :governance_ids, label: 'Governance', as: :tags, collection: Governance.all %>
+          <%= f.input :document_type_ids, label: 'Document', as: :tags,
+            collection: DocumentType.order('LOWER(name) ASC') %>
+          <%= f.input :instrument_ids, label: 'Instrument', as: :select,
+            collection: Instrument.ordered_with_parent.to_select, input_html: { multiple: true } %>
+          <%= f.input :governance_ids, label: 'Governance', as: :select,
+            collection: Governance.ordered_with_parent.to_select, input_html: { multiple: true } %>
           <%=
             Arbre::Context.new do
               columns do

--- a/app/views/admin/legislations/_form.html.erb
+++ b/app/views/admin/legislations/_form.html.erb
@@ -26,7 +26,7 @@
           <%=
             Arbre::Context.new do
               columns do
-                column { f.input :geography }
+                column { f.input :geography, collection: Geography.order(:name) }
                 column { f.input :date_passed }
                 column do
                   f.input :framework_ids, label: 'Frameworks', as: :tags, collection: Framework.all
@@ -37,8 +37,10 @@
               end
             end
           %>
-          <%= f.input :natural_hazards_string, label: 'Natural Hazards', hint: t('hint.tag'), as: :tags, collection: NaturalHazard.all.pluck(:name) %>
-          <%= f.input :keywords_string, label: 'Keywords', hint: t('hint.tag'), as: :tags, collection: Keyword.all.pluck(:name) %>
+        <%= f.input :natural_hazards_string, label: 'Natural Hazards', hint: t('hint.tag'), as: :tags,
+          collection: NaturalHazard.order('LOWER(name)').pluck(:name) %>
+        <%= f.input :keywords_string, label: 'Keywords', hint: t('hint.tag'), as: :tags,
+          collection: Keyword.order('LOWER(name) ASC').pluck(:name) %>
         <% end %>
       </div>
 

--- a/app/views/admin/litigations/_form.html.erb
+++ b/app/views/admin/litigations/_form.html.erb
@@ -26,7 +26,7 @@
           <%= f.input :external_legislation_ids, as: :selected_list, label: 'Connected External Laws', fields: [:name], display_name: :name, order: 'name_asc' %>
           <%= f.input :visibility_status, as: :select %>
           <%= f.input :keywords_string, as: :tags, label: 'Keywords', hint: t('hint.tag'),
-            collection: Keyword.order('LOWER(name) ASC').pluck(:name) %>
+            collection: Keyword.order(Arel.sql('LOWER(name) ASC')).pluck(:name) %>
         <% end %>
       </div>
 

--- a/app/views/admin/litigations/_form.html.erb
+++ b/app/views/admin/litigations/_form.html.erb
@@ -16,7 +16,7 @@
       <div id="details">
         <%= f.inputs do %>
           <%= f.input :title %>
-          <%= f.input :jurisdiction %>
+          <%= f.input :jurisdiction, collection: Geography.order(:name) %>
           <%= f.input :citation_reference_number %>
           <%= f.input :sector %>
           <%= f.input :document_type, as: :select, collection: array_to_select_collection(Litigation::DOCUMENT_TYPES) %>
@@ -25,7 +25,8 @@
           <%= f.input :legislation_ids, as: :selected_list, label: 'Connected Laws', fields: [:title], display_name: :title, order: 'title_asc' %>
           <%= f.input :external_legislation_ids, as: :selected_list, label: 'Connected External Laws', fields: [:name], display_name: :name, order: 'name_asc' %>
           <%= f.input :visibility_status, as: :select %>
-          <%= f.input :keywords_string, as: :tags, label: 'Keywords', hint: t('hint.tag'), collection: Keyword.all.pluck(:name) %>
+          <%= f.input :keywords_string, as: :tags, label: 'Keywords', hint: t('hint.tag'),
+            collection: Keyword.order('LOWER(name) ASC').pluck(:name) %>
         <% end %>
       </div>
 

--- a/app/views/admin/targets/_form.html.erb
+++ b/app/views/admin/targets/_form.html.erb
@@ -17,7 +17,7 @@
           <%= f.input :year %>
           <%= f.input :base_year_period %>
           <%= f.input :target_type, as: :select, collection: array_to_select_collection(Target::TYPES) %>
-          <%= f.input :geography %>
+          <%= f.input :geography, collection: Geography.order(:name) %>
           <%= f.input :sector %>
           <%= f.input :target_scope %>
           <%= f.input :legislation_ids, as: :selected_list, label: 'Connected Laws', fields: [:title], display_name: :title, order: 'title_asc' %>


### PR DESCRIPTION
In this PR:

- sorts tags in forms (though for keywords it doesn't really seem to work with the case sensitivity, but I lost hope now);
- sorts jurisdictions and geographies in forms;
- includes instrument types in instruments form selection;
- includes governance types in governances form selection;

I found out that formtastic hasn't been updated since 2017... and is a bit buggy and annoying.