### PR TITLE
Tpi/frontend tweaks

### DIFF
--- a/app/admin/companies.rb
+++ b/app/admin/companies.rb
@@ -16,6 +16,7 @@ ActiveAdmin.register Company do
   filter :isin_contains, label: 'ISIN'
   filter :name_contains, label: 'Name'
   filter :geography
+  filter :sector
   filter :headquarters_geography
   filter :market_cap_group,
          as: :check_boxes,
@@ -121,6 +122,7 @@ ActiveAdmin.register Company do
 
   index do
     column(:name) { |company| link_to company.name, admin_company_path(company) }
+    column :sector
     column :isin, &:isin_as_tags
     column(:market_cap_group) { |company| company.market_cap_group.humanize }
     column :level, &:mq_level_tag
@@ -187,6 +189,7 @@ ActiveAdmin.register Company do
     def scoped_collection
       super.includes(
         :geography,
+        :sector,
         :headquarters_geography,
         :latest_mq_assessment,
         *csv_includes

--- a/app/assets/stylesheets/tpi/_charts.scss
+++ b/app/assets/stylesheets/tpi/_charts.scss
@@ -3,6 +3,18 @@
   flex-flow: row wrap;
   justify-content: center;
   position: relative;
+
+  &--mq-sector-pie-chart {
+    .chart-title {
+      font-family: $font-family-regular;
+      font-size: 16px;
+
+      .companies-size {
+        font-size: 36px;
+        font-family: $font-family-bold;
+      }
+    }
+  }
 }
 
 .chart-title {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,8 @@
 module ApplicationHelper
+  def humanize_boolean(value)
+    value ? 'Yes' : 'No'
+  end
+
   def render_breadcrumb
     return unless defined?(@breadcrumb)
 

--- a/app/helpers/chart_helper.rb
+++ b/app/helpers/chart_helper.rb
@@ -3,6 +3,9 @@ module ChartHelper
   # defaults chart options (Highcharts)
   def default_chart_options
     {
+      colors: [
+        '#00C170', '#ED3D4A', '#FFDD49', '#440388', '#FF9600', '#B75038', '#00A8FF', '#F78FB3', '#191919', '#F602B4'
+      ],
       legend: {
         verticalAlign: 'top'
       },
@@ -22,6 +25,7 @@ module ChartHelper
 
   def mq_sector_pie_chart_options
     {
+      colors: ['#86A9F9', '#5587F7', '#2465F5', '#0A4BDC', '#083AAB'],
       tooltip: {
         enabled: false
       },
@@ -30,6 +34,35 @@ module ChartHelper
           dataLabels: {
             format: 'Level {point.name} <br> {point.y} companies <br> {point.percentage:.1f}%'
           }
+        }
+      }
+    }
+  end
+
+  def cp_all_sectors_chart_options
+    {
+      colors: [
+        '#00C170', '#ED3D4A', '#FFDD49', '#191919', '#FF9600', '#B75038', '#00A8FF', '#F78FB3', '#F602B4', '#440388'
+      ],
+      legend: {
+        align: 'left',
+        verticalAlign: 'top',
+        margin: 50
+      },
+      plotOptions: {
+        area: {
+          fillOpacity: 0.3,
+          marker: {
+            enabled: false
+          }
+        },
+        column: {
+          stacking: 'percent'
+        }
+      },
+      yAxis: {
+        labels: {
+          format: '{value}%' # does not work!
         }
       }
     }

--- a/app/views/tpi/companies/show.html.erb
+++ b/app/views/tpi/companies/show.html.erb
@@ -57,12 +57,12 @@
             </div>
             <div class="column">
               <%= render 'company_property', name: 'SEDOL', tooltip: t('.tooltips.SEDOL') do %>
-                Don't have that
+                <%= @company.sedol %>
               <% end %>
             </div>
             <div class="column">
               <%= render 'company_property', name: 'CA100+ engagement', tooltip: t('.tooltips.CA100') do %>
-                <%= @company.ca100? ? 'Yes' : 'No' %>
+                <%= humanize_boolean(@company.ca100?) %>
               <% end %>
             </div>
           </div>

