### PR TITLE
Feature/tpi styling vol2

### DIFF
--- a/app/assets/stylesheets/tpi.scss
+++ b/app/assets/stylesheets/tpi.scss
@@ -5,6 +5,7 @@
 @import "tpi/mixins";
 @import "tpi/sizes";
 @import "tpi/typography";
+@import "tpi/inputs";
 
 @import "bulma/sass/utilities/all";
 @import "bulma/sass/base/all";

--- a/app/assets/stylesheets/tpi/_base-tooltip.scss
+++ b/app/assets/stylesheets/tpi/_base-tooltip.scss
@@ -1,19 +1,44 @@
 @import 'colors';
 @import "typography";
 
-.base-tooltip {
-  position: relative;
+$default-trigger-size: 20px;
+
+div[data-react-class=BaseTooltip] {
+  display: inline-block;
 }
 
-.base-tooltip-content {
-  position: absolute;
-  bottom: 0;
-  left: 120%;
-  min-width: 200px;
-  min-height: 110px;
-  background-color: $dark;
-  color: rgba($white, 0.9);
-  font-size: 14px;
-  font-family: $font-family-regular;
-  padding: 20px;
+.base-tooltip {
+  position: relative;
+
+  &__default-trigger {
+    font-family: $font-family-bold;
+    color: white;
+    background-color: $blue;
+    font-size: 16px;
+    height: $default-trigger-size;
+    width: $default-trigger-size;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    outline: none;
+    cursor: pointer;
+
+    &:hover {
+      background-color: $blue-dark;
+    }
+  }
+
+  &__content {
+    position: absolute;
+    bottom: 0;
+    left: 120%;
+    min-width: 200px;
+    z-index: 10;
+    background-color: $dark;
+    color: rgba($white, 0.9);
+    font-size: 14px;
+    font-family: $font-family-regular;
+    padding: 20px;
+  }
 }

--- a/app/assets/stylesheets/tpi/_bubble-chart.scss
+++ b/app/assets/stylesheets/tpi/_bubble-chart.scss
@@ -6,7 +6,6 @@ $tape-height: 8px;
 $tape-color: rgba(25,25,25,0.1);
 $cell-height: 55px;
 $legend-image-width: 60px;
-$legend-info-size: 20px;
 
 .bubble-chart__container {
   width: 100%;
@@ -127,23 +126,4 @@ $legend-info-size: 20px;
   color: $blue-dark;
   text-align: right;
   padding-right: 50px;
-}
-
-.bubble-chart__info {
-  font-family: $font-family-bold;
-  color: white;
-  background-color: $blue;
-  font-size: 16px;
-  height: $legend-info-size;
-  width: $legend-info-size;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: none;
-  outline: none;
-  cursor: pointer;
-
-  &:hover {
-    background-color: $blue-dark;
-  }
 }

--- a/app/assets/stylesheets/tpi/_inputs.scss
+++ b/app/assets/stylesheets/tpi/_inputs.scss
@@ -1,0 +1,12 @@
+.input {
+  padding: 10px 15px;
+  outline: none;
+  background: transparent;
+  border: 1px solid $dark;
+
+  &.is-focused,
+  &:focus {
+    outline: none;
+    border: 1px solid $yellow;
+  }
+}

--- a/app/assets/stylesheets/tpi/_mixins.scss
+++ b/app/assets/stylesheets/tpi/_mixins.scss
@@ -2,9 +2,13 @@
   @include mq-level-backgrounds;
 
   height: $size;
+  min-height: $size;
   width: $size;
-  line-height: $size;
   border-radius: 50%;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   margin: 20px 0;
 
@@ -12,9 +16,28 @@
 
   font-weight: bold;
   font-size: $font-size;
+  line-height: $font-size;
+
+  &> * {
+    &:not(:last-child) {
+      margin-right: 5px;
+    }
+  }
 
   .mq-level-trend {
     @include mq-level-trend($size / 4);
+
+    &__container {
+      flex-direction: column;
+      margin-top: -$size/16;
+
+      &> * {
+        &:not(:last-child) {
+          margin: 0;
+          margin-bottom: 5px;
+        }
+      }
+    }
   }
 }
 
@@ -22,9 +45,18 @@
   width: $size;
   height: $size;
 
-  display: inline-block;
   background-repeat: no-repeat;
   background-size: 100%;
+
+  &__container {
+    display: inline-flex;
+
+    &> * {
+      &:not(:last-child) {
+        margin-right: 5px;
+      }
+    }
+  }
 
   &--unchanged, &--new {
     display: none;

--- a/app/assets/stylesheets/tpi/pages/company.scss
+++ b/app/assets/stylesheets/tpi/pages/company.scss
@@ -3,6 +3,16 @@
     background: $grey;
     padding: 40px;
 
+    h3 {
+      font-size: 16px;
+      line-height: 20px;
+    }
+
+    small {
+      font-size: 12px;
+      color: $grey-dark;
+    }
+
     &--assessment {
       height: 280px;
       display: flex;
@@ -18,10 +28,20 @@
 
   .company-property {
     &__name {
+      white-space: nowrap;
+      font-size: 12px;
+      line-height: 15px;
+      color: $grey-dark;
 
+      .base-tooltip {
+        margin-left: 5px;
+      }
     }
 
     &__value {
+      margin-top: 10px;
+      font-size: 16px;
+      line-height: 20px;
     }
   }
 

--- a/app/javascript/components/BaseTooltip.js
+++ b/app/javascript/components/BaseTooltip.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 
-const BaseTooltip = ({ tooltipTrigger, tooltipContent }) => {
+const BaseTooltip = ({ trigger, content }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
@@ -10,10 +10,10 @@ const BaseTooltip = ({ tooltipTrigger, tooltipContent }) => {
         onMouseEnter={() => setIsOpen(true)}
         onMouseLeave={() => setIsOpen(false)}
       >
-        {tooltipTrigger}
+        {trigger || (<span className="base-tooltip__default-trigger">?</span>)}
       </span>
-      {isOpen && <div className="base-tooltip-content">
-        {tooltipContent}
+      {isOpen && <div className="base-tooltip__content">
+        {content}
       </div>}
     </span>
   )

--- a/app/javascript/components/BubbleChart.js
+++ b/app/javascript/components/BubbleChart.js
@@ -74,8 +74,8 @@ const BubbleChart = (data) => {
       {levelsSignature.map((el, i) => (
         <div className="bubble-chart__level" key={`${el}-${i}-${Math.random()}`}>
           <div className="bubble-chart__level-container">
-            <div class="bubble-chart__level-title">{`Level ${el}`}</div>
-            <div class="bubble-chart__level-subtitle">{LEVELS_SUBTITLES[el]}</div>
+            <div className="bubble-chart__level-title">{`Level ${el}`}</div>
+            <div className="bubble-chart__level-subtitle">{LEVELS_SUBTITLES[el]}</div>
           </div>
         </div>
       ))}

--- a/app/javascript/components/BubbleChart.js
+++ b/app/javascript/components/BubbleChart.js
@@ -59,8 +59,7 @@ const BubbleChart = (data) => {
         <div className="bubble-chart__title-container">
           <span className="bubble-chart__title">Market cap</span>
           <BaseTooltip
-            tooltipTrigger={<button className="bubble-chart__info">?</button>}
-            tooltipContent={<span>{tooltipDisclaimer}</span>}
+            content={<span>{tooltipDisclaimer}</span>}
           />
         </div>
         <div className="bubble-chart__legend">

--- a/app/services/api/charts/cp_assessment.rb
+++ b/app/services/api/charts/cp_assessment.rb
@@ -17,7 +17,7 @@ module Api
       # @return [Array]
       # @example
       #   [
-      #     { name: 'Air China',                   data: { '2014' => 111.0, '2015' => 112.0 } },
+      #     { name: 'Air China',                   data: { 2014 => 111.0, 2015 => 112.0 } },
       #
       #     { name: 'Airlines sector mean',        data: { ... } },
       #
@@ -40,7 +40,7 @@ module Api
       def emissions_data_from_company
         {
           name: company.name,
-          data: assessment&.emissions
+          data: assessment&.emissions&.transform_keys(&:to_i)
         }
       end
 
@@ -57,7 +57,7 @@ module Api
             type: 'area',
             fillOpacity: 0.1,
             name: benchmark.scenario,
-            data: benchmark.emissions
+            data: benchmark.emissions.transform_keys(&:to_i)
           }
         end
       end
@@ -66,18 +66,18 @@ module Api
       # For each year, average value is calculated from all available
       # companies emissions, up to last reported year.
       #
-      # @example {'2014' => 111.0, '2015' => 112.0 }
+      # @example {2014 => 111.0, 2015 => 112.0 }
       #
       def sector_average_emissions
         years_with_reported_emissions
-          .map { |year| [year.to_s, sector_average_emission_for_year(year)] }
+          .map { |year| [year.to_i, sector_average_emission_for_year(year)] }
           .to_h
       end
 
       # @return [Float] average emission from all Companies from single year
       def sector_average_emission_for_year(year)
         company_emissions = sector_all_emissions
-          .map { |emissions| emissions[year.to_s] }
+          .map { |emissions| emissions[year] }
           .compact
 
         return nil if company_emissions.empty?
@@ -103,7 +103,9 @@ module Api
         @sector_all_emissions ||= company.sector
           .companies
           .includes(:cp_assessments)
-          .flat_map { |c| c.cp_assessments.published_on_or_before(assessment.publication_date).last&.emissions }
+          .flat_map do |c|
+            c.cp_assessments.published_on_or_before(assessment.publication_date).last&.emissions&.transform_keys(&:to_i)
+          end
           .compact
       end
 

--- a/app/views/tpi/companies/_company_property.html.erb
+++ b/app/views/tpi/companies/_company_property.html.erb
@@ -1,6 +1,9 @@
 <div class="company-property">
   <div class="company-property__name">
     <%= name %>
+    <% if defined?(tooltip) %>
+      <%= react_component("BaseTooltip", { content: tooltip }) %>
+    <% end %>
   </div>
   <div class="company-property__value">
     <%= yield%>

--- a/app/views/tpi/companies/_cp_assessment.html.erb
+++ b/app/views/tpi/companies/_cp_assessment.html.erb
@@ -2,7 +2,7 @@
   <%= line_chart(
     emissions_chart_data_tpi_company_path(assessment.company, cp_assessment_id: assessment.id),
     id: 'cp_assessment_chart',
-    width: '800px',
+    width: '100%',
     height: '600px',
     library: default_chart_options
   )%>

--- a/app/views/tpi/companies/_mq_level.html.erb
+++ b/app/views/tpi/companies/_mq_level.html.erb
@@ -1,4 +1,6 @@
 <div class="mq-level level<%= level.to_i %>">
-  <%= level.to_i %>
+  <div>
+    <%= level.to_i %>
+  </div>
   <%= render 'mq_level_trend', level: level, status: status %>
 </div>

--- a/app/views/tpi/companies/_mq_level_trend.html.erb
+++ b/app/views/tpi/companies/_mq_level_trend.html.erb
@@ -1,6 +1,8 @@
-<div class="mq-level-trend mq-level-trend--<%= status %>">
+<div class="mq-level-trend__container">
+  <div class="mq-level-trend mq-level-trend--<%= status %>">
+  </div>
+  <% if level.include?('STAR') %>
+    <div class="mq-level-trend mq-level-trend--star">
+    </div>
+  <% end %>
 </div>
-<% if level.include?('STAR') %>
-  <span class="mq-level-trend mq-level-trend--star">
-  </span>
-<% end %>

--- a/app/views/tpi/companies/show.html.erb
+++ b/app/views/tpi/companies/show.html.erb
@@ -3,9 +3,9 @@
     <div class="columns">
       <div class="column">
         <div class="summary-box summary-box--assessment">
-          <h3>Management Quality</h3>
+          <h4>Management Quality</h4>
           <p>
-            Number of assessments: <%= @company.mq_assessments.size %>
+            <small>Number of assessments: <%= @company.mq_assessments.size %></small>
           </p>
           <%= render 'mq_level', level: @company.mq_level, status: @company.mq_status %>
           <p>
@@ -15,9 +15,9 @@
       </div>
       <div class="column">
         <div class="summary-box summary-box--assessment">
-          <h3>Carbon Performance</h3>
+          <h4>Carbon Performance</h4>
           <p>
-            Number of assessments: <%= @company.cp_assessments.size %>
+            <small>Number of assessments: <%= @company.cp_assessments.size %></small>
           </p>
           <p>
             Below 2 degrees
@@ -43,22 +43,22 @@
               <% end %>
             </div>
             <div class="column">
-              <%= render 'company_property', name: 'Market cap (Group)' do %>
+              <%= render 'company_property', name: 'Market cap (Group)', tooltip: t('.tooltips.market_cap') do %>
                 <%= @company.size %>
               <% end %>
             </div>
             <div class="column">
-              <%= render 'company_property', name: 'ISIN' do %>
+              <%= render 'company_property', name: 'ISIN', tooltip: t('.tooltips.ISIN') do %>
                 <%= @company.isin_array.join('<br/>').html_safe %>
               <% end %>
             </div>
             <div class="column">
-              <%= render 'company_property', name: 'SEDOL' do %>
+              <%= render 'company_property', name: 'SEDOL', tooltip: t('.tooltips.SEDOL') do %>
                 Don't have that
               <% end %>
             </div>
             <div class="column">
-              <%= render 'company_property', name: 'CA100+ engagement' do %>
+              <%= render 'company_property', name: 'CA100+ engagement', tooltip: t('.tooltips.CA100') do %>
                 <%= @company.ca100? ? 'Yes' : 'No' %>
               <% end %>
             </div>
@@ -70,10 +70,12 @@
 
   <section class="management-quality container">
     <div class="management-quality__header">
-      <h4>Management Quality: <%= @company.name %></h4>
+      <h4>
+        Management Quality: <%= @company.name %> <%= react_component("BaseTooltip", { content: t('.tooltips.mq_header') }) %>
+      </h4>
 
       <div>
-        Assessment Date
+        Assessment Date: <%= react_component("BaseTooltip", { content: t('.tooltips.mq_assessment_date') }) %>
         <%= select_tag :mq_assessment_id,
                        options_from_collection_for_select(@company.mq_assessments, "id", "assessment_date", @mq_assessment.id),
                        class: 'input',
@@ -97,10 +99,12 @@
   <% unless @company.cp_assessments.empty? %>
     <section class="carbon-performance container">
       <div class="management-quality__header">
-        <h4>Carbon Performance <%= @company.name %></h4>
+        <h4>
+          Carbon Performance <%= @company.name %> <%= react_component("BaseTooltip", { content: t('.tooltips.cp_header') }) %>
+        </h4>
         <div>
           <div>
-            Assessment Date
+            Assessment Date: <%= react_component("BaseTooltip", { content: t('.tooltips.cp_assessment_date') }) %>
             <%= select_tag :cp_assessment_id,
                            options_from_collection_for_select(@company.cp_assessments, "id", "assessment_date", @cp_assessment.id),
                            class: 'input',

--- a/app/views/tpi/companies/show.html.erb
+++ b/app/views/tpi/companies/show.html.erb
@@ -75,11 +75,12 @@
       <div>
         Assessment Date
         <%= select_tag :mq_assessment_id,
-              options_from_collection_for_select(@company.mq_assessments, "id", "assessment_date", @mq_assessment.id),
-           data: {
-             remote: true,
-             url: mq_assessment_tpi_company_path(@company)
-           }
+                       options_from_collection_for_select(@company.mq_assessments, "id", "assessment_date", @mq_assessment.id),
+                       class: 'input',
+                       data: {
+                         remote: true,
+                         url: mq_assessment_tpi_company_path(@company)
+                       }
         %>
       </div>
     </div>
@@ -101,11 +102,12 @@
           <div>
             Assessment Date
             <%= select_tag :cp_assessment_id,
-                    options_from_collection_for_select(@company.cp_assessments, "id", "assessment_date", @cp_assessment.id),
-               data: {
-                 remote: true,
-                 url: cp_assessment_tpi_company_path(@company)
-               }
+                           options_from_collection_for_select(@company.cp_assessments, "id", "assessment_date", @cp_assessment.id),
+                           class: 'input',
+                           data: {
+                             remote: true,
+                             url: cp_assessment_tpi_company_path(@company)
+                           }
             %>
           </div>
         </div>

--- a/app/views/tpi/home/sandbox.html.erb
+++ b/app/views/tpi/home/sandbox.html.erb
@@ -1,7 +1,7 @@
 <section class="section">
   <div class="container">
     <h2>Typography</h2>
-  
+
     <h1>h1</h1>
     <h3>h3</h3>
     <h4>h4</h4>
@@ -23,7 +23,7 @@
 <section class="section">
   <div class="container">
     <h2>Links</h2>
-    
+
     <div class="columns">
       <div class="column">
         <a class="link" href="#">link</a>
@@ -41,7 +41,7 @@
 <section class="section">
   <div class="container">
     <h2>Buttons</h2>
-    
+
     <div class="columns">
       <div class="column">
         <button class="button is-primary">primary</button>
@@ -83,6 +83,25 @@
         <span class="tag">
           Tag label
         </span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <h2>Inputs</h2>
+
+    <div class="columns">
+      <div class="column">
+        <input type="text" class="input" placeholder="Type something" />
+      </div>
+      <div class="column">
+        <select class="input">
+          <option value="option1">Option 1</option>
+          <option value="option2">Option 2</option>
+          <option value="option3">Option 3</option>
+        </select>
       </div>
     </div>
   </div>

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -1,0 +1,14 @@
+en:
+  tpi:
+    companies:
+      show:
+        tooltips:
+          market_cap: 'Market cap'
+          ISIN: 'ISIN'
+          SEDOL: 'SEDOL'
+          CA100: 'CA100'
+          mq_header: 'Management quality'
+          mq_assessment_date: 'Assessment Date'
+          mq_current_level: 'Current Level'
+          cp_header: 'Carbon performance'
+          cp_assessment_date: 'Assessment Date'

--- a/spec/services/api/charts/cp_assessment_spec.rb
+++ b/spec/services/api/charts/cp_assessment_spec.rb
@@ -53,19 +53,19 @@ RSpec.describe Api::Charts::CPAssessment do
             # company
             {
               name: company_sector_a_1.name,
-              data: {'2017' => 100.0, '2018' => 70.0, '2019' => 110.0}
+              data: {2017 => 100.0, 2018 => 70.0, 2019 => 110.0}
             },
             # sector average only taking cp assessments published before company selected assessment
             {
               name: "#{sector_a.name} sector mean",
-              data: {'2017' => (100.0 + 40.0) / 2, '2018' => (70.0 + 50.0) / 2, '2019' => 110.0}
+              data: {2017 => (100.0 + 40.0) / 2, 2018 => (70.0 + 50.0) / 2, 2019 => 110.0}
             },
             # CP benchmarks
             {
               type: 'area',
               fillOpacity: 0.1,
               name: 'scenario',
-              data: {'2016' => 115.5, '2017' => 122.0, '2018' => 124.0}
+              data: {2016 => 115.5, 2017 => 122.0, 2018 => 124.0}
             }
           ]
         end
@@ -79,19 +79,19 @@ RSpec.describe Api::Charts::CPAssessment do
             # company
             {
               name: company_sector_a_1.name,
-              data: {'2017' => 90.0, '2018' => 90.0, '2019' => 110.0}
+              data: {2017 => 90.0, 2018 => 90.0, 2019 => 110.0}
             },
             # sector average only taking cp assessments published before company selected assessment
             {
               name: "#{sector_a.name} sector mean",
-              data: {'2017' => (90.0 + 40.0) / 2, '2018' => (90.0 + 50.0) / 2, '2019' => 110.0}
+              data: {2017 => (90.0 + 40.0) / 2, 2018 => (90.0 + 50.0) / 2, 2019 => 110.0}
             },
             # CP benchmarks taken the latest valid before published assessment
             {
               type: 'area',
               fillOpacity: 0.1,
               name: 'scenario',
-              data: {'2016' => 130.0, '2017' => 120.0, '2018' => 100.0}
+              data: {2016 => 130.0, 2017 => 120.0, 2018 => 100.0}
             }
           ]
         end


### PR DESCRIPTION
- Adding tooltips to company page (I think we may consider using some tooltip library instead, like tippy.js)
- Fixing CP emission chart data (sometimes year 2013, 2014 were at the end, how knows why, problem is gone when providing year as an integer not a string)
- couple small fixes with styling, company properties, trend badges (should be on top of each other when star + up trend for example), adding some base styles for inputs, using it for select.

