### PR TITLE
add public-activity for tracking updates in publishable records

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'octokit', '~> 4.0'
 gem 'google-cloud-storage', require: false
 
 gem 'discard'
+gem 'public_activity'
 gem 'friendly_id'
 gem 'language_list'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,6 +277,11 @@ GEM
     pg (1.1.4)
     polyamorous (2.3.0)
       activerecord (>= 5.0)
+    public_activity (1.6.4)
+      actionpack (>= 3.0.0)
+      activerecord (>= 3.0)
+      i18n (>= 0.5.0)
+      railties (>= 3.0.0)
     public_suffix (4.0.1)
     puma (4.3.0)
       nio4r (~> 2.0)
@@ -492,6 +497,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   octokit (~> 4.0)
   pg (>= 0.18, < 2.0)
+  public_activity
   puma (~> 4.1)
   rails (~> 6.0.1)
   rails-controller-testing

--- a/app/admin/activities.rb
+++ b/app/admin/activities.rb
@@ -1,5 +1,6 @@
 ActiveAdmin.register PublicActivity::Activity do
   config.per_page = 30
+
   menu parent: 'Administration', priority: 3, label: 'Users Activity'
 
   decorate_with PublicActivity::ActivityDecorator

--- a/app/admin/activities.rb
+++ b/app/admin/activities.rb
@@ -1,0 +1,15 @@
+ActiveAdmin.register PublicActivity::Activity do
+  config.per_page = 30
+  menu parent: 'Administration', priority: 3, label: 'Users Activity'
+
+  decorate_with PublicActivity::ActivityDecorator
+
+  index do
+    column 'Record Type', :trackable_type
+    column 'Record ID', :trackable_id
+    column 'User', :owner
+    column 'Activity', &:activity_details
+    column 'Record', :trackable, &:trackable_link
+    column :updated_at, &:updated_at_display
+  end
+end

--- a/app/admin/activities.rb
+++ b/app/admin/activities.rb
@@ -9,17 +9,15 @@ ActiveAdmin.register PublicActivity::Activity do
   actions :all, except: [:new, :create]
 
   filter :trackable_type, label: 'Record Type'
-  filter :trackable_id_equals, label: 'Record ID'
-  filter :owner_id_equals, label: 'User ID'
+  filter :owner_of_AdminUser_type_email_contains, label: 'User email contains'
   filter :key_contains, label: 'Action details contains'
   filter :updated_at
 
   index title: 'Users Activity' do
     column 'Record Type', :trackable_type
-    column 'Record ID', :trackable_id
-    column 'User', :owner
-    column 'Activity details', &:activity_details
     column 'Record', :trackable, &:trackable_link
+    column 'Activity details', &:activity_details
+    column 'User', :owner
     column :updated_at, &:updated_at_display
   end
 end

--- a/app/admin/activities.rb
+++ b/app/admin/activities.rb
@@ -1,15 +1,24 @@
 ActiveAdmin.register PublicActivity::Activity do
   config.per_page = 30
+  config.batch_actions = false
 
   menu parent: 'Administration', priority: 3, label: 'Users Activity'
 
   decorate_with PublicActivity::ActivityDecorator
 
-  index do
+  actions :all, except: [:new, :create]
+
+  filter :trackable_type, label: 'Record Type'
+  filter :trackable_id_equals, label: 'Record ID'
+  filter :owner_id_equals, label: 'User ID'
+  filter :key_contains, label: 'Action details contains'
+  filter :updated_at
+
+  index title: 'Users Activity' do
     column 'Record Type', :trackable_type
     column 'Record ID', :trackable_id
     column 'User', :owner
-    column 'Activity', &:activity_details
+    column 'Activity details', &:activity_details
     column 'Record', :trackable, &:trackable_link
     column :updated_at, &:updated_at_display
   end

--- a/app/commands/command/batch/archive.rb
+++ b/app/commands/command/batch/archive.rb
@@ -9,7 +9,7 @@ module Command
       def call
         @collection
           .where(id: [*@ids])
