### PR TITLE
Fix/admin tags component

### DIFF
--- a/app/admin/legislations.rb
+++ b/app/admin/legislations.rb
@@ -9,8 +9,8 @@ ActiveAdmin.register Legislation do
 
   permit_params :title, :date_passed, :description,
                 :geography_id, :sector_id, :law_id, :legislation_type,
-                :natural_hazards_string, :keywords_string,
                 :created_by_id, :updated_by_id, :visibility_status,
+                :natural_hazards_string, :keywords_string,
                 events_attributes: permit_params_for(:events),
                 documents_attributes: permit_params_for(:documents),
                 framework_ids: [], document_type_ids: [], instrument_ids: [],

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -46,6 +46,7 @@ module Taggable
           array
             .map(&:strip)
             .reject(&:blank?)
+            .uniq
             .map { |group| tag_class.find_or_initialize_by(name: group) }
         )
       end

--- a/app/views/admin/legislations/_form.html.erb
+++ b/app/views/admin/legislations/_form.html.erb
@@ -37,10 +37,8 @@
               end
             end
           %>
-        <%= f.input :natural_hazards_string, label: 'Natural Hazards', hint: t('hint.tag'), as: :tags,
-          collection: NaturalHazard.order(Arel.sql('LOWER(name)')).pluck(:name) %>
-        <%= f.input :keywords_string, label: 'Keywords', hint: t('hint.tag'), as: :tags,
-          collection: Keyword.order(Arel.sql('LOWER(name) ASC')).pluck(:name) %>
+        <%= f.input :natural_hazards_string, label: 'Natural Hazards', hint: t('hint.tag'), as: :tags, collection: NaturalHazard.pluck(:name) %>
+        <%= f.input :keywords_string, label: 'Keywords', hint: t('hint.tag'), as: :tags, collection: Keyword.pluck(:name) %>
         <% end %>
       </div>
 

--- a/app/views/admin/litigations/_form.html.erb
+++ b/app/views/admin/litigations/_form.html.erb
@@ -25,8 +25,7 @@
           <%= f.input :legislation_ids, as: :selected_list, label: 'Connected Laws', fields: [:title], display_name: :title, order: 'title_asc' %>
           <%= f.input :external_legislation_ids, as: :selected_list, label: 'Connected External Laws', fields: [:name], display_name: :name, order: 'name_asc' %>
           <%= f.input :visibility_status, as: :select %>
-          <%= f.input :keywords_string, as: :tags, label: 'Keywords', hint: t('hint.tag'),
-            collection: Keyword.order(Arel.sql('LOWER(name) ASC')).pluck(:name) %>
+          <%= f.input :keywords_string, as: :tags, label: 'Keywords', hint: t('hint.tag'), collection: Keyword.pluck(:name) %>
         <% end %>
       </div>
 

--- a/config/initializers/activeadmin_addons.rb
+++ b/config/initializers/activeadmin_addons.rb
@@ -1,3 +1,5 @@
+Dir[Rails.root.join('lib/extensions/active_admin_addons/*.rb')].each { |f| require f }
+
 ActiveadminAddons.setup do |config|
   # Change to "default" if you want to use ActiveAdmin's default select control.
   # config.default_select = "select2"
@@ -9,4 +11,8 @@ ActiveadminAddons.setup do |config|
 
   # Set DateTimePickerInput input format. This if for backend (Ruby)
   # config.datetime_picker_input_format = "%Y-%m-%d %H:%M"
+end
+
+Rails.configuration.to_prepare do
+  ActiveAdminAddons::SelectHelpers.send :prepend, ActiveAdminAddonsSelectHelpers
 end

--- a/lib/extensions/active_admin_addons/select_helpers.rb
+++ b/lib/extensions/active_admin_addons/select_helpers.rb
@@ -1,0 +1,12 @@
+module ActiveAdminAddonsSelectHelpers
+  def array_to_select_options
+    selected_values = input_value.is_a?(Array) ? input_value : input_value.to_s.split(',').map(&:strip)
+    array = collection.map(&:to_s) + selected_values
+
+    array.sort_by(&:downcase).map do |value|
+      option = {id: value, text: value}
+      option[:selected] = 'selected' if selected_values.include?(value)
+      option
+    end.uniq
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,36 @@
+FactoryBot.define do
+  factory :keyword do
+    type { 'Keyword' }
+    sequence(:name) { |n|
+      [
+        'climate law',
+        'climate policy',
+        'COP25',
+        'COP24',
+        'ghg',
+        'carbon emission',
+        'energy',
+        'industry'
+      ].sample << n.to_s
+    }
+  end
+
+  factory :natural_hazard do
+    type { 'NaturalHazard' }
+    sequence(:name) { |n|
+      [
+        'avalanche',
+        'drought',
+        'earthquake',
+        'erosion',
+        'extreme temperature',
+        'flood',
+        'landslide',
+        'storm surge',
+        'tsunami',
+        'volcanic activity',
+        'wildfire'
+      ].sample << n.to_s
+    }
+  end
+end

--- a/spec/models/taggable_spec.rb
+++ b/spec/models/taggable_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe Taggable do
+  describe 'Legislation keywords' do
+    let(:legislation) { create(:legislation) }
+
+    describe 'keywords_list' do
+      it 'should set keywords list properly' do
+        keywords = %w(sport holiday travel)
+
+        expect {
+          legislation.keywords_list = keywords
+        }.to change(Keyword, :count).by(3)
+
+        expect(legislation.keywords.pluck(:name)).to include(*keywords)
+      end
+
+      it 'should not set keywords duplicates' do
+        keywords = %w(sport sport sport holiday travel)
+
+        expect {
+          legislation.keywords_list = keywords
+        }.to change(Keyword, :count).by(3)
+
+        expect(legislation.keywords.size).to be(3)
+        expect(legislation.keywords.pluck(:name)).to include(*keywords.uniq)
+      end
+
+      it 'should get keywords list' do
+        legislation.keywords = [
+          create(:keyword, name: 'sport'),
+          create(:keyword, name: 'holiday'),
+          create(:keyword, name: 'travel')
+        ]
+
+        expect(legislation.keywords_list.sort).to eq(%w(holiday sport travel))
+      end
+    end
+
+    describe 'keywords_string' do
+      it 'should set keywords list using string properly' do
+        keywords = 'sport, holiday, travel'
+
+        expect {
+          legislation.keywords_string = keywords
+        }.to change(Keyword, :count).by(3)
+
+        expect(legislation.keywords.pluck(:name)).to include(*keywords.split(', '))
+      end
+
+      it 'should get keywords list in one string' do
+        legislation.keywords = [
+          create(:keyword, name: 'sport'),
+          create(:keyword, name: 'holiday'),
+          create(:keyword, name: 'travel')
+        ]
+
+        expect(legislation.keywords_string).to eq('sport, holiday, travel')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes
- double entries for selected tags. if tag has been already selected there should be only one entry to deselect it in the dropdown
- fixing order to be sorted by downcased strings
- adding couple tests for Taggable concern 