### PR TITLE
setting up production deploy files for cap

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -7,9 +7,6 @@ set :repo_url, "https://github.com/Vizzuality/laws_and_pathways.git"
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
 
-# Default deploy_to directory is /var/www/my_app_name
-set :deploy_to, "/var/www/laws-pathways"
-
 # Default value for :format is :airbrussh.
 # set :format, :airbrussh
 

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -3,7 +3,6 @@ set :ssh_options, forward_agent: true
 
 set :branch, 'master'
 
-# Default deploy_to directory is /var/www/my_app_name
-set :deploy_to, '/var/www/laws-pathways'
+set :deploy_to, '/var/www/laws-pathways-production'
 
-# append :linked_files, 'config/secrets/google-credentials-staging.json'
+append :linked_files, 'config/secrets/google-credentials-staging.json'

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -4,6 +4,6 @@ set :ssh_options, forward_agent: true
 set :branch, 'master'
 
 # Default deploy_to directory is /var/www/my_app_name
-set :deploy_to, "/var/www/laws-pathways"
+set :deploy_to, '/var/www/laws-pathways'
 
 # append :linked_files, 'config/secrets/google-credentials-staging.json'

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,55 +1,9 @@
-# server-based syntax
-# ======================
-# Defines a single server with a list of roles and multiple properties.
-# You can define all roles on a single server, or split them:
+server '35.242.181.47', user: 'ubuntu', roles: %w{web app db}, primary: true
+set :ssh_options, forward_agent: true
 
-# server "example.com", user: "deploy", roles: %w{app db web}, my_property: :my_value
-# server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
-# server "db.example.com", user: "deploy", roles: %w{db}
+set :branch, 'master'
 
-# role-based syntax
-# ==================
+# Default deploy_to directory is /var/www/my_app_name
+set :deploy_to, "/var/www/laws-pathways"
 
-# Defines a role with one or multiple servers. The primary server in each
-# group is considered to be the first unless any hosts have the primary
-# property set. Specify the username and a domain or IP for the server.
-# Don't use `:all`, it's a meta role.
-
-# role :app, %w{deploy@example.com}, my_property: :my_value
-# role :web, %w{user1@primary.com user2@additional.com}, other_property: :other_value
-# role :db,  %w{deploy@example.com}
-
-# Configuration
-# =============
-# You can set any configuration variable like in config/deploy.rb
-# These variables are then only loaded and set in this stage.
-# For available Capistrano configuration variables see the documentation page.
-# http://capistranorb.com/documentation/getting-started/configuration/
-# Feel free to add new variables to customise your setup.
-
-# Custom SSH Options
-# ==================
-# You may pass any option but keep in mind that net/ssh understands a
-# limited set of options, consult the Net::SSH documentation.
-# http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start
-#
-# Global options
-# --------------
-#  set :ssh_options, {
-#    keys: %w(/home/rlisowski/.ssh/id_rsa),
-#    forward_agent: false,
-#    auth_methods: %w(password)
-#  }
-#
-# The server-based syntax can be used to override options:
-# ------------------------------------
-# server "example.com",
-#   user: "user_name",
-#   roles: %w{web app},
-#   ssh_options: {
-#     user: "user_name", # overrides user setting above
-#     keys: %w(/home/user_name/.ssh/id_rsa),
-#     forward_agent: false,
-#     auth_methods: %w(publickey password)
-#     # password: "please use keys"
-#   }
+# append :linked_files, 'config/secrets/google-credentials-staging.json'

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -3,7 +3,6 @@ set :ssh_options, forward_agent: true
 
 set :branch, 'develop'
 
-# Default deploy_to directory is /var/www/my_app_name
 set :deploy_to, '/var/www/laws-pathways-staging'
 
 append :linked_files, 'config/secrets/google-credentials-staging.json'

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -3,4 +3,7 @@ set :ssh_options, forward_agent: true
 
 set :branch, 'develop'
 
+# Default deploy_to directory is /var/www/my_app_name
+set :deploy_to, "/var/www/laws-pathways-staging"
+
 append :linked_files, 'config/secrets/google-credentials-staging.json'

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -4,6 +4,6 @@ set :ssh_options, forward_agent: true
 set :branch, 'develop'
 
 # Default deploy_to directory is /var/www/my_app_name
-set :deploy_to, "/var/www/laws-pathways-staging"
+set :deploy_to, '/var/www/laws-pathways-staging'
 
 append :linked_files, 'config/secrets/google-credentials-staging.json'


### PR DESCRIPTION
Would be great to get your help with this, @tiagojsag.

Currently we are using `laws-pathways` as a staging site and now I've got a new subdomain of `laws-pathways-staging.vizzuality.com`, should we start using the current site and database as production and create the apache2 conf and database for staging? We can purge the current database and load only the relevant data. What do you think is easiest?

- [ ] Setup apache2 conf;
- [ ] Create new database for new environment;
- [ ] Setup SSL certificate;