-          .update_all(visibility_status: 'archived')
+          .update(visibility_status: 'archived')
       end
     end
   end

--- a/app/commands/command/batch/publish.rb
+++ b/app/commands/command/batch/publish.rb
@@ -9,7 +9,7 @@ module Command
       def call
         @collection
           .where(id: [*@ids])
-          .update_all(visibility_status: 'published')
+          .update(visibility_status: 'published')
       end
     end
   end

--- a/app/decorators/public_activity/activity_decorator.rb
+++ b/app/decorators/public_activity/activity_decorator.rb
@@ -1,0 +1,40 @@
+class PublicActivity::ActivityDecorator < Draper::Decorator
+  delegate_all
+
+  TRACKABLE_DISPLAY_NAME_MAPPING = {
+    'Litigation' => :title,
+    'Legislation' => :title,
+    'Company' => :name
+  }.freeze
+
+  TRACKABLE_ACTION_KEYS_MAPPING = {
+    'draft' => 'moved to DRAFT state',
+    'pending' => 'moved to PENDING state',
+    'published' => 'moved to PUBLISHED state',
+    'archived' => 'archived'
+  }.freeze
+
+  def activity_details
+    resource, action = model.key.split('.')
+    "#{resource} was #{TRACKABLE_ACTION_KEYS_MAPPING[action] || action}"
+  end
+
+  def updated_at_display
+    "#{h.time_ago_in_words(updated_at)} ago"
+  end
+
+  def trackable_link
+    return h.link_to trackable_display_name(trackable) if trackable
+
+    discarded_trackable = find_discarded_trackable
+    trackable_display_name(discarded_trackable) if discarded_trackable
+  end
+
+  def find_discarded_trackable
+    trackable_type.constantize.all_discarded.find(trackable_id)
+  end
+
+  def trackable_display_name(trackable_object)
+    trackable_object.send(TRACKABLE_DISPLAY_NAME_MAPPING[trackable_type] || :to_s).truncate(50)
+  end
+end

--- a/app/decorators/public_activity/activity_decorator.rb
+++ b/app/decorators/public_activity/activity_decorator.rb
@@ -4,30 +4,37 @@ class PublicActivity::ActivityDecorator < Draper::Decorator
   TRACKABLE_DISPLAY_NAME_MAPPING = {
     'Litigation' => :title,
     'Legislation' => :title,
-    'Company' => :name
+    'Company' => :name,
+    'Geography' => :name
   }.freeze
 
   TRACKABLE_ACTION_KEYS_MAPPING = {
-    'draft' => 'moved to DRAFT state',
-    'pending' => 'moved to PENDING state',
-    'published' => 'moved to PUBLISHED state',
+    'draft' => 'moved to "Draft" state',
+    'pending' => 'moved to "Pending" state',
+    'published' => 'moved to "Published" state',
     'archived' => 'archived'
   }.freeze
 
   def activity_details
     resource, action = model.key.split('.')
+
     "#{resource} was #{TRACKABLE_ACTION_KEYS_MAPPING[action] || action}"
   end
 
   def updated_at_display
-    "#{h.time_ago_in_words(updated_at)} ago"
+    "#{h.time_ago_in_words(updated_at)} ago (#{updated_at})"
   end
 
   def trackable_link
+    # link to record if exists
     return h.link_to trackable_display_name(trackable) if trackable
 
+    # if trackable record does not exist, it could have been discarded
     discarded_trackable = find_discarded_trackable
-    trackable_display_name(discarded_trackable) if discarded_trackable
+    return trackable_display_name(discarded_trackable) if discarded_trackable
+
+    # fallback message
+    '(no record found)'
   end
 
   def find_discarded_trackable
@@ -35,6 +42,8 @@ class PublicActivity::ActivityDecorator < Draper::Decorator
   end
 
   def trackable_display_name(trackable_object)
