### PR TITLE
Feature/changes to companies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,9 @@ Layout/DotPosition:
 Naming/HeredocDelimiterNaming:
   Enabled: false
 
+Style/BracesAroundHashParameters:
+  EnforcedStyle: context_dependent
+
 Style/SymbolArray:
   EnforcedStyle: brackets
 

--- a/app/admin/companies.rb
+++ b/app/admin/companies.rb
@@ -10,15 +10,15 @@ ActiveAdmin.register Company do
   publishable_sidebar only: :show
 
   permit_params :name, :isin, :sector_id, :geography_id, :headquarters_geography_id,
-                :ca100, :size, :visibility_status
+                :ca100, :market_cap_group, :visibility_status
 
   filter :isin_contains, label: 'ISIN'
   filter :name_contains, label: 'Name'
   filter :geography
   filter :headquarters_geography
-  filter :size,
+  filter :market_cap_group,
          as: :check_boxes,
-         collection: proc { array_to_select_collection(Company::SIZES) }
+         collection: proc { array_to_select_collection(Company::MARKET_CAP_GROUPS) }
 
   data_export_sidebar 'Companies'
 
@@ -42,7 +42,7 @@ ActiveAdmin.register Company do
           row :geography
           row :headquarters_geography
           row :ca100
-          row :size
+          row :market_cap_group
           row 'Management Quality Level', &:mq_level_tag
           row :created_at
           row :updated_at
@@ -118,7 +118,7 @@ ActiveAdmin.register Company do
   index do
     column(:name) { |company| link_to company.name, admin_company_path(company) }
     column :isin, &:isin_as_tags
-    column(:size) { |company| company.size.humanize }
+    column(:market_cap_group) { |company| company.market_cap_group.humanize }
     column :level, &:mq_level_tag
     column :geography
     column :headquarters_geography
@@ -132,7 +132,7 @@ ActiveAdmin.register Company do
     column :name
     column :isin
     column(:sector) { |c| c.sector.name }
-    column :size
+    column :market_cap_group
     column(:geography_iso) { |c| c.geography.iso }
     column(:geography) { |c| c.geography.name }
     column(:headquarters_geography_iso) { |c| c.headquarters_geography.iso }
@@ -153,9 +153,9 @@ ActiveAdmin.register Company do
       columns do
         column { f.input :sector }
         column do
-          f.input :size,
+          f.input :market_cap_group,
                   as: :select,
-                  collection: array_to_select_collection(Company::SIZES)
+                  collection: array_to_select_collection(Company::MARKET_CAP_GROUPS)
         end
       end
 

--- a/app/admin/companies.rb
+++ b/app/admin/companies.rb
@@ -10,7 +10,8 @@ ActiveAdmin.register Company do
   publishable_sidebar only: :show
 
   permit_params :name, :isin, :sector_id, :geography_id, :headquarters_geography_id,
-                :ca100, :market_cap_group, :visibility_status
+                :ca100, :market_cap_group, :visibility_status, :sedol,
+                :latest_information, :historical_comments
 
   filter :isin_contains, label: 'ISIN'
   filter :name_contains, label: 'Name'
@@ -39,11 +40,14 @@ ActiveAdmin.register Company do
           row :slug
           row :sector
           row :isin, &:isin_as_tags
+          row :sedol
           row :geography
           row :headquarters_geography
           row :ca100
           row :market_cap_group
           row 'Management Quality Level', &:mq_level_tag
+          row :latest_information
+          row :historical_comments
           row :created_at
           row :updated_at
         end
@@ -133,10 +137,12 @@ ActiveAdmin.register Company do
     column :isin
     column(:sector) { |c| c.sector.name }
     column :market_cap_group
+    column :sedol
     column(:geography_iso) { |c| c.geography.iso }
     column(:geography) { |c| c.geography.name }
     column(:headquarters_geography_iso) { |c| c.headquarters_geography.iso }
     column(:headquarters_geography) { |c| c.headquarters_geography.name }
+    column :latest_information
     column :ca100
     column :visibility_status
   end
@@ -148,6 +154,7 @@ ActiveAdmin.register Company do
       columns do
         column { f.input :name }
         column { f.input :isin, as: :tags }
+        column { f.input :sedol }
       end
 
       columns do
@@ -168,6 +175,9 @@ ActiveAdmin.register Company do
       end
 
       f.input :ca100
+
+      f.input :latest_information
+      f.input :historical_comments
     end
 
     f.actions

--- a/app/javascript/components/BubbleChart.js
+++ b/app/javascript/components/BubbleChart.js
@@ -4,7 +4,7 @@ import legendImage from '../../assets/images/bubble-chart-legend.svg';
 import SingleBubbleChart from './SingleBubbleChart';
 import BaseTooltip from './BaseTooltip.js';
 
