### PR TITLE
Add menu attribute for placing the static pages in the Menu on FE

### DIFF
--- a/app/admin/page.rb
+++ b/app/admin/page.rb
@@ -14,8 +14,8 @@ ActiveAdmin.register Page do
   filter :slug
 
   index do
+    column :title, &:title_link
     column :slug
-    column :title
     column :menu
     actions
   end
@@ -24,8 +24,8 @@ ActiveAdmin.register Page do
     tabs do
       tab :details do
         attributes_table do
-          row :slug
           row :title
+          row :slug
           row :menu
           row :description
         end

--- a/app/admin/page.rb
+++ b/app/admin/page.rb
@@ -5,7 +5,7 @@ ActiveAdmin.register Page do
 
   menu priority: 6, parent: 'TPI'
 
-  permit_params :title, :slug, :description,
+  permit_params :title, :slug, :description, :menu,
                 contents_attributes: [:id, :title, :content_type, :text, :_destroy,
                                       images_attributes: [:id, :link, :logo, :_destroy]],
                 content_ids: []
@@ -16,6 +16,7 @@ ActiveAdmin.register Page do
   index do
     column :slug
     column :title
+    column :menu
     actions
   end
 
@@ -25,6 +26,7 @@ ActiveAdmin.register Page do
         attributes_table do
           row :slug
           row :title
+          row :menu
           row :description
         end
       end

--- a/app/controllers/concerns/tpi/static_pages_controller.rb
+++ b/app/controllers/concerns/tpi/static_pages_controller.rb
@@ -3,12 +3,12 @@ module TPI
     extend ActiveSupport::Concern
 
     included do
-      before_action :get_pages
+      before_action :static_pages
     end
 
-    def get_pages
-      @tpi_tool_pages = Page.where(menu: "tpi_tool")
-      @about_pages = Page.where(menu: "about")
+    def static_pages
+      @tpi_tool_pages = Page.where(menu: 'tpi_tool')
+      @about_pages = Page.where(menu: 'about')
     end
   end
 end

--- a/app/controllers/concerns/tpi/static_pages_controller.rb
+++ b/app/controllers/concerns/tpi/static_pages_controller.rb
@@ -1,0 +1,14 @@
+module TPI
+  module StaticPagesController
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :get_pages
+    end
+
+    def get_pages
+      @tpi_tool_pages = Page.where(menu: "tpi_tool")
+      @about_pages = Page.where(menu: "about")
+    end
+  end
+end

--- a/app/controllers/tpi/tpi_controller.rb
+++ b/app/controllers/tpi/tpi_controller.rb
@@ -1,7 +1,7 @@
 module TPI
   class TPIController < ApplicationController
     include StaticPagesController
-    
+
     layout 'tpi'
   end
 end

--- a/app/controllers/tpi/tpi_controller.rb
+++ b/app/controllers/tpi/tpi_controller.rb
@@ -1,5 +1,7 @@
 module TPI
   class TPIController < ApplicationController
+    include StaticPagesController
+    
     layout 'tpi'
   end
 end

--- a/app/decorators/page_decorator.rb
+++ b/app/decorators/page_decorator.rb
@@ -1,6 +1,10 @@
 class PageDecorator < Draper::Decorator
   delegate_all
 
+  def title_link
+    h.link_to model.title, h.admin_page_path(model)
+  end
+
   def description
     model.description.html_safe
   end

--- a/app/javascript/admin/controllers/nested_list_controller.js
+++ b/app/javascript/admin/controllers/nested_list_controller.js
@@ -9,18 +9,10 @@ export default class extends Controller {
 
   addRecord(event) {
     const templateName = event.target.dataset['template'];
+    const newRecordRegex = new RegExp(this.newRecordId, 'g');
     const content = this._getTemplateElement(templateName)
                         .innerHTML
-                        .replace(/NEW_RECORD/g, new Date().getTime());
-
-    this._manipulateDOM(content);
-  }
-
-  addNestedRecord(event) {
-    const templateName = event.target.dataset['template'];
-    const content = this._getTemplateElement(templateName)
-                        .innerHTML
-                        .replace(/NEW_IMAGE_RECORD/g, new Date().getTime());
+                        .replace(newRecordRegex, new Date().getTime());
 
     this._manipulateDOM(content);
   }
@@ -53,5 +45,9 @@ export default class extends Controller {
     // very nasty trick, using dynamic list instead of AA has_many forms
     // many plugins listen to this event to reinitialize, for example select2 from activeadmin addons
     document.dispatchEvent(new Event('has_many_add:after'));
+  }
+
+  get newRecordId() {
+    return this.element.dataset['newRecordId'] || 'NEW_RECORD';
   }
 }

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -2,8 +2,16 @@ class Page < ApplicationRecord
   has_many :contents, dependent: :destroy
   has_many :images, through: :contents
 
+  MENU_HEADERS = %w[
+    tpi_tool
+    about
+  ].freeze
+
   validates :slug, uniqueness: true, presence: true
   validates :title, presence: true
+  validates :menu, presence: true
+
+  enum menu: array_to_enum_hash(MENU_HEADERS)
 
   with_options allow_destroy: true, reject_if: :all_blank do
     accepts_nested_attributes_for :contents, allow_destroy: true

--- a/app/views/admin/pages/_form.html.erb
+++ b/app/views/admin/pages/_form.html.erb
@@ -15,6 +15,7 @@
         <%= f.inputs do %>
           <%= f.input :slug %>
           <%= f.input :title %>
+          <%= f.input :menu, as: :select, collection: array_to_select_collection(Page::MENU_HEADERS) %>
           <%= f.input :description, as: :trix %>
         <% end %>
       </div>

