### PR TITLE
Feature/optimize queries

### DIFF
--- a/app/admin/companies.rb
+++ b/app/admin/companies.rb
@@ -175,7 +175,12 @@ ActiveAdmin.register Company do
 
   controller do
     def scoped_collection
-      super.includes(:geography, :headquarters_geography, *csv_includes)
+      super.includes(
+        :geography,
+        :headquarters_geography,
+        :latest_mq_assessment,
+        *csv_includes
+      )
     end
 
     def csv_includes

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -32,7 +32,9 @@ class Company < ApplicationRecord
   belongs_to :headquarters_geography, class_name: 'Geography'
 
   has_many :mq_assessments, class_name: 'MQ::Assessment', inverse_of: :company
+  has_one :latest_mq_assessment, -> { order(assessment_date: :desc) }, class_name: 'MQ::Assessment'
   has_many :cp_assessments, class_name: 'CP::Assessment', inverse_of: :company
+  has_one :latest_cp_assessment, -> { order(assessment_date: :desc) }, class_name: 'CP::Assessment'
   has_many :litigation_sides, as: :connected_entity
   has_many :litigations, through: :litigation_sides
 
@@ -45,14 +47,6 @@ class Company < ApplicationRecord
 
   def to_s
     name
-  end
-
-  def latest_mq_assessment
-    mq_assessments.order(:assessment_date).last
-  end
-
-  def latest_cp_assessment
-    cp_assessments.order(:assessment_date).last
   end
 
   def latest_sector_benchmarks

--- a/app/services/api/charts/cp_benchmark.rb
+++ b/app/services/api/charts/cp_benchmark.rb
@@ -112,7 +112,7 @@ module Api
       #
       # @return [TPISector::ActiveRecord_Relation]
       def all_sectors
-        ::TPISector.includes(:cp_benchmarks, companies: [:cp_assessments])
+        ::TPISector.includes(:cp_benchmarks, companies: [:latest_cp_assessment])
       end
 
       # @return [String] string with current year

--- a/app/services/api/charts/sector.rb
+++ b/app/services/api/charts/sector.rb
@@ -51,6 +51,7 @@ module Api
         grouped_by_sectors_and_levels
           .map do |sector, levels|
             lvls.each { |l| levels[l].nil? ? levels[l] = [] : '' }
+            levels.reject! { |l, _c| l.nil? }
             levels.sort.to_h
             [sector, levels]
           end
@@ -100,6 +101,7 @@ module Api
         @company_scope
           .includes(:latest_mq_assessment)
           .group_by(&:mq_level)
+          .reject { |l, _companies| l.nil? }
       end
 
       def companies_grouped_by_sector

--- a/app/services/api/charts/sector.rb
+++ b/app/services/api/charts/sector.rb
@@ -37,6 +37,20 @@ module Api
         result
       end
 
+      # Returns Companies summaries (name, status) grouped by sector and current mq level
+      #
+      # @return [Hash]
+      # @example
+      #   {
+      #    'Airlines' => {
+      #      '1' => [{ name: 'Air China', sector: 'Airlines', size: 'large', ... }],
+      #      '2' => [{ name: 'China Southern', sector: 'Airlines', size: 'large', ... }],
+      #    ]
+      #    'Autos' => [
+      #      '1' => [{ name: 'Tesla', sector: 'Autos', size: 'large', ... }],
+      #      '3' => [{ name: 'BMW', sector: 'Airlines', size: 'large', ... }],
+      #    ]
+      #   }
       def companies_market_cap_by_sector
         lvls = MQ::Assessment::LEVELS.reject { |a| a == '4STAR' }
 
@@ -100,8 +114,8 @@ module Api
       def companies_grouped_by_latest_assessment_level
         @company_scope
           .includes(:latest_mq_assessment)
-          .group_by(&:mq_level)
-          .reject { |l, _companies| l.nil? }
+          .reject { |c| c.mq_level.nil? }
+          .group_by { |c| c.mq_level.to_i.to_s }
       end
 
       def companies_grouped_by_sector

--- a/spec/services/api/charts/sector_spec.rb
+++ b/spec/services/api/charts/sector_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Api::Charts::Sector do
-  let(:sector) { create(:tpi_sector) }
+  let(:sector) { create(:tpi_sector, name: 'Airlines') }
+  let(:sector2) { create(:tpi_sector, name: 'Autos') }
   let(:company) { create(:company, sector: sector) }
-  let(:company2) { create(:company, sector: sector) }
+  let(:company2) { create(:company, sector: sector2) }
 
   subject { described_class.new(Company) }
 
@@ -11,39 +12,44 @@ RSpec.describe Api::Charts::Sector do
     create(
       :mq_assessment,
       assessment_date: '2019-02-01',
-      level: 1,
+      level: '1',
       company: company
     )
     create(
       :mq_assessment,
       assessment_date: '2019-01-01',
-      level: 2,
+      level: '2',
       company: company
     )
     create(
       :mq_assessment,
-      company: company2
+      company: company2,
+      level: '4STAR'
     )
   end
 
-  describe '.companies_summaries' do
+  describe '.companies_summaries_by_level' do
     it 'returns Companies summaries grouped by their level' do
       expect(subject.companies_summaries_by_level).to eq(
         '0' => [],
         '1' => [
-          {id: company.id, name: company.name, status: 'down', level: '1'},
-          {id: company2.id, name: company2.name, status: 'new', level: '1'}
+          {id: company.id, name: company.name, status: 'down', level: '1'}
         ],
         '2' => [],
         '3' => [],
-        '4' => []
+        '4' => [
+          {id: company2.id, name: company2.name, status: 'new', level: '4STAR'}
+        ]
       )
     end
   end
 
   describe '.companies_count' do
     it 'returns companies count grouped by their level' do
-      expect(subject.companies_count_by_level).to eq('1' => 2)
+      expect(subject.companies_count_by_level).to eq(
+        '1' => 1,
+        '4' => 1
+      )
     end
   end
 
@@ -77,6 +83,45 @@ RSpec.describe Api::Charts::Sector do
             name: company2.name
           }
         ]
+      )
+    end
+  end
+
+  describe '.companies_market_cap_by_sector' do
+    it 'returns Companies grouped by their sector and level' do
+      expect(subject.companies_market_cap_by_sector).to eq(
+        'Airlines' => {
+          '0' => [],
+          '1' => [
+            {
+              name: company.name,
+              slug: company.slug,
+              sector: company.sector.name,
+              size: company.size,
+              level: company.mq_level.to_i.to_s,
+              level4STAR: false
+            }
+          ],
+          '2' => [],
+          '3' => [],
+          '4' => []
+        },
+        'Autos' => {
+          '0' => [],
+          '1' => [],
+          '2' => [],
+          '3' => [],
+          '4' => [
+            {
+              name: company2.name,
+              slug: company2.slug,
+              sector: company2.sector.name,
+              size: company2.size,
+              level: company2.mq_level.to_i.to_s,
+              level4STAR: true
+            }
+          ]
+        }
       )
     end
   end


### PR DESCRIPTION
- optimize queries for tpi/sectors page
- fix charts to include 4STAR level as 4 level
- add missing tests for bubble charts

This is the first step, probably storing status in mq_assessments table could be beneficial in terms of optimization. Although, we will have to recompute statuses every time assessment is updated (and any previous assessment). Storing status or materialized view which needs to be recomputed.