### PR TITLE
Search through correct keys - laws search dropdown

### DIFF
--- a/app/javascript/components/LawsDropdown.js
+++ b/app/javascript/components/LawsDropdown.js
@@ -58,10 +58,10 @@ const LawsDropdown = ({ geographies, lawsAndPolicies, litigations, targets, rece
   }
 
   // SEARCH RESULTS for each category
-  const searchGeographiesResults = useMemo(() => searchValue ? fuse(geographies, ['name']) : [], [searchValue]);
-  const searchLawsResults = useMemo(() => searchValue ? fuse(lawsAndPolicies, ['name', 'geography_name']) : [], [searchValue]);
-  const searchLitigationsResults = useMemo(() => searchValue ? fuse(litigations, ['name', 'jurisdiction_name']) : [], [searchValue]);
-  const searchTargetsResults = useMemo(() => searchValue ? fuse(targets, ['name', 'geography_name']) : [], [searchValue]);
+  const searchGeographiesResults = useMemo(() => searchValue ? fuse(geographies, ['name', 'region', 'legislative_process']) : [], [searchValue]);
+  const searchLawsResults = useMemo(() => searchValue ? fuse(lawsAndPolicies, ['title', 'description', 'geography_name']) : [], [searchValue]);
+  const searchLitigationsResults = useMemo(() => searchValue ? fuse(litigations, ['title', 'summary', 'jurisdiction_name']) : [], [searchValue]);
+  const searchTargetsResults = useMemo(() => searchValue ? fuse(targets, ['description', 'target_type', 'geography_name']) : [], [searchValue]);
   // end of search results
 
   const allSearchResults = [...searchGeographiesResults, ...searchLawsResults, ...searchLitigationsResults, ...searchTargetsResults];


### PR DESCRIPTION
The second argument that we pass to `fuse` function is the keys that it should look through for the search key - add the correct keys for laws, litigation and target records.

![image](https://user-images.githubusercontent.com/6136899/69443425-44b7f600-0d46-11ea-90f9-da4d43ea25cd.png)