-const COMPANIES_SIZES = {
+const COMPANIES_MARKET_CAP_GROUPS = {
   large: 65,
   medium: 45,
   small: 30
@@ -65,7 +65,7 @@ const BubbleChart = (data) => {
         <div className="bubble-chart__legend">
           <img className="bubble-chart__legend-image" src={legendImage} />
           <div className="bubble-chart__legend-titles-container">
-            {Object.keys(COMPANIES_SIZES).map(companySize => (
+            {Object.keys(COMPANIES_MARKET_CAP_GROUPS).map(companySize => (
               <span className="bubble-chart__legend-title">{companySize}</span>
             ))}
           </div>
@@ -111,7 +111,7 @@ const createRow = (dataRow, title, sectors) => {
       </div>
       {dataRow.map((el, i) => {
         const companiesBubbles = el.map(company => ({
-          value: COMPANIES_SIZES[company.market_cap_group],
+          value: COMPANIES_MARKET_CAP_GROUPS[company.market_cap_group],
           tooltipContent: [company.name, `Level ${company.level}`],
           slug: company.slug,
           color: LEVELS_COLORS[i]

--- a/app/javascript/components/BubbleChart.js
+++ b/app/javascript/components/BubbleChart.js
@@ -111,7 +111,7 @@ const createRow = (dataRow, title, sectors) => {
       </div>
       {dataRow.map((el, i) => {
         const companiesBubbles = el.map(company => ({
-          value: COMPANIES_SIZES[company.size],
+          value: COMPANIES_SIZES[company.market_cap_group],
           tooltipContent: [company.name, `Level ${company.level}`],
           slug: company.slug,
           color: LEVELS_COLORS[i]

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -9,12 +9,15 @@
 #  name                      :string           not null
 #  slug                      :string           not null
 #  isin                      :string           not null
-#  size                      :string
+#  market_cap_group          :string
 #  ca100                     :boolean          default(FALSE), not null
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  visibility_status         :string           default("draft")
 #  discarded_at              :datetime
+#  sedol                     :integer
+#  latest_information        :text
+#  historical_comments       :text
 #
 
 class Company < ApplicationRecord

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -26,9 +26,9 @@ class Company < ApplicationRecord
   extend FriendlyId
   friendly_id :name, use: :slugged, routes: :default
 
-  SIZES = %w[small medium large].freeze
+  MARKET_CAP_GROUPS = %w[small medium large].freeze
 
-  enum size: array_to_enum_hash(SIZES)
+  enum market_cap_group: array_to_enum_hash(MARKET_CAP_GROUPS)
 
   belongs_to :sector, class_name: 'TPISector', foreign_key: 'sector_id'
   belongs_to :geography
@@ -45,7 +45,7 @@ class Company < ApplicationRecord
            to: :latest_mq_assessment, prefix: :mq, allow_nil: true
 
   validates :ca100, inclusion: {in: [true, false]}
-  validates_presence_of :name, :slug, :isin, :size
+  validates_presence_of :name, :slug, :isin, :market_cap_group
   validates_uniqueness_of :slug, :isin, :name
 
   def to_s

--- a/app/services/api/charts/sector.rb
+++ b/app/services/api/charts/sector.rb
@@ -45,12 +45,12 @@ module Api
       # @example
       #   {
       #    'Airlines' => {
-      #      '1' => [{ name: 'Air China', sector: 'Airlines', size: 'large', ... }],
-      #      '2' => [{ name: 'China Southern', sector: 'Airlines', size: 'large', ... }],
+      #      '1' => [{ name: 'Air China', sector: 'Airlines', market_cap_group: 'large', ... }],
+      #      '2' => [{ name: 'China Southern', sector: 'Airlines', market_cap_group: 'large', ... }],
       #    ]
       #    'Autos' => [
-      #      '1' => [{ name: 'Tesla', sector: 'Autos', size: 'large', ... }],
-      #      '3' => [{ name: 'BMW', sector: 'Airlines', size: 'large', ... }],
+      #      '1' => [{ name: 'Tesla', sector: 'Autos', market_cap_group: 'large', ... }],
+      #      '3' => [{ name: 'BMW', sector: 'Airlines', market_cap_group: 'large', ... }],
       #    ]
       #   }
       def companies_market_cap_by_sector
@@ -157,7 +157,7 @@ module Api
           {
             name: company.name,
             sector: company.sector.name,
-            size: company.size,
+            market_cap_group: company.market_cap_group,
             slug: company.slug,
             level4STAR: company.is_4_star?,
             level: company.mq_level.to_i.to_s

--- a/app/services/api/presenters/company.rb
+++ b/app/services/api/presenters/company.rb
@@ -10,7 +10,7 @@ module Api
           name: @company.name,
           country: @company.geography.name,
           sector: @company.sector.name,
-          market_cap: @company.size.titlecase,
+          market_cap: @company.market_cap_group.titlecase,
           isin: @company.isin,
           sedol: 60,
           ca100: @company.ca100 ? 'Yes' : 'No'

--- a/app/services/csv_import/companies.rb
+++ b/app/services/csv_import/companies.rb
@@ -40,7 +40,7 @@ module CSVImport
         name: row[:name],
         isin: row[:isin],
         sector: find_or_create_tpi_sector(row[:sector]),
-        size: row[:size],
+        market_cap_group: row[:market_cap_group],
         geography: geographies[row[:geography_iso]],
         headquarters_geography: geographies[row[:headquarters_geography_iso]],
         ca100: row[:ca100],

--- a/app/views/tpi/companies/show.html.erb
+++ b/app/views/tpi/companies/show.html.erb
@@ -47,7 +47,7 @@
             </div>
             <div class="column">
               <%= render 'company_property', name: 'Market cap (Group)', tooltip: t('.tooltips.market_cap') do %>
-                <%= @company.size %>
+                <%= @company.market_cap_group %>
               <% end %>
             </div>
             <div class="column">

--- a/db/migrate/20191120162650_make_changes_to_companies_table.rb
+++ b/db/migrate/20191120162650_make_changes_to_companies_table.rb
@@ -1,0 +1,8 @@
+class MakeChangesToCompaniesTable < ActiveRecord::Migration[6.0]
+  def change
+    add_column :companies, :sedol, :integer
+    add_column :companies, :latest_information, :text
+    add_column :companies, :historical_comments, :text
+    rename_column :companies, :size, :market_cap_group
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_20_152618) do
+ActiveRecord::Schema.define(version: 2019_11_20_162650) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,18 +71,21 @@ ActiveRecord::Schema.define(version: 2019_11_20_152618) do
     t.string "name", null: false
     t.string "slug", null: false
     t.string "isin", null: false
-    t.string "size"
+    t.string "market_cap_group"
     t.boolean "ca100", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "visibility_status", default: "draft"
     t.datetime "discarded_at"
+    t.integer "sedol"
+    t.text "latest_information"
+    t.text "historical_comments"
     t.index ["discarded_at"], name: "index_companies_on_discarded_at"
     t.index ["geography_id"], name: "index_companies_on_geography_id"
     t.index ["headquarters_geography_id"], name: "index_companies_on_headquarters_geography_id"
     t.index ["isin"], name: "index_companies_on_isin", unique: true
+    t.index ["market_cap_group"], name: "index_companies_on_market_cap_group"
     t.index ["sector_id"], name: "index_companies_on_sector_id"
-    t.index ["size"], name: "index_companies_on_size"
     t.index ["slug"], name: "index_companies_on_slug", unique: true
   end
 

--- a/db/seeds/companies.csv
+++ b/db/seeds/companies.csv
@@ -1,4 +1,4 @@
-Id,Name,ISIN,Sector,Size,Geography iso,Headquarters geography iso,CA100,Visibility status
+Id,Name,ISIN,Sector,Market cap group,Geography iso,Headquarters geography iso,CA100,Visibility status
 ,AES,US00130H1059,Electricity Utilities,medium,USA,USA,false,published
 ,AGL Energy,AU000000AGL7,Electricity Utilities,large,AUS,AUS,false,published
 ,ANA Holdings,JP3429800000,Airlines,large,JPN,JPN,false,published

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -9,12 +9,15 @@
 #  name                      :string           not null
 #  slug                      :string           not null
 #  isin                      :string           not null
-#  size                      :string
+#  market_cap_group          :string
 #  ca100                     :boolean          default(FALSE), not null
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  visibility_status         :string           default("draft")
 #  discarded_at              :datetime
+#  sedol                     :integer
+#  latest_information        :text
+#  historical_comments       :text
 #
 
 FactoryBot.define do

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -30,7 +30,7 @@ FactoryBot.define do
     isin { SecureRandom.uuid }
 
     ca100 { true }
-    size { Company::SIZES.sample }
+    market_cap_group { Company::MARKET_CAP_GROUPS.sample }
     visibility_status { Litigation::VISIBILITY.sample }
 
     trait :with_mq_assessments do

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -33,6 +33,9 @@ FactoryBot.define do
     market_cap_group { Company::MARKET_CAP_GROUPS.sample }
     visibility_status { Litigation::VISIBILITY.sample }
 
+    latest_information { 'My information' }
+    historical_comments { 'I changed my name last week' }
+
     trait :with_mq_assessments do
       after(:create) do |c|
         create :mq_assessment, company: c, assessment_date: 1.year.ago

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: tags
+#
+#  id         :bigint           not null, primary key
+#  name       :string           not null
+#  type       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 FactoryBot.define do
   factory :keyword do
     type { 'Keyword' }

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -9,12 +9,15 @@
 #  name                      :string           not null
 #  slug                      :string           not null
 #  isin                      :string           not null
-#  size                      :string
+#  market_cap_group          :string
 #  ca100                     :boolean          default(FALSE), not null
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  visibility_status         :string           default("draft")
 #  discarded_at              :datetime
+#  sedol                     :integer
+#  latest_information        :text
+#  historical_comments       :text
 #
 
 require 'rails_helper'

--- a/spec/services/api/charts/cp_benchmark_spec.rb
+++ b/spec/services/api/charts/cp_benchmark_spec.rb
@@ -91,17 +91,15 @@ RSpec.describe Api::Charts::CPBenchmark do
         end
 
         it 'returns chart data' do
-          expect(subject.cp_performance_data).to eq(
-            [
-              {
-                name: scenario_2,
-                data: [[sector.name, 2]]
-              },
-              {
-                name: scenario_1,
-                data: [[sector.name, 2]]
-              }
-            ]
+          expect(subject.cp_performance_data).to contain_exactly(
+            {
+              name: scenario_2,
+              data: [[sector.name, 2]]
+            },
+            {
+              name: scenario_1,
+              data: [[sector.name, 2]]
+            }
           )
         end
       end

--- a/spec/services/api/charts/sector_spec.rb
+++ b/spec/services/api/charts/sector_spec.rb
@@ -70,19 +70,17 @@ RSpec.describe Api::Charts::Sector do
     end
 
     it 'returns companies emissions' do
-      expect(subject.companies_emissions_data).to eq(
-        [
-          {
-            data: {'2017' => 90.0, '2018' => 120.0, '2019' => 110.0},
-            lineWidth: 4,
-            name: company.name
-          },
-          {
-            data: {'2017' => 190.0, '2018' => 220.0, '2019' => 90.0},
-            lineWidth: 4,
-            name: company2.name
-          }
-        ]
+      expect(subject.companies_emissions_data).to contain_exactly(
+        {
+          data: {'2017' => 90.0, '2018' => 120.0, '2019' => 110.0},
+          lineWidth: 4,
+          name: company.name
+        },
+        {
+          data: {'2017' => 190.0, '2018' => 220.0, '2019' => 90.0},
+          lineWidth: 4,
+          name: company2.name
+        }
       )
     end
   end

--- a/spec/services/api/charts/sector_spec.rb
+++ b/spec/services/api/charts/sector_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Api::Charts::Sector do
               name: company.name,
               slug: company.slug,
               sector: company.sector.name,
-              size: company.size,
+              market_cap_group: company.market_cap_group,
               level: company.mq_level.to_i.to_s,
               level4STAR: false
             }
@@ -116,7 +116,7 @@ RSpec.describe Api::Charts::Sector do
               name: company2.name,
               slug: company2.slug,
               sector: company2.sector.name,
-              size: company2.size,
+              market_cap_group: company2.market_cap_group,
               level: company2.mq_level.to_i.to_s,
               level4STAR: true
             }

--- a/spec/support/fixtures/files/companies.csv
+++ b/spec/support/fixtures/files/companies.csv
@@ -1,4 +1,4 @@
-"Id","Name","ISIN","Sector id","Sector","Size","Geography iso","Geography","Headquarters geography iso","Headquarters geography","CA100","Visibility status"
+"Id","Name","ISIN","Sector id","Sector","Market Cap Group","Geography iso","Geography","Headquarters geography iso","Headquarters geography","CA100","Visibility status"
 "69","Consol Energy","US20854P1093","2","Coal Mining","small","USA","United States of America","USA","United States of America","true","published"
 "74","Daio Paper","JP3440400004,23783837783","14","Paper","small","JPN","Japan","JPN","Japan","false","draft"
 "81","Domtar","US2575592033","14","Paper","small","USA","United States of America","USA","United States of America","false","draft"


### PR DESCRIPTION
This PR makes some updates to the companies tables:

- renames `size` to `market_cap_group`, and updates everywhere (I hope accordingly);
- adds `sedol`, `latest_information` and `historical_comments` to the companies table.

The specs locally are a failing sometimes :/ but I don't know exactly why... in particular this: `bundle exec rspec spec/services/api/charts/cp_benchmark_spec.rb:15`. It seems that the result is not in the right order, but I don't know why. Can one of you (Tomasz or Marek) check it out if you know? =) Or is it for Marta? 