### PR TITLE
(spike): activity log for publishable resources

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'draper'
 gem 'google-cloud-storage', require: false
 
 gem 'paper_trail'
+gem 'logidze'
 gem 'discard'
 gem 'friendly_id'
 gem 'language_list'

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'draper'
 
 gem 'google-cloud-storage', require: false
 
+gem 'paper_trail'
 gem 'discard'
 gem 'friendly_id'
 gem 'language_list'

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'google-cloud-storage', require: false
 
 gem 'paper_trail'
 gem 'logidze'
+gem 'public_activity'
 gem 'discard'
 gem 'friendly_id'
 gem 'language_list'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,8 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    logidze (0.11.0)
+      rails (>= 4.2)
     loofah (2.3.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -472,6 +474,7 @@ DEPENDENCIES
   google-cloud-storage
   language_list
   listen (>= 3.0.5, < 3.2)
+  logidze
   paper_trail
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,6 +254,9 @@ GEM
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
     os (1.0.1)
+    paper_trail (10.3.1)
+      activerecord (>= 4.2)
+      request_store (~> 1.1)
     parallel (1.18.0)
     parser (2.6.5.0)
       ast (~> 2.4.0)
@@ -469,6 +472,7 @@ DEPENDENCIES
   google-cloud-storage
   language_list
   listen (>= 3.0.5, < 3.2)
+  paper_trail
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)
   rails (~> 5.2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,11 @@ GEM
     pg (1.1.4)
     polyamorous (2.3.0)
       activerecord (>= 5.0)
+    public_activity (1.6.4)
+      actionpack (>= 3.0.0)
+      activerecord (>= 3.0)
+      i18n (>= 0.5.0)
+      railties (>= 3.0.0)
     public_suffix (4.0.1)
     puma (3.12.1)
     rack (2.0.7)
@@ -477,6 +482,7 @@ DEPENDENCIES
   logidze
   paper_trail
   pg (>= 0.18, < 2.0)
+  public_activity
   puma (~> 3.11)
   rails (~> 5.2.3)
   rails-controller-testing

--- a/app/admin/activity_log.rb
+++ b/app/admin/activity_log.rb
@@ -1,0 +1,17 @@
+ActiveAdmin.register_page 'Activity Log' do
+  menu parent: 'Administration', priority: 3
+
+  content do
+    panel 'Activity Log' do
+      section 'Using paper_trail (Companies, Geographies)' do
+        table_for PaperTrail::Version.order('id desc').limit(20) do # Use PaperTrail::Version if this throws an error
+        column ("Item") { |v| v.item || '[Record deleted (TODO: find it by all_discarded scope)]' }
+        # column ("Item") { |v| link_to v.item, [:admin, v.item] } # Uncomment to display as link
+        column ("Type") { |v| v.item_type.underscore.humanize }
+        column ("Modified at") { |v| v.created_at.to_s :long }
+        column ("Admin") { |v| link_to AdminUser.find_by_email(v.whodunnit).email, [:admin, AdminUser.find_by_email(v.whodunnit)] }
+        end
+      end
+    end
+  end
+end

--- a/app/admin/activity_log.rb
+++ b/app/admin/activity_log.rb
@@ -4,48 +4,62 @@ ActiveAdmin.register_page 'Activity Log' do
   content do
     panel 'Activity Log (paper_trail), [Companies, Geo]' do
       section do
-        table_for PaperTrail::Version.order('id desc').limit(20) do
-          column ("Item") { |v| v.item || '[Record deleted (TODO: find it by all_discarded scope)]' }
-          column ("Type") { |v| v.item_type.underscore.humanize }
-          column ("Updated at") { |v| v.created_at.to_s :long }
-          column ("Whodunnit") { |v| v.whodunnit }
-          column ('Details') { |v| v.changeset }
+        # all tracked models versions are automatically fetched
+        record_versions_paper_trail = PaperTrail::Version.order('id desc').limit(20)
+
+        changesets_paper_trail = record_versions_paper_trail.map do |record_version|
+          {
+            item: record_version.item || 'DELETED',
+            type: record_version.item_type.underscore.humanize,
+            updated_at: record_version.created_at.to_s,
+            made_by: record_version.whodunnit,
+            changes: record_version.changeset.except('updated_at', 'updated_by_id')
+          }
+        end
+
+        table_for(changesets_paper_trail) do
+          column('Item') { |v| v[:item] }
+          column('Type') { |v| v[:type] }
+          column('Updated at') { |v| v[:updated_at] }
+          column('Whodunnit') { |v| v[:made_by] }
+          column('Details') { |v| v[:changes] }
         end
       end
     end
 
     panel 'Activity Log (logidze), [Legislations, Targets]' do
       section do
-        audited_records = {
-          legislations: Legislation.where.not(log_data: nil).order(updated_at: :desc),
-          targets: Target.where.not(log_data: nil).order(updated_at: :desc)
-        }
+        # need to define which models we want
+        klasses = [Legislation, Target]
 
-        changesets = audited_records.flat_map do |collection_name, collection|
-          collection.flat_map do |record|
+        changesets_logidze = klasses.flat_map do |klass|
+          klass.where.not(log_data: nil).order(updated_at: :desc).flat_map do |record|
             record_updates = record.log_data.versions.each_cons(2).map do |before, after|
               record.at(time: after.time).diff_from(time: before.time)
             end
 
             record_updates.reverse.compact.map do |record_update|
+              single_record_changes = record_update['changes']
+                .except('updated_at')
+                .map { |name, changes| {name => [changes['old'], changes['new']]} }
+
               {
                 item: record,
                 type: record.class.name,
                 updated_at: record_update['changes']['updated_at']['new'],
-                changes: record_update['changes'].except('updated_at'),
+                changes: single_record_changes,
                 made_by: record.log_data.responsible_id
               }
             end
           end
         end
 
-        # presentation
-        table_for changesets do
-          column ("Item") { |v| v[:item] }
-          column ("Type") { |v| v[:type] }
-          column ("Updated at") { |v| v[:updated_at] }
-          column ("Whodunnit") { |v| v[:made_by] }
-          column ("Details") { |v| v[:changes].map { |name, changes| "#{name} (#{changes['old']} => #{changes['new']})" }.join(', ') }
+        table_for(changesets_logidze) do
+          column('Item') { |v| v[:item] }
+          column('Type') { |v| v[:type] }
+          column('Updated at') { |v| v[:updated_at] }
+          column('Whodunnit') { |v| v[:made_by] }
+          column('Details') { |v| v[:changes] }
         end
       end
     end

--- a/app/admin/activity_log.rb
+++ b/app/admin/activity_log.rb
@@ -2,6 +2,31 @@ ActiveAdmin.register_page 'Activity Log' do
   menu parent: 'Administration', priority: 3
 
   content do
+    panel 'Activity Log (paper_trail), [Litigations]' do
+      section do
+        # all tracked models versions are automatically fetched
+        record_versions_public_activity = PublicActivity::Activity.all
+
+        changesets_public_activity = record_versions_public_activity.map do |activity|
+          {
+            item: activity.trackable_id,
+            type: activity.trackable_type.underscore.humanize,
+            updated_at: activity.updated_at.to_s,
+            made_by: activity.owner_id,
+            changes: activity.key
+          }
+        end
+
+        table_for(changesets_public_activity) do
+          column('Item') { |v| v[:item] }
+          column('Type') { |v| v[:type] }
+          column('Updated at') { |v| v[:updated_at] }
+          column('Whodunnit') { |v| v[:made_by] }
+          column('Details') { |v| v[:changes] }
+        end
+      end
+    end
+
     panel 'Activity Log (paper_trail), [Companies, Geo]' do
       section do
         # all tracked models versions are automatically fetched

--- a/app/admin/activity_log.rb
+++ b/app/admin/activity_log.rb
@@ -2,14 +2,50 @@ ActiveAdmin.register_page 'Activity Log' do
   menu parent: 'Administration', priority: 3
 
   content do
-    panel 'Activity Log' do
-      section 'Using paper_trail (Companies, Geographies)' do
-        table_for PaperTrail::Version.order('id desc').limit(20) do # Use PaperTrail::Version if this throws an error
-        column ("Item") { |v| v.item || '[Record deleted (TODO: find it by all_discarded scope)]' }
-        # column ("Item") { |v| link_to v.item, [:admin, v.item] } # Uncomment to display as link
-        column ("Type") { |v| v.item_type.underscore.humanize }
-        column ("Modified at") { |v| v.created_at.to_s :long }
-        column ("Admin") { |v| link_to AdminUser.find_by_email(v.whodunnit).email, [:admin, AdminUser.find_by_email(v.whodunnit)] }
+    panel 'Activity Log (paper_trail), [Companies, Geo]' do
+      section do
+        table_for PaperTrail::Version.order('id desc').limit(20) do
+          column ("Item") { |v| v.item || '[Record deleted (TODO: find it by all_discarded scope)]' }
+          column ("Type") { |v| v.item_type.underscore.humanize }
+          column ("Updated at") { |v| v.created_at.to_s :long }
+          column ("Whodunnit") { |v| v.whodunnit }
+          column ('Details') { |v| v.changeset }
+        end
+      end
+    end
+
+    panel 'Activity Log (logidze), [Legislations, Targets]' do
+      section do
+        audited_records = {
+          legislations: Legislation.where.not(log_data: nil).order(updated_at: :desc),
+          targets: Target.where.not(log_data: nil).order(updated_at: :desc)
+        }
+
+        changesets = audited_records.flat_map do |collection_name, collection|
+          collection.flat_map do |record|
+            record_updates = record.log_data.versions.each_cons(2).map do |before, after|
+              record.at(time: after.time).diff_from(time: before.time)
+            end
+
+            record_updates.reverse.compact.map do |record_update|
+              {
+                item: record,
+                type: record.class.name,
+                updated_at: record_update['changes']['updated_at']['new'],
+                changes: record_update['changes'].except('updated_at'),
+                made_by: record.log_data.responsible_id
+              }
+            end
+          end
+        end
+
+        # presentation
+        table_for changesets do
+          column ("Item") { |v| v[:item] }
+          column ("Type") { |v| v[:type] }
+          column ("Updated at") { |v| v[:updated_at] }
+          column ("Whodunnit") { |v| v[:made_by] }
+          column ("Details") { |v| v[:changes].map { |name, changes| "#{name} (#{changes['old']} => #{changes['new']})" }.join(', ') }
         end
       end
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,10 +2,19 @@ class ApplicationController < ActionController::Base
   include BaseAuth
 
   before_action :set_current_user
+  before_action :set_paper_trail_whodunnit
 
   private
 
   def set_current_user
     ::Current.admin_user = current_admin_user
+  end
+
+  def get_current_user
+    ::Current.admin_user
+  end
+
+  def user_for_paper_trail
+    get_current_user
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   before_action :set_current_user
   before_action :set_paper_trail_whodunnit
 
-  around_action :use_logidze_responsible, only: %i[create update]
+  around_action :use_logidze_responsible, only: [:create, :update]
 
   def use_logidze_responsible(&block)
     Logidze.with_responsible(get_current_user.email, &block)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,12 @@ class ApplicationController < ActionController::Base
   before_action :set_current_user
   before_action :set_paper_trail_whodunnit
 
+  around_action :use_logidze_responsible, only: %i[create update]
+
+  def use_logidze_responsible(&block)
+    Logidze.with_responsible(get_current_user.email, &block)
+  end
+
   private
 
   def set_current_user

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -21,7 +21,10 @@ class Company < ApplicationRecord
   include DiscardableModel
   include VisibilityStatus
   extend FriendlyId
+
   friendly_id :name, use: :slugged, routes: :default
+
+  has_paper_trail
 
   SIZES = %w[small medium large].freeze
 

--- a/app/models/concerns/public_activity_trackable.rb
+++ b/app/models/concerns/public_activity_trackable.rb
@@ -1,0 +1,31 @@
+# Tracks updates of:
+# - common attributes updates (visibility_status, discarded_at)
+# - deletes
+#
+module PublicActivityTrackable
+  extend ActiveSupport::Concern
+
+  included do
+    around_update :track_updates_activity
+  end
+
+  protected
+
+  def track_updates_activity
+    yield
+
+    return unless errors.blank? && previous_changes.present?
+
+    create_activity activity_key_for_last_update, owner: updated_by
+  end
+
+  def activity_key_for_last_update
+    if previous_changes['visibility_status']
+      previous_changes['visibility_status'].last
+    elsif previous_changes['discarded_at']
+      'deleted'
+    else
+      'edited'
+    end
+  end
+end

--- a/app/models/geography.rb
+++ b/app/models/geography.rb
@@ -28,6 +28,8 @@ class Geography < ApplicationRecord
 
   friendly_id :name, use: :slugged, routes: :default
 
+  has_paper_trail
+
   EVENT_TYPES = %w[
     election
     government_change

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -20,6 +20,7 @@
 #
 
 class Legislation < ApplicationRecord
+  has_logidze
   include UserTrackable
   include Taggable
   include VisibilityStatus

--- a/app/models/litigation.rb
+++ b/app/models/litigation.rb
@@ -24,6 +24,8 @@ class Litigation < ApplicationRecord
   include Taggable
   include VisibilityStatus
   include DiscardableModel
+  include PublicActivity::Common
+  include PublicActivityTrackable
   extend FriendlyId
 
   friendly_id :title, use: :slugged, routes: :default

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -21,6 +21,7 @@
 #
 
 class Target < ApplicationRecord
+  has_logidze
   include UserTrackable
   include VisibilityStatus
   include DiscardableModel

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,8 @@ module LawsAndPathways
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
+    config.active_record.schema_format = :sql
+
     # Don't generate system test files.
     config.generators.system_tests = nil
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,7 +21,7 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  host: localhost
+  host: ''
 
 development:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,7 +21,7 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  host: ''
+  host: localhost
 
 development:
   <<: *default

--- a/db/migrate/20191115134208_create_versions.rb
+++ b/db/migrate/20191115134208_create_versions.rb
@@ -1,0 +1,36 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[5.2]
+
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions do |t|
+      t.string   :item_type, {:null=>false}
+      t.integer  :item_id,   null: false, limit: 8
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.text     :object, limit: TEXT_BYTES
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      t.datetime :created_at
+    end
+    add_index :versions, %i(item_type item_id)
+  end
+end

--- a/db/migrate/20191115170554_logidze_install.rb
+++ b/db/migrate/20191115170554_logidze_install.rb
@@ -1,0 +1,239 @@
+class LogidzeInstall < ActiveRecord::Migration[5.0]
+  require 'logidze/migration'
+  include Logidze::Migration
+
+  def up
+    unless current_setting_missing_supported?
+      execute <<-SQL
+        DO $$
+          BEGIN
+          EXECUTE 'ALTER DATABASE ' || quote_ident(current_database()) || ' SET logidze.disabled=' || quote_literal('');
+          EXECUTE 'ALTER DATABASE ' || quote_ident(current_database()) || ' SET logidze.meta=' || quote_literal('');
+          END;
+        $$
+        LANGUAGE plpgsql;
+      SQL
+    end
+
+    
+
+    execute <<-SQL
+      CREATE OR REPLACE FUNCTION logidze_version(v bigint, data jsonb, ts timestamp with time zone, blacklist text[] DEFAULT '{}') RETURNS jsonb AS $body$
+        DECLARE
+          buf jsonb;
+        BEGIN
+          buf := jsonb_build_object(
+                   'ts',
+                   (extract(epoch from ts) * 1000)::bigint,
+                   'v',
+                    v,
+                    'c',
+                    logidze_exclude_keys(data, VARIADIC array_append(blacklist, 'log_data'))
+                   );
+          IF coalesce(#{current_setting('logidze.meta')}, '') <> '' THEN
+            buf := jsonb_set(buf, ARRAY['m'], current_setting('logidze.meta')::jsonb);
+          END IF;
+          RETURN buf;
+        END;
+      $body$
+      LANGUAGE plpgsql;
+
+      CREATE OR REPLACE FUNCTION logidze_snapshot(item jsonb, ts_column text, blacklist text[] DEFAULT '{}') RETURNS jsonb AS $body$
+        DECLARE
+          ts timestamp with time zone;
+        BEGIN
+          IF ts_column IS NULL THEN
+            ts := statement_timestamp();
+          ELSE
+            ts := coalesce((item->>ts_column)::timestamp with time zone, statement_timestamp());
+          END IF;
+          return json_build_object(
+            'v', 1,
+            'h', jsonb_build_array(
+                   logidze_version(1, item, ts, blacklist)
+                 )
+            );
+        END;
+      $body$
+      LANGUAGE plpgsql;
+
+      CREATE OR REPLACE FUNCTION logidze_exclude_keys(obj jsonb, VARIADIC keys text[]) RETURNS jsonb AS $body$
+        DECLARE
+          res jsonb;
+          key text;
+        BEGIN
+          res := obj;
+          FOREACH key IN ARRAY keys
+          LOOP
+            res := res - key;
+          END LOOP;
+          RETURN res;
+        END;
+      $body$
+      LANGUAGE plpgsql;
+
+      CREATE OR REPLACE FUNCTION logidze_compact_history(log_data jsonb) RETURNS jsonb AS $body$
+        DECLARE
+          merged jsonb;
+        BEGIN
+          merged := jsonb_build_object(
+            'ts',
+            log_data#>'{h,1,ts}',
+            'v',
+            log_data#>'{h,1,v}',
+            'c',
+            (log_data#>'{h,0,c}') || (log_data#>'{h,1,c}')
+          );
+
+          IF (log_data#>'{h,1}' ? 'm') THEN
+            merged := jsonb_set(merged, ARRAY['m'], log_data#>'{h,1,m}');
+          END IF;
+
+          return jsonb_set(
+            log_data,
+            '{h}',
+            jsonb_set(
+              log_data->'h',
+              '{1}',
+              merged
+            ) - 0
+          );
+        END;
+      $body$
+      LANGUAGE plpgsql;
+
+      CREATE OR REPLACE FUNCTION logidze_logger() RETURNS TRIGGER AS $body$
+        DECLARE
+          changes jsonb;
+          version jsonb;
+          snapshot jsonb;
+          new_v integer;
+          size integer;
+          history_limit integer;
+          debounce_time integer;
+          current_version integer;
+          merged jsonb;
+          iterator integer;
+          item record;
+          columns_blacklist text[];
+          ts timestamp with time zone;
+          ts_column text;
+        BEGIN
+          ts_column := NULLIF(TG_ARGV[1], 'null');
+          columns_blacklist := COALESCE(NULLIF(TG_ARGV[2], 'null'), '{}');
+
+          IF TG_OP = 'INSERT' THEN
+            snapshot = logidze_snapshot(to_jsonb(NEW.*), ts_column, columns_blacklist);
+
+            IF snapshot#>>'{h, -1, c}' != '{}' THEN
+              NEW.log_data := snapshot;
+            END IF;
+
+          ELSIF TG_OP = 'UPDATE' THEN
+
+            IF OLD.log_data is NULL OR OLD.log_data = '{}'::jsonb THEN
+              snapshot = logidze_snapshot(to_jsonb(NEW.*), ts_column, columns_blacklist);
+              IF snapshot#>>'{h, -1, c}' != '{}' THEN
+                NEW.log_data := snapshot;
+              END IF;
+              RETURN NEW;
+            END IF;
+
+            history_limit := NULLIF(TG_ARGV[0], 'null');
+            debounce_time := NULLIF(TG_ARGV[3], 'null');
+
+            current_version := (NEW.log_data->>'v')::int;
+
+            IF ts_column IS NULL THEN
+              ts := statement_timestamp();
+            ELSE
+              ts := (to_jsonb(NEW.*)->>ts_column)::timestamp with time zone;
+              IF ts IS NULL OR ts = (to_jsonb(OLD.*)->>ts_column)::timestamp with time zone THEN
+                ts := statement_timestamp();
+              END IF;
+            END IF;
+
+            IF NEW = OLD THEN
+              RETURN NEW;
+            END IF;
+
+            IF current_version < (NEW.log_data#>>'{h,-1,v}')::int THEN
+              iterator := 0;
+              FOR item in SELECT * FROM jsonb_array_elements(NEW.log_data->'h')
+              LOOP
+                IF (item.value->>'v')::int > current_version THEN
+                  NEW.log_data := jsonb_set(
+                    NEW.log_data,
+                    '{h}',
+                    (NEW.log_data->'h') - iterator
+                  );
+                END IF;
+                iterator := iterator + 1;
+              END LOOP;
+            END IF;
+
+            changes := hstore_to_jsonb_loose(
+              hstore(NEW.*) - hstore(OLD.*)
+            );
+
+            new_v := (NEW.log_data#>>'{h,-1,v}')::int + 1;
+
+            size := jsonb_array_length(NEW.log_data->'h');
+            version := logidze_version(new_v, changes, ts, columns_blacklist);
+
+            IF version->>'c' = '{}' THEN
+              RETURN NEW;
+            END IF;
+
+            IF (
+              debounce_time IS NOT NULL AND
+              (version->>'ts')::bigint - (NEW.log_data#>'{h,-1,ts}')::text::bigint <= debounce_time
+            ) THEN
+              -- merge new version with the previous one
+              new_v := (NEW.log_data#>>'{h,-1,v}')::int;
+              version := logidze_version(new_v, (NEW.log_data#>'{h,-1,c}')::jsonb || changes, ts, columns_blacklist);
+              -- remove the previous version from log
+              NEW.log_data := jsonb_set(
+                NEW.log_data,
+                '{h}',
+                (NEW.log_data->'h') - (size - 1)
+              );
+            END IF;
+
+            NEW.log_data := jsonb_set(
+              NEW.log_data,
+              ARRAY['h', size::text],
+              version,
+              true
+            );
+
+            NEW.log_data := jsonb_set(
+              NEW.log_data,
+              '{v}',
+              to_jsonb(new_v)
+            );
+
+            IF history_limit IS NOT NULL AND history_limit = size THEN
+              NEW.log_data := logidze_compact_history(NEW.log_data);
+            END IF;
+          END IF;
+
+          return NEW;
+        END;
+        $body$
+        LANGUAGE plpgsql;
+    SQL
+  end
+
+  def down
+    
+    execute <<-SQL
+      DROP FUNCTION logidze_version(bigint, jsonb, timestamp with time zone, text[]) CASCADE;
+      DROP FUNCTION logidze_exclude_keys(jsonb, text[]) CASCADE;
+      DROP FUNCTION logidze_compact_history(jsonb) CASCADE;
+      DROP FUNCTION logidze_snapshot(jsonb, text, text[]) CASCADE;
+      DROP FUNCTION logidze_logger() CASCADE;
+    SQL
+    
+  end
+end

--- a/db/migrate/20191115170555_enable_hstore.rb
+++ b/db/migrate/20191115170555_enable_hstore.rb
@@ -1,0 +1,5 @@
+class EnableHstore < ActiveRecord::Migration[5.0]
+  def change
+    enable_extension :hstore
+  end
+end

--- a/db/migrate/20191115173122_add_logidze_to_legislations.rb
+++ b/db/migrate/20191115173122_add_logidze_to_legislations.rb
@@ -1,0 +1,29 @@
+class AddLogidzeToLegislations < ActiveRecord::Migration[5.0]
+  require 'logidze/migration'
+  include Logidze::Migration
+
+  def up
+    
+    add_column :legislations, :log_data, :jsonb
+    
+
+    execute <<-SQL
+      CREATE TRIGGER logidze_on_legislations
+      BEFORE UPDATE OR INSERT ON legislations FOR EACH ROW
+      WHEN (coalesce(#{current_setting('logidze.disabled')}, '') <> 'on')
+      EXECUTE PROCEDURE logidze_logger(null, 'updated_at');
+    SQL
+
+    
+  end
+
+  def down
+    
+    execute "DROP TRIGGER IF EXISTS logidze_on_legislations on legislations;"
+
+    
+    remove_column :legislations, :log_data
+    
+    
+  end
+end

--- a/db/migrate/20191115205950_add_logidze_to_targets.rb
+++ b/db/migrate/20191115205950_add_logidze_to_targets.rb
@@ -1,0 +1,29 @@
+class AddLogidzeToTargets < ActiveRecord::Migration[5.0]
+  require 'logidze/migration'
+  include Logidze::Migration
+
+  def up
+    
+    add_column :targets, :log_data, :jsonb
+    
+
+    execute <<-SQL
+      CREATE TRIGGER logidze_on_targets
+      BEFORE UPDATE OR INSERT ON targets FOR EACH ROW
+      WHEN (coalesce(#{current_setting('logidze.disabled')}, '') <> 'on')
+      EXECUTE PROCEDURE logidze_logger(null, 'updated_at');
+    SQL
+
+    
+  end
+
+  def down
+    
+    execute "DROP TRIGGER IF EXISTS logidze_on_targets on targets;"
+
+    
+    remove_column :targets, :log_data
+    
+    
+  end
+end

--- a/db/migrate/20191115221338_add_object_changes_to_versions.rb
+++ b/db/migrate/20191115221338_add_object_changes_to_versions.rb
@@ -1,0 +1,12 @@
+# This migration adds the optional `object_changes` column, in which PaperTrail
+# will store the `changes` diff for each update event. See the readme for
+# details.
+class AddObjectChangesToVersions < ActiveRecord::Migration[5.2]
+  # The largest text column available in all supported RDBMS.
+  # See `create_versions.rb` for details.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    add_column :versions, :object_changes, :text, limit: TEXT_BYTES
+  end
+end

--- a/db/migrate/20191118124313_create_activities.rb
+++ b/db/migrate/20191118124313_create_activities.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Migration responsible for creating a table with activities
+class CreateActivities < (ActiveRecord.version.release() < Gem::Version.new('5.2.0') ? ActiveRecord::Migration : ActiveRecord::Migration[5.2])
+  # Create table
+  def self.up
+    create_table :activities do |t|
+      t.belongs_to :trackable, :polymorphic => true
+      t.belongs_to :owner, :polymorphic => true
+      t.string  :key
+      t.text    :parameters
+      t.belongs_to :recipient, :polymorphic => true
+
+      t.timestamps
+    end
+
+    add_index :activities, [:trackable_id, :trackable_type]
+    add_index :activities, [:owner_id, :owner_type]
+    add_index :activities, [:recipient_id, :recipient_type]
+  end
+  # Drop table
+  def self.down
+    drop_table :activities
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_28_102103) do
+ActiveRecord::Schema.define(version: 2019_11_15_134208) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -336,11 +336,6 @@ ActiveRecord::Schema.define(version: 2019_10_28_102103) do
     t.index ["discarded_at"], name: "index_mq_assessments_on_discarded_at"
   end
 
-  create_table "publications", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "taggings", force: :cascade do |t|
     t.bigint "tag_id"
     t.string "taggable_type"
@@ -399,6 +394,16 @@ ActiveRecord::Schema.define(version: 2019_10_28_102103) do
     t.text "cp_unit"
     t.index ["name"], name: "index_tpi_sectors_on_name", unique: true
     t.index ["slug"], name: "index_tpi_sectors_on_slug", unique: true
+  end
+
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.text "object"
+    t.datetime "created_at"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_15_134208) do
+ActiveRecord::Schema.define(version: 2019_11_15_170555) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "hstore"
   enable_extension "plpgsql"
 
   create_table "active_admin_comments", force: :cascade do |t|

--- a/spec/controllers/admin/litigations_controller_spec.rb
+++ b/spec/controllers/admin/litigations_controller_spec.rb
@@ -131,6 +131,22 @@ RSpec.describe Admin::LitigationsController, type: :controller do
     end
   end
 
+  describe 'PATCH update' do
+    context 'with valid params' do
+      subject { patch :update, params: {litigation: {title: "#{litigation.title} was updated"}} }
+
+      it { is_expected.to be_successful }
+
+      it 'updates existing Litigation' do
+        expect(litigation.reload.title).to eq('was updated')
+      end
+
+      it 'redirects to the updated Litigation' do
+        expect(subject).to redirect_to(admin_litigation_path(litigation))
+      end
+    end
+  end
+
   describe 'DELETE destroy' do
     let!(:litigation) { create(:litigation, discarded_at: nil) }
     subject { delete :destroy, params: {id: litigation.id} }


### PR DESCRIPTION
# Summary

Add option to track changes in publishable models. Required cases:
```
- [X someone] published [record Y] on [date] - link to record;
- [X someone] archived [record Y] on [date] - link to record;
- [X someone] deleted [record Y] on [date];
- [X someone] unpublished [record Y] on [date] - link to record;
- [X someone] edited [record Y] on [date] - link to record;
```

### Details

Testing/comparing following solutions:

- `paper_trail`
  * separate `versions` table
  * association versioning - [via another gem](https://github.com/westonganger/paper_trail-association_tracking)
- `logidze`
  * only PostgreSQL 9.5+
  * requires SQL schema format
  * associations versioning - [experimental feature](https://github.com/palkan/logidze/wiki/Associations-versioning)
  * requires migration for every new tracked model
  * requires [custom code to build "change-sets" from records "versions"](https://github.com/Vizzuality/laws_and_pathways/pull/113/files#r347364488)
  * does not require joins with main table in case we're working only on given model (not our use-case right now)
- `public_activity`
  * separate `activities` table
  * by default doesn't store info which attributes have changed

Go to http://localhost:3000/admin/activity_log to see all libraries used (for different example models):

#### Testing
![activity2](https://user-images.githubusercontent.com/10665/69093042-f658dd80-0a4d-11ea-9acc-4c3e0dcfd2e0.png)

