### PR TITLE
Feature/tpi charts last reported year

### DIFF
--- a/app/admin/companies.rb
+++ b/app/admin/companies.rb
@@ -92,7 +92,9 @@ ActiveAdmin.register Company do
                 attributes_table_for a do
                   row :publication_date
                   row :assessment_date
+                  row :cp_alignment
                   row :assumptions
+                  row :last_reported_year
                 end
 
                 render 'admin/cp/emissions_table', emissions: a.emissions

--- a/app/assets/stylesheets/tpi/_charts.scss
+++ b/app/assets/stylesheets/tpi/_charts.scss
@@ -77,6 +77,41 @@ $tpi-pie-chart-colors: #86A9F9 #5587F7 #2465F5 #0A4BDC #083AAB;
     @import "highcharts/css/highcharts";
   }
 
+  &--cp-emissions {
+    margin-top: 10px;
+    justify-content: unset;
+
+    .legend {
+      display: flex;
+
+      .legend-item {
+        display: flex;
+        align-items: center;
+        margin-right: 20px;
+        font-size: 12px;
+
+        &::before {
+          content: '';
+          display: block;
+          width: 40px;
+          margin-right: 10px;
+        }
+
+        &--reported {
+          &::before {
+            border-bottom: 4px solid black;
+          }
+        }
+
+        &--targeted {
+          &::before {
+            border-bottom: 4px dotted black;
+          }
+        }
+      }
+    }
+  }
+
   &--mq-sector-pie-chart {
     @for $i from 1 through length($tpi-pie-chart-colors) {
       $color: nth($tpi-pie-chart-colors, $i);

--- a/app/helpers/chart_helper.rb
+++ b/app/helpers/chart_helper.rb
@@ -74,13 +74,17 @@ module ChartHelper
     }
   end
 
-  def cp_chart_options
+  def cp_chart_options(unit)
     {
+      # chart: {
+      #   spacingTop: 50
+      # },
       colors: [
         '#00C170', '#ED3D4A', '#FFDD49', '#440388', '#FF9600', '#B75038', '#00A8FF', '#F78FB3', '#191919', '#F602B4'
       ],
       legend: {
-        verticalAlign: 'top'
+        verticalAlign: 'top',
+        margin: 50
       },
       plotOptions: {
         area: {
@@ -99,6 +103,17 @@ module ChartHelper
         },
         series: {
           lineWidth: 4
+        }
+      },
+      yAxis: {
+        title: {
+          text: unit,
+          reserveSpace: false,
+          textAlign: 'left',
+          align: 'high',
+          rotation: 0,
+          x: 0,
+          y: -20
         }
       }
     }

--- a/app/helpers/chart_helper.rb
+++ b/app/helpers/chart_helper.rb
@@ -76,9 +76,6 @@ module ChartHelper
 
   def cp_chart_options(unit)
     {
-      # chart: {
-      #   spacingTop: 50
-      # },
       colors: [
         '#00C170', '#ED3D4A', '#FFDD49', '#440388', '#FF9600', '#B75038', '#00A8FF', '#F78FB3', '#191919', '#F602B4'
       ],

--- a/app/helpers/chart_helper.rb
+++ b/app/helpers/chart_helper.rb
@@ -89,8 +89,16 @@ module ChartHelper
             enabled: false
           }
         },
+        line: {
+          marker: {
+            enabled: false
+          }
+        },
         column: {
           stacking: 'normal'
+        },
+        series: {
+          lineWidth: 4
         }
       }
     }

--- a/app/services/api/charts/cp_assessment.rb
+++ b/app/services/api/charts/cp_assessment.rb
@@ -42,7 +42,13 @@ module Api
       def emissions_data_from_company
         {
           name: company.name,
-          data: assessment&.emissions&.transform_keys(&:to_i)
+          data: assessment&.emissions&.transform_keys(&:to_i),
+          zoneAxis: 'x',
+          zones: [{
+            value: assessment.last_reported_year&.to_i
+          }, {
+            dashStyle: 'dot'
+          }]
         }
       end
 

--- a/app/services/api/charts/sector.rb
+++ b/app/services/api/charts/sector.rb
@@ -141,10 +141,17 @@ module Api
       end
 
       def emissions_data_from_company(company)
+        assessment = company.latest_cp_assessment
+
         {
           name: company.name,
-          data: company.latest_cp_assessment&.emissions&.transform_keys(&:to_i),
-          lineWidth: 4
+          data: assessment&.emissions&.transform_keys(&:to_i),
+          zoneAxis: 'x',
+          zones: [{
+            value: assessment&.last_reported_year&.to_i
+          }, {
+            dashStyle: 'dot'
+          }]
         }
       end
 

--- a/app/views/tpi/companies/_cp_assessment.html.erb
+++ b/app/views/tpi/companies/_cp_assessment.html.erb
@@ -5,7 +5,7 @@
     curve: false,
     width: '100%',
     height: '600px',
-    library: cp_chart_options
+    library: cp_chart_options(assessment.company.sector.cp_unit)
     )%>
 </div>
 

--- a/app/views/tpi/companies/_cp_assessment.html.erb
+++ b/app/views/tpi/companies/_cp_assessment.html.erb
@@ -1,4 +1,9 @@
-<div class="chart">
+<div class="chart chart--cp-emissions">
+  <div class="legend">
+    <span class="legend-item legend-item--reported">Reported</span>
+    <span class="legend-item legend-item--targeted">Targeted</span>
+  </div>
+
   <%= line_chart(
     emissions_chart_data_tpi_company_path(assessment.company, cp_assessment_id: assessment.id),
     id: 'cp_assessment_chart',

--- a/app/views/tpi/sectors/show.html.erb
+++ b/app/views/tpi/sectors/show.html.erb
@@ -77,7 +77,7 @@
         width: '1200px',
         height: '800px',
         curve: false,
-        library: cp_chart_options
+        library: cp_chart_options(@sector.cp_unit)
         )%>
     </div>
   </section>

--- a/app/views/tpi/sectors/show.html.erb
+++ b/app/views/tpi/sectors/show.html.erb
@@ -71,7 +71,12 @@
 
   <section id="carbon-performance" class="container">
     <h4>Carbon Performance: <%= @sector.name %></h4>
-    <div class="chart">
+    <div class="chart chart--cp-emissions">
+      <div class="legend">
+        <span class="legend-item legend-item--reported">Reported</span>
+        <span class="legend-item legend-item--targeted">Targeted</span>
+      </div>
+
       <%= line_chart(
         emissions_chart_data_tpi_sector_path(@sector.id),
         width: '1200px',

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,8 +24,9 @@ end
   ['Services'],
   ['Steel', 'Carbon intensity (tonnes of CO2 per tonne of steel)']
 ].each do |sector_name, sector_cp_unit|
-  sector = TPISector.find_or_create_by!(name: sector_name)
-  sector.update!(cp_unit: sector_cp_unit) if sector.new_record? && sector_cp_unit.present?
+  TPISector.find_or_create_by!(name: sector_name) do |sector|
+    sector.cp_unit = sector_cp_unit
+  end
 end
 
 # instruments: Instrument Type & Instrument

--- a/spec/services/api/charts/sector_spec.rb
+++ b/spec/services/api/charts/sector_spec.rb
@@ -70,18 +70,11 @@ RSpec.describe Api::Charts::Sector do
     end
 
     it 'returns companies emissions' do
-      expect(subject.companies_emissions_data).to contain_exactly(
-        {
-          data: {2017 => 90.0, 2018 => 120.0, 2019 => 110.0},
-          lineWidth: 4,
-          name: company.name
-        },
-        {
-          data: {2017 => 190.0, 2018 => 220.0, 2019 => 90.0},
-          lineWidth: 4,
-          name: company2.name
-        }
-      )
+      company_data = subject.companies_emissions_data.find { |c| c[:name] == company.name }[:data]
+      company2_data = subject.companies_emissions_data.find { |c| c[:name] == company2.name }[:data]
+
+      expect(company_data).to eq(2017 => 90.0, 2018 => 120.0, 2019 => 110.0)
+      expect(company2_data).to eq(2017 => 190.0, 2018 => 220.0, 2019 => 90.0)
     end
   end
 


### PR DESCRIPTION
- fixing seed of cp_unit for a sector
- adding unit to cp charts, sector one and company cp assessment one
- adding reported year distinction

![image](https://user-images.githubusercontent.com/1286444/69876909-0c259880-12c1-11ea-8455-4b0d4593602d.png)

I know that this sublegend (projected/targeted) should be below normal legend, but this was the quickest way and we will have to rewrite normal legend outside of highcharts anyway.