-    trackable_object.send(TRACKABLE_DISPLAY_NAME_MAPPING[trackable_type] || :to_s).truncate(50)
+    display_method = TRACKABLE_DISPLAY_NAME_MAPPING[trackable_type] || :to_s
+
+    trackable_object.send(display_method).truncate(50)
   end
 end

--- a/app/decorators/public_activity/activity_decorator.rb
+++ b/app/decorators/public_activity/activity_decorator.rb
@@ -27,7 +27,7 @@ class PublicActivity::ActivityDecorator < Draper::Decorator
 
   def trackable_link
     # link to record if exists
-    return h.link_to trackable_display_name(trackable) if trackable
+    return h.link_to trackable_display_name(trackable), h.polymorphic_url([:admin, trackable]) if trackable
 
     # if trackable record does not exist, it could have been discarded
     discarded_trackable = find_discarded_trackable

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -21,9 +21,12 @@
 #
 
 class Company < ApplicationRecord
-  include DiscardableModel
   include VisibilityStatus
+  include DiscardableModel
+  include PublicActivity::Common
+  include PublicActivityTrackable
   extend FriendlyId
+
   friendly_id :name, use: :slugged, routes: :default
 
   MARKET_CAP_GROUPS = %w[small medium large].freeze

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -23,7 +23,6 @@
 class Company < ApplicationRecord
   include VisibilityStatus
   include DiscardableModel
-  include PublicActivity::Common
   include PublicActivityTrackable
   extend FriendlyId
 

--- a/app/models/concerns/public_activity_trackable.rb
+++ b/app/models/concerns/public_activity_trackable.rb
@@ -24,9 +24,7 @@ module PublicActivityTrackable
   end
 
   def owner
-    return unless respond_to?(:updated_by)
-
-    updated_by
+    ::Current.admin_user
   end
 
   def activity_key_for_last_update

--- a/app/models/concerns/public_activity_trackable.rb
+++ b/app/models/concerns/public_activity_trackable.rb
@@ -1,0 +1,41 @@
+# Tracks updates of:
+# - common attributes updates (visibility_status, discarded_at)
+# - deletes
+#
+# Required to be implemmented by the model
+# - create_activity (from PublicActivity::Common)
+# - updated_by (from UserTrackable)
+#
+module PublicActivityTrackable
+  extend ActiveSupport::Concern
+
+  included do
+    around_update :track_updates_activity
+  end
+
+  protected
+
+  def track_updates_activity
+    yield
+
+    return unless errors.blank? && previous_changes.present?
+
+    create_activity activity_key_for_last_update, owner: owner
+  end
+
+  def owner
+    return unless respond_to?(:updated_by)
+
+    updated_by
+  end
+
+  def activity_key_for_last_update
+    if previous_changes['visibility_status']
+      previous_changes['visibility_status'].last
+    elsif previous_changes['discarded_at']
+      'deleted'
+    else
+      'edited'
+    end
+  end
+end

--- a/app/models/concerns/public_activity_trackable.rb
+++ b/app/models/concerns/public_activity_trackable.rb
@@ -4,7 +4,6 @@
 #
 # Required to be implemmented by the model
 # - create_activity (from PublicActivity::Common)
-# - updated_by (from UserTrackable)
 #
 module PublicActivityTrackable
   extend ActiveSupport::Concern

--- a/app/models/concerns/public_activity_trackable.rb
+++ b/app/models/concerns/public_activity_trackable.rb
@@ -9,6 +9,8 @@ module PublicActivityTrackable
   extend ActiveSupport::Concern
 
   included do
+    include PublicActivity::Common
+
     around_update :track_updates_activity
   end
 

--- a/app/models/geography.rb
+++ b/app/models/geography.rb
@@ -24,6 +24,8 @@ class Geography < ApplicationRecord
   include Taggable
   include VisibilityStatus
   include DiscardableModel
+  include PublicActivity::Common
+  include PublicActivityTrackable
   extend FriendlyId
 
   friendly_id :name, use: :slugged, routes: :default