--- a/app/views/tpi/sectors/index.html.erb
+++ b/app/views/tpi/sectors/index.html.erb
@@ -2,7 +2,7 @@
   <div class="dropdown-selector-sector-page-wrapper">
     <%= react_component("DropdownSelector", { sectors: @sectors, companies: @companies, selectedOption: 'All sectors' }) %>
   </div>
-  
+
 
   <div class="sectors-header">
     <div class="container">
@@ -26,9 +26,10 @@
 
     <p>Distribution of companies in All sectors according to the management of their greenhouse gas emissions and of risks and opportunities to the low-carbon transition.</p>
 
-    <div class="chart">
+    <div class="chart chart--mq-sector-pie-chart">
       <%= pie_chart(
         levels_chart_data_tpi_sectors_path,
+        height: '400px',
         donut: true,
         library: mq_sector_pie_chart_options
         ) %>
@@ -46,12 +47,13 @@
 
     <p>CP alignment with the Paris agreement benchmarks by sector and cluster (number and % of companies). Please note that this information is not available for all sectors.</p>
 
-    <div class="chart">
+    <div class="chart chart--cp-all-sectors">
       <%= column_chart(
         benchmarks_chart_data_tpi_sectors_path,
         stacked: true,
-        width: '1200px',
-        library: default_chart_options
+        width: '100%',
+        height: '600px',
+        library: cp_all_sectors_chart_options
         ) %>
     </div>
   </section>

--- a/app/views/tpi/sectors/show.html.erb
+++ b/app/views/tpi/sectors/show.html.erb
@@ -29,9 +29,14 @@
     <div class="chart chart--mq-sector-pie-chart">
       <%= pie_chart(
         levels_chart_data_tpi_sector_path(@sector.id),
+        height: '400px',
         donut: true,
         library: mq_sector_pie_chart_options
         ) %>
+      <div class="chart-title">
+        <p class="companies-size"><%= @sector_companies.size %></p>
+        companies
+      </div>
     </div>
 
     <div class="sector-level-overview columns">

--- a/app/views/tpi/sectors/show.html.erb
+++ b/app/views/tpi/sectors/show.html.erb
@@ -2,7 +2,7 @@
   <div class="dropdown-selector-sector-page-wrapper">
     <%= react_component("DropdownSelector", { sectors: @sectors, companies: @companies, selectedOption: @sector.name }) %>
   </div>
-  <div class="sectors-header">    
+  <div class="sectors-header">
     <div class="container">
       <a href="#management-quality" class="link with-icon is-pulled-left">
         <img src="<%= asset_path 'icons/arrow-down.svg'%>" />
@@ -26,7 +26,7 @@
       Distribution of companies in the <strong><%= @sector.name %></strong> sector according to the management of their greenhouse gas emissions and of risks and opportunities related to the low-carbon transition.
     </p>
 
-    <div class="chart">
+    <div class="chart chart--mq-sector-pie-chart">
       <%= pie_chart(
         levels_chart_data_tpi_sector_path(@sector.id),
         donut: true,

--- a/db/migrate/20191126085901_change_column_sedol_companies.rb
+++ b/db/migrate/20191126085901_change_column_sedol_companies.rb
@@ -1,0 +1,5 @@
+class ChangeColumnSedolCompanies < ActiveRecord::Migration[6.0]
+  def change
+    change_column :companies, :sedol, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_22_133323) do
+ActiveRecord::Schema.define(version: 2019_11_26_085901) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,7 +96,7 @@ ActiveRecord::Schema.define(version: 2019_11_22_133323) do
     t.datetime "updated_at", null: false
     t.string "visibility_status", default: "draft"
     t.datetime "discarded_at"
-    t.integer "sedol"
+    t.string "sedol"
     t.text "latest_information"
     t.text "historical_comments"
     t.index ["discarded_at"], name: "index_companies_on_discarded_at"


### PR DESCRIPTION
Couple tweaks

- Adding sector to AA company index page
- changing colors and a few styles for pie charts
- missing companies number for sector's pie chart of levels
- changing colors for stacked bar chart, sectors cp benchmarks
- changing colors, xAxis interval, yAxis title placement for MQ assessment company level chart
- add Sedol to frontend (companies have 0 as this number, could be bug with import script @simaob)

Tweaking charts is a slow process, highcharts are the most customizable charts I've ever seen, milion options, just finding the one takes time.

CP assessment chart left intact, I couldn't find a good way to make those areas look as on designs yet.