--- a/app/views/admin/pages/_image.html.erb
+++ b/app/views/admin/pages/_image.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="nested-list">
+<div data-controller="nested-list" data-new-record-id="NEW_IMAGE_RECORD">
   <template>
     <%= form.semantic_fields_for :images, Image.new, child_index: 'NEW_IMAGE_RECORD' do |image| %>
       <%= render "image_fields", form: image %>
@@ -10,6 +10,6 @@
   <% end %>
 
   <div class="nested-list__actions" data-target="nested-list.links">
-    <%= button_tag "Add Image", type: 'button', class: 'button button--raised', data: { action: "click->nested-list#addNestedRecord" } %>
+    <%= button_tag "Add Image", type: 'button', class: 'button button--raised', data: { action: "click->nested-list#addRecord" } %>
   </div>
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -18,12 +18,11 @@
 
             <div class="navbar-dropdown">
               <%= link_to 'TPI tool', tpi_sectors_path, class: 'navbar-item' %>
-              <a class="navbar-item">
-                Methodology
-              </a>
-              <a class="navbar-item">
-                Data background
-              </a>
+              <% @tpi_tool_pages.each do |page| %>
+                <a href="/tpi/<%= page.slug %>" class="navbar-item">
+                  <%= page.title %>
+                </a>
+              <% end %>
             </div>
           </div>
 
@@ -37,27 +36,11 @@
             </a>
 
             <div class="navbar-dropdown">
-              <a class="navbar-item">
-                Overview of the TPI
-              </a>
-              <a class="navbar-item">
-                Partners
-              </a>
-              <a class="navbar-item">
-                Technical advisory
-              </a>
-              <a class="navbar-item">
-                Supporters
-              </a>
-              <a class="navbar-item">
-                Investors
-              </a>
-              <a class="navbar-item">
-                Endorsements
-              </a>
-              <a class="navbar-item">
-                FAQ
-              </a>
+              <% @about_pages.each do |page| %>
+                <a href="/tpi/<%= page.slug %>" class="navbar-item">
+                  <%= page.title %>
+                </a>
+              <% end %>
               <!-- <hr class="navbar-divider"> -->
             </div>
           </div>

--- a/db/migrate/20191128144950_add_menu_to_pages.rb
+++ b/db/migrate/20191128144950_add_menu_to_pages.rb
@@ -1,0 +1,5 @@
+class AddMenuToPages < ActiveRecord::Migration[6.0]
+  def change
+    add_column :pages, :menu, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_26_123014) do
+ActiveRecord::Schema.define(version: 2019_11_28_144950) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -382,11 +382,7 @@ ActiveRecord::Schema.define(version: 2019_11_26_123014) do
     t.string "slug"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-  end
-
-  create_table "publications", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "menu"
   end
 
   create_table "taggings", force: :cascade do |t|

--- a/lib/tasks/static_pages.rake
+++ b/lib/tasks/static_pages.rake
@@ -1,29 +1,32 @@
 namespace :static_pages do
   desc 'Scaffold static pages'
   task generate: :environment do
+    MENU_HEADERS = OpenStruct.new(Hash[Page::MENU_HEADERS.map { |el| [el, el] }])
+    
     pages = [
-      ['overview', 'Overview of the TPI'],
-      ['strategic-relationships', 'Strategic Relationships'],
-      ['technical-advisory-group', 'Technical Advisory Group'],
-      %w[supporters Supporters],
-      ['investors', 'How Investors can use TPI'],
-      %w[endorsements Endorsements],
-      %w[team Team],
-      %w[faq FAQ],
-      %w[methodology Methodology],
-      ['data-background', 'Data Background']
+      ['overview', 'Overview of the TPI', MENU_HEADERS.about],
+      ['strategic-relationships', 'Strategic Relationships', MENU_HEADERS.about],
+      ['technical-advisory-group', 'Technical Advisory Group', MENU_HEADERS.about],
+      ['supporters', 'Supporters', MENU_HEADERS.about],
+      ['investors', 'How Investors can use TPI', MENU_HEADERS.about],
+      ['endorsements', 'Endorsements', MENU_HEADERS.about],
+      ['team', 'Team', MENU_HEADERS.about],
+      ['faq', 'FAQ', MENU_HEADERS.about],
+      ['methodology', 'Methodology', MENU_HEADERS.tpi_tool],
+      ['data-background', 'Data Background', MENU_HEADERS.tpi_tool]
     ]
 
     supporters_content = %w(partners supporters)
 
-    pages.each do |slug, title|
+    pages.each do |slug, title, menu_header|
       next if Page.find_by(slug: slug)
 
       puts "Creating page: #{slug}"
       Page.create(
         slug: slug,
         title: title,
-        description: "#{title} Description goes here"
+        description: "#{title} Description goes here",
+        menu: menu_header
       )
     end
 

--- a/lib/tasks/static_pages.rake
+++ b/lib/tasks/static_pages.rake
@@ -2,7 +2,7 @@ namespace :static_pages do
   desc 'Scaffold static pages'
   task generate: :environment do
     MENU_HEADERS = OpenStruct.new(Hash[Page::MENU_HEADERS.map { |el| [el, el] }])
-    
+
     pages = [
       ['overview', 'Overview of the TPI', MENU_HEADERS.about],
       ['strategic-relationships', 'Strategic Relationships', MENU_HEADERS.about],


### PR DESCRIPTION
This PR adds a migration for adding `menu` attribute to the `Page` model. It also changes the form && show && index partials in the Admin panel to include that attribute. This allows us to know in which menu header we need to place the static pages links. The links are now added to the menu header.

I also changed the rake task to include known menu headers in scaffolding. So, we're gonna need to destroy the Pages if we already created them on staging and run the task again.