--- a/app/models/geography.rb
+++ b/app/models/geography.rb
@@ -24,7 +24,6 @@ class Geography < ApplicationRecord
   include Taggable
   include VisibilityStatus
   include DiscardableModel
-  include PublicActivity::Common
   include PublicActivityTrackable
   extend FriendlyId
 

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -24,7 +24,6 @@ class Legislation < ApplicationRecord
   include Taggable
   include VisibilityStatus
   include DiscardableModel
-  include PublicActivity::Common
   include PublicActivityTrackable
   extend FriendlyId
 

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -24,6 +24,8 @@ class Legislation < ApplicationRecord
   include Taggable
   include VisibilityStatus
   include DiscardableModel
+  include PublicActivity::Common
+  include PublicActivityTrackable
   extend FriendlyId
 
   friendly_id :title, use: :slugged, routes: :default

--- a/app/models/litigation.rb
+++ b/app/models/litigation.rb
@@ -24,6 +24,8 @@ class Litigation < ApplicationRecord
   include Taggable
   include VisibilityStatus
   include DiscardableModel
+  include PublicActivity::Common
+  include PublicActivityTrackable
   extend FriendlyId
 
   friendly_id :title, use: :slugged, routes: :default

--- a/app/models/litigation.rb
+++ b/app/models/litigation.rb
@@ -24,7 +24,6 @@ class Litigation < ApplicationRecord
   include Taggable
   include VisibilityStatus
   include DiscardableModel
-  include PublicActivity::Common
   include PublicActivityTrackable
   extend FriendlyId
 

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -24,6 +24,8 @@ class Target < ApplicationRecord
   include UserTrackable
   include VisibilityStatus
   include DiscardableModel
+  include PublicActivity::Common
+  include PublicActivityTrackable
 
   TYPES = %w[
     base_year_target

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -24,7 +24,6 @@ class Target < ApplicationRecord
   include UserTrackable
   include VisibilityStatus
   include DiscardableModel
-  include PublicActivity::Common
   include PublicActivityTrackable
 
   TYPES = %w[

--- a/db/migrate/20191121060716_create_activities.rb
+++ b/db/migrate/20191121060716_create_activities.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Migration responsible for creating a table with activities
+class CreateActivities < (ActiveRecord.version.release() < Gem::Version.new('5.2.0') ? ActiveRecord::Migration : ActiveRecord::Migration[5.2])
+  # Create table
+  def self.up
+    create_table :activities do |t|
+      t.belongs_to :trackable, :polymorphic => true
+      t.belongs_to :owner, :polymorphic => true
+      t.string  :key
+      t.text    :parameters
+      t.belongs_to :recipient, :polymorphic => true
+
+      t.timestamps
+    end
+
+    add_index :activities, [:trackable_id, :trackable_type]
+    add_index :activities, [:owner_id, :owner_type]
+    add_index :activities, [:recipient_id, :recipient_type]
+  end
+  # Drop table
+  def self.down
+    drop_table :activities
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -50,6 +50,25 @@ ActiveRecord::Schema.define(version: 2019_11_22_133323) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
+  create_table "activities", force: :cascade do |t|
+    t.string "trackable_type"
+    t.bigint "trackable_id"
+    t.string "owner_type"
+    t.bigint "owner_id"
+    t.string "key"
+    t.text "parameters"
+    t.string "recipient_type"
+    t.bigint "recipient_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["owner_id", "owner_type"], name: "index_activities_on_owner_id_and_owner_type"
+    t.index ["owner_type", "owner_id"], name: "index_activities_on_owner_type_and_owner_id"
+    t.index ["recipient_id", "recipient_type"], name: "index_activities_on_recipient_id_and_recipient_type"
+    t.index ["recipient_type", "recipient_id"], name: "index_activities_on_recipient_type_and_recipient_id"
+    t.index ["trackable_id", "trackable_type"], name: "index_activities_on_trackable_id_and_trackable_type"
+    t.index ["trackable_type", "trackable_id"], name: "index_activities_on_trackable_type_and_trackable_id"
+  end
+
   create_table "admin_users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false

--- a/spec/controllers/admin/companies_controller_spec.rb
+++ b/spec/controllers/admin/companies_controller_spec.rb
@@ -62,6 +62,35 @@ RSpec.describe Admin::CompaniesController, type: :controller do
     end
   end
 
+  describe 'PATCH update' do
+    let!(:company_to_update) { create(:company) }
+
+    context 'with valid params' do
+      let(:valid_update_params) { {name: 'name was updated'} }
+
+      subject { patch :update, params: {id: company_to_update.id, company: valid_update_params} }
+
+      it 'does not create another record' do
+        expect { subject }.not_to change(Company, :count)
+      end
+
+      it 'updates existing Company' do
+        expect { subject }.to change { company_to_update.reload.name }.to('name was updated')
+      end
+
+      it 'creates "edited" activity' do
+        expect { subject }.to change(PublicActivity::Activity, :count).by(1)
+
+        expect(PublicActivity::Activity.last.trackable_id).to eq(company_to_update.id)
+        expect(PublicActivity::Activity.last.key).to eq('company.edited')
+      end
+
+      it 'redirects to the updated Company' do
+        expect(subject).to redirect_to(admin_company_path(company_to_update))
+      end
+    end
+  end
+
   describe 'DELETE destroy' do
     let!(:company) { create(:company, discarded_at: nil) }
 

--- a/spec/controllers/admin/geographies_controller_spec.rb
+++ b/spec/controllers/admin/geographies_controller_spec.rb
@@ -91,6 +91,35 @@ RSpec.describe Admin::GeographiesController, type: :controller do
     end
   end
 
+  describe 'PATCH update' do
+    let!(:geography_to_update) { create(:geography) }
+
+    context 'with valid params' do
+      let(:valid_update_params) { {name: 'name was updated'} }
+
+      subject { patch :update, params: {id: geography_to_update.id, geography: valid_update_params} }
+
+      it 'does not create another record' do
+        expect { subject }.not_to change(Geography, :count)
+      end
+
+      it 'updates existing Geography' do
+        expect { subject }.to change { geography_to_update.reload.name }.to('name was updated')
+      end
+
+      it 'creates "edited" activity' do
+        expect { subject }.to change(PublicActivity::Activity, :count).by(1)
+
+        expect(PublicActivity::Activity.last.trackable_id).to eq(geography_to_update.id)
+        expect(PublicActivity::Activity.last.key).to eq('geography.edited')
+      end
+
+      it 'redirects to the updated Geography' do
+        expect(subject).to redirect_to(admin_geography_path(geography_to_update))
+      end
+    end
+  end
+
   describe 'DELETE destroy' do
     let!(:geography) { create(:geography, discarded_at: nil) }
 

--- a/spec/controllers/admin/legislations_controller_spec.rb
+++ b/spec/controllers/admin/legislations_controller_spec.rb
@@ -163,28 +163,30 @@ RSpec.describe Admin::LegislationsController, type: :controller do
   end
 
   describe 'PATCH update' do
+    let!(:legislation_to_update) { create(:legislation, visibility_status: 'published') }
+
     context 'with valid params' do
       let(:valid_update_params) { {title: 'title was updated'} }
 
-      subject { patch :update, params: {id: legislation.id, legislation: valid_update_params} }
+      subject { patch :update, params: {id: legislation_to_update.id, legislation: valid_update_params} }
 
       it 'does not create another record' do
         expect { subject }.not_to change(Legislation, :count)
       end
 
       it 'updates existing Legislation' do
-        expect { subject }.to change { legislation.reload.title }.to('title was updated')
+        expect { subject }.to change { legislation_to_update.reload.title }.to('title was updated')
       end
 
-      it 'creates records update activity' do
+      it 'creates "edited" activity' do
         expect { subject }.to change(PublicActivity::Activity, :count).by(1)
 
-        expect(PublicActivity::Activity.last.trackable_id).to eq(legislation.id)
+        expect(PublicActivity::Activity.last.trackable_id).to eq(legislation_to_update.id)
         expect(PublicActivity::Activity.last.key).to eq('legislation.edited')
       end
 
       it 'redirects to the updated Legislation' do
-        expect(subject).to redirect_to(admin_legislation_path(legislation))
+        expect(subject).to redirect_to(admin_legislation_path(legislation_to_update))
       end
     end
   end

--- a/spec/controllers/admin/legislations_controller_spec.rb
+++ b/spec/controllers/admin/legislations_controller_spec.rb
@@ -162,6 +162,33 @@ RSpec.describe Admin::LegislationsController, type: :controller do
     end
   end
 
+  describe 'PATCH update' do
+    context 'with valid params' do
+      let(:valid_update_params) { {title: 'title was updated'} }
+
+      subject { patch :update, params: {id: legislation.id, legislation: valid_update_params} }
+
+      it 'does not create another record' do
+        expect { subject }.not_to change(Legislation, :count)
+      end
+
+      it 'updates existing Legislation' do
+        expect { subject }.to change { legislation.reload.title }.to('title was updated')
+      end
+
+      it 'creates records update activity' do
+        expect { subject }.to change(PublicActivity::Activity, :count).by(1)
+
+        expect(PublicActivity::Activity.last.trackable_id).to eq(legislation.id)
+        expect(PublicActivity::Activity.last.key).to eq('legislation.edited')
+      end
+
+      it 'redirects to the updated Legislation' do
+        expect(subject).to redirect_to(admin_legislation_path(legislation))
+      end
+    end
+  end
+
   describe 'DELETE destroy' do
     let!(:legislation_to_delete) { create(:legislation, discarded_at: nil) }
 

--- a/spec/controllers/admin/litigations_controller_spec.rb
+++ b/spec/controllers/admin/litigations_controller_spec.rb
@@ -132,28 +132,30 @@ RSpec.describe Admin::LitigationsController, type: :controller do
   end
 
   describe 'PATCH update' do
+    let!(:litigation_to_update) { create(:litigation, :with_sides) }
+
     context 'with valid params' do
       let(:valid_update_params) { {title: 'title was updated'} }
 
-      subject { patch :update, params: {id: litigation.id, litigation: valid_update_params} }
+      subject { patch :update, params: {id: litigation_to_update.id, litigation: valid_update_params} }
 
       it 'does not create another record' do
         expect { subject }.not_to change(Litigation, :count)
       end
 
       it 'updates existing Litigation' do
-        expect { subject }.to change { litigation.reload.title }.to('title was updated')
+        expect { subject }.to change { litigation_to_update.reload.title }.to('title was updated')
       end
 
-      it 'creates records update activity' do
+      it 'creates "edited" activity' do
         expect { subject }.to change(PublicActivity::Activity, :count).by(1)
 
-        expect(PublicActivity::Activity.last.trackable_id).to eq(litigation.id)
+        expect(PublicActivity::Activity.last.trackable_id).to eq(litigation_to_update.id)
         expect(PublicActivity::Activity.last.key).to eq('litigation.edited')
       end
 
       it 'redirects to the updated Litigation' do
-        expect(subject).to redirect_to(admin_litigation_path(litigation))
+        expect(subject).to redirect_to(admin_litigation_path(litigation_to_update))
       end
     end
   end

--- a/spec/controllers/admin/litigations_controller_spec.rb
+++ b/spec/controllers/admin/litigations_controller_spec.rb
@@ -133,12 +133,23 @@ RSpec.describe Admin::LitigationsController, type: :controller do
 
   describe 'PATCH update' do
     context 'with valid params' do
-      subject { patch :update, params: {litigation: {title: "#{litigation.title} was updated"}} }
+      let(:valid_update_params) { {title: 'title was updated'} }
 
-      it { is_expected.to be_successful }
+      subject { patch :update, params: {id: litigation.id, litigation: valid_update_params} }
+
+      it 'does not create another record' do
+        expect { subject }.not_to change(Litigation, :count)
+      end
 
       it 'updates existing Litigation' do
-        expect(litigation.reload.title).to eq('was updated')
+        expect { subject }.to change { litigation.reload.title }.to('title was updated')
+      end
+
+      it 'creates records update activity' do
+        expect { subject }.to change(PublicActivity::Activity, :count).by(1)
+
+        expect(PublicActivity::Activity.last.trackable_id).to eq(litigation.id)
+        expect(PublicActivity::Activity.last.key).to eq('litigation.edited')
       end
 
       it 'redirects to the updated Litigation' do

--- a/spec/controllers/admin/litigations_controller_spec.rb
+++ b/spec/controllers/admin/litigations_controller_spec.rb
@@ -131,6 +131,22 @@ RSpec.describe Admin::LitigationsController, type: :controller do
     end
   end
 
+  describe 'PATCH update' do
+    context 'with valid params' do
+      subject { patch :update, params: {litigation: {title: "#{litigation.title} was updated"}} }
+
+      it { is_expected.to be_successful }
+
+      it 'updates existing Litigation' do
+        expect(litigation.reload.title).to eq('was updated')
+      end
+
+      it 'redirects to the updated Litigation' do
+        expect(subject).to redirect_to(admin_litigation_path(litigation))
+      end
+    end
+  end
+
   describe 'DELETE destroy' do
     let!(:litigation) { create(:litigation, discarded_at: nil) }
     subject { delete :destroy, params: {id: litigation.id} }

--- a/spec/controllers/admin/targets_controller_spec.rb
+++ b/spec/controllers/admin/targets_controller_spec.rb
@@ -137,6 +137,35 @@ RSpec.describe Admin::TargetsController, type: :controller do
     end
   end
 
+  describe 'PATCH update' do
+    let!(:target_to_update) { create(:target, year: 2055) }
+
+    context 'with valid params' do
+      let(:valid_update_params) { {year: 2080} }
+
+      subject { patch :update, params: {id: target_to_update.id, target: valid_update_params} }
+
+      it 'does not create another record' do
+        expect { subject }.not_to change(Target, :count)
+      end
+
+      it 'updates existing Target' do
+        expect { subject }.to change { target_to_update.reload.year }.to(2080)
+      end
+
+      it 'creates "edited" activity' do
+        expect { subject }.to change(PublicActivity::Activity, :count).by(1)
+
+        expect(PublicActivity::Activity.last.trackable_id).to eq(target_to_update.id)
+        expect(PublicActivity::Activity.last.key).to eq('target.edited')
+      end
+
+      it 'redirects to the updated Target' do
+        expect(subject).to redirect_to(admin_target_path(target_to_update))
+      end
+    end
+  end
+
   describe 'DELETE destroy' do
     let!(:target) { create(:target, discarded_at: nil) }
 

--- a/spec/factories/geographies.rb
+++ b/spec/factories/geographies.rb
@@ -21,7 +21,7 @@
 
 FactoryBot.define do
   factory :geography do
-    sequence(:name) { |n| 'name-' + ('AA'..'ZZ').to_a[n] }
+    sequence(:name) { |n| "name-#{('AA'..'ZZ').to_a[n]}" }
     sequence(:iso) { |n| ('AAA'..'ZZZ').to_a[n] }
 
     geography_type { 'national' }


### PR DESCRIPTION
#### Summary

* Adds public_activity page
* tracks `Company, Geography, Legislation, Litigation, Target` resources
* recognizes changes to `visibility_status`, deletes and all other "edits"
* only single updates for now (bulk updates skips callbacks)

![act200](https://user-images.githubusercontent.com/10665/69496753-a490d700-0ed5-11ea-99c2-c1adf562ab3b.png)
