### PR TITLE
Added a page with the mailchimp embed for newsletter

### DIFF
--- a/app/assets/stylesheets/tpi.scss
+++ b/app/assets/stylesheets/tpi.scss
@@ -29,6 +29,7 @@
 @import "tpi/base-tooltip";
 @import "tpi/footer";
 @import "tpi/dropdown-selector";
+@import "tpi/newsletter";
 @import "tpi/pages";
 
 @import "tpi/pages/*";

--- a/app/assets/stylesheets/tpi/_newsletter.scss
+++ b/app/assets/stylesheets/tpi/_newsletter.scss
@@ -1,0 +1,13 @@
+@import "bulma/sass/utilities/all";
+@import "sizes";
+@import "colors";
+@import "typography";
+
+.newsletter__title {
+  margin-top: 80px;
+  margin-bottom: 40px;
+}
+
+.newsletter__container {
+  margin-bottom: 70px;
+}

--- a/app/controllers/tpi/home_controller.rb
+++ b/app/controllers/tpi/home_controller.rb
@@ -34,5 +34,7 @@ module TPI
     def about; end
 
     def sandbox; end
+
+    def newsletter; end
   end
 end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,22 +1,24 @@
-<section class="footer__subscribe">
-  <div class="container">
-    <div class="columns">
-      <div class="column is-5 subscribe__logo">
-        <img src="<%= asset_path 'newsletter_background/newsletter img@2x.png' %>" alt="tpi newsletter logo">
-      </div>
+<% unless action_name == "newsletter" %>
+  <section class="footer__subscribe">
+    <div class="container">
+      <div class="columns">
+        <div class="column is-5 subscribe__logo">
+          <img src="<%= asset_path 'newsletter_background/newsletter img@2x.png' %>" alt="tpi newsletter logo">
+        </div>
 
-      <div class="column is-5 subscribe__container">
-        <h4>Subscribe to the TPI newsletter</h4>
+        <div class="column is-5 subscribe__container">
+          <h4>Subscribe to the TPI newsletter</h4>
 
-        <p class="content">
-          Receive updates on the TPI, including on latest developments and research findings, by signing-up to our newsletter.
-        </p>
+          <p class="content">
+            Receive updates on the TPI, including on latest developments and research findings, by signing-up to our newsletter.
+          </p>
 
-        <button class="button is-primary">Subscribe</button>
+          <%= link_to 'Subscribe', tpi_newsletter_path, class: 'button is-primary' %>
+        </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
+<% end %>
 
 <section class="footer__information">
   <div class="container">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -47,9 +47,7 @@
         </div>
 
         <div class="navbar-end">
-          <a class="navbar-item">
-            Newsletter
-          </a>
+          <%= link_to 'Newsletter', tpi_newsletter_path, class: 'navbar-item' %>
           <a class="navbar-item">
             Login / Register
           </a>

--- a/app/views/tpi/home/newsletter.html.erb
+++ b/app/views/tpi/home/newsletter.html.erb
@@ -1,0 +1,39 @@
+<div class="container newsletter__container">
+  <h1 class="newsletter__title">Sign up to receive the TPI Newsletter</h1>
+  <!-- Begin Mailchimp Signup Form -->
+  <!-- Begin Mailchimp Signup Form -->
+  <link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
+  <style type="text/css">
+#mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
+/* Add your own Mailchimp form style overrides in your site stylesheet or in this style block.
+   We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
+  </style>
+  <div id="mc_embed_signup">
+    <form action="https://transitionpathwayinitiative.us17.list-manage.com/subscribe/post?u=e90609003c33a150ea0a14a50&amp;id=4fef3f7731" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+      <div id="mc_embed_signup_scroll">
+        <div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
+        <div class="mc-field-group">
+          <label for="mce-EMAIL">Email Address  <span class="asterisk">*</span>
+          </label>
+          <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
+        </div>
+        <div class="mc-field-group">
+          <label for="mce-FNAME">First Name </label>
+          <input type="text" value="" name="FNAME" class="" id="mce-FNAME">
+        </div>
+        <div class="mc-field-group">
+          <label for="mce-LNAME">Last Name </label>
+          <input type="text" value="" name="LNAME" class="" id="mce-LNAME">
+        </div>
+        <div id="mce-responses" class="clear">
+          <div class="response" id="mce-error-response" style="display:none"></div>
+          <div class="response" id="mce-success-response" style="display:none"></div>
+        </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+        <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_e90609003c33a150ea0a14a50_4fef3f7731" tabindex="-1" value=""></div>
+        <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+      </div>
+    </form>
+  </div>
+  <script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='ADDRESS';ftypes[3]='address';fnames[4]='PHONE';ftypes[4]='phone';fnames[5]='MMERGE5';ftypes[5]='zip';fnames[6]='MMERGE6';ftypes[6]='zip';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+  <!--End mc_embed_signup-->
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
     root to: 'home#index'
 
     get '/about', to: 'home#about'
+    get '/newsletter', to: 'home#newsletter'
     get '/sandbox', to: 'home#sandbox' if Rails.env.development?
 
     resources :sectors, only: [:show, :index] do


### PR DESCRIPTION
*All pertaining to TPI*

newsletter can be found here: http://localhost:3000/tpi/newsletter

* adds a new route for the newsletter under the home controller
* adds a new view and some basic styles;
* embeds the newsletter code from Mailchimp;
* updates links to the newsletter to point to this page;
* hides Subscribe to newsletter section under the newsletter action because it's redundant;

Not done here:

* not the best styles;
* didn't customize the mailchimp form for now.