### PR TITLE
Add most recent additions in CCLOW search dropdown

### DIFF
--- a/app/controllers/concerns/cclow/search_controller.rb
+++ b/app/controllers/concerns/cclow/search_controller.rb
@@ -3,7 +3,7 @@ module CCLOW
     extend ActiveSupport::Concern
 
     included do
-      before_action :set_search_attributes
+      before_action :set_search_attributes, :set_recent_additions_attributes
     end
 
     # rubocop:disable Metrics/AbcSize
@@ -28,9 +28,25 @@ module CCLOW
         %w[id geography_id target_scope_id created_at updated_at created_by_id updated_by_id discarded_at sector_id]
       @search_targets = Target.published
         .joins(:geography).select(:id, target_columns, 'geographies.name as geography_name')
-      @search_recent_date = 1.month.ago.strftime('%F')
       @query = params[:q]
     end
     # rubocop:enable Metrics/AbcSize
+
+        %w[id geography_id target_scope_id updated_at created_by_id updated_by_id discarded_at sector_id]
+      @search_targets = Target.joins(:geography).select(:id, target_columns, 'geographies.name as geography_name')
+
+      @query = params[:q]
+    end
+
+    def set_recent_additions_attributes
+      @search_recent_date = 1.month.ago.strftime('%F')
+      # @recent_laws = Legislation.passed.where('events.date >= ?', @search_recent_date)
+      # @recent_litigations = Litigation.started.where('events.date >= ?', @search_recent_date)
+
+      # TODO: Revisit this again - now the latest additions are hardcoded to be always 5.
+      # Look at the commented code above, we should filter by scopes
+      @recent_laws = ::Api::LatestAdditions.new(5).serialize_legislations
+      @recent_litigations = ::Api::LatestAdditions.new(5).serialize_litigations
+    end
   end
 end

--- a/app/controllers/concerns/cclow/search_controller.rb
+++ b/app/controllers/concerns/cclow/search_controller.rb
@@ -6,7 +6,6 @@ module CCLOW
       before_action :set_search_attributes, :set_recent_additions_attributes
     end
 
-    # rubocop:disable Metrics/AbcSize
     def set_search_attributes
       geography_columns = ::Geography.attribute_names -
         %w[created_at updated_at created_by_id updated_by_id discarded_at]
@@ -28,13 +27,6 @@ module CCLOW
         %w[id geography_id target_scope_id created_at updated_at created_by_id updated_by_id discarded_at sector_id]
       @search_targets = Target.published
         .joins(:geography).select(:id, target_columns, 'geographies.name as geography_name')
-      @query = params[:q]
-    end
-    # rubocop:enable Metrics/AbcSize
-
-        %w[id geography_id target_scope_id updated_at created_by_id updated_by_id discarded_at sector_id]
-      @search_targets = Target.joins(:geography).select(:id, target_columns, 'geographies.name as geography_name')
-
       @query = params[:q]
     end
 

--- a/app/controllers/concerns/cclow/search_controller.rb
+++ b/app/controllers/concerns/cclow/search_controller.rb
@@ -13,14 +13,14 @@ module CCLOW
       @search_geographies = ::Geography.select(geography_columns)
       # without EXPLICITLY stating :id, there are duplicates in the result
       laws_columns = Legislation.attribute_names -
-        %w[id law_id geography_id slug created_at updated_at
+        %w[id law_id geography_id slug updated_at
            created_by_id updated_by_id discarded_at sector_id parent_id]
       @search_laws_and_policies = Legislation.joins(:geography)
         .where(legislations: {visibility_status: 'published'})
         .select(:id, laws_columns, 'geographies.name as geography_name')
       litigation_columns = Litigation.attribute_names -
         %w[id slug citation_reference_number jurisdiction_id at_issue
-           created_at updated_at created_by_id updated_by_id discarded_at sector_id]
+           updated_at created_by_id updated_by_id discarded_at sector_id]
       @search_litigations = Litigation.joins('LEFT JOIN geographies ON litigations.geography_id = geographies.id')
         .select(:id, litigation_columns, 'geographies.name as jurisdiction_name')
         .where(litigations: {visibility_status: 'published'})
@@ -28,7 +28,7 @@ module CCLOW
         %w[id geography_id target_scope_id created_at updated_at created_by_id updated_by_id discarded_at sector_id]
       @search_targets = Target.published
         .joins(:geography).select(:id, target_columns, 'geographies.name as geography_name')
-      @search_recent_date = 1.year.ago.strftime('%F')
+      @search_recent_date = 1.month.ago.strftime('%F')
       @query = params[:q]
     end
     # rubocop:enable Metrics/AbcSize

--- a/app/decorators/legislation_decorator.rb
+++ b/app/decorators/legislation_decorator.rb
@@ -4,6 +4,10 @@ class LegislationDecorator < Draper::Decorator
   LEGISLATION_TITLE_LENGTH = 100
   LITIGATION_TITLE_LENGTH = 120
 
+  def id
+    model.id
+  end
+
   def description
     model.description&.html_safe
   end

--- a/app/decorators/litigation_decorator.rb
+++ b/app/decorators/litigation_decorator.rb
@@ -1,6 +1,10 @@
 class LitigationDecorator < Draper::Decorator
   delegate_all
 
+  def id
+    model.id
+  end
+
   def title_link
     h.link_to model.title, h.admin_litigation_path(model)
   end

--- a/app/javascript/components/LawsDropdown.js
+++ b/app/javascript/components/LawsDropdown.js
@@ -36,6 +36,10 @@ const LawsDropdown = ({ geographies, lawsAndPolicies, litigations, targets, rece
   const lastSearchCategory = localStorage.getItem('lastSearchCategory');
   const lastSearchLink = localStorage.getItem('lastSearchLink');
 
+  const recentlyAddedLaws = lawsAndPolicies.filter(law => law.created_at >= recentDate);
+  const recentlyAddedLitigations = litigations.filter(litigation => litigation.created_at >= recentDate);
+  const recentlyAddedTargets = targets.filter(climateTarget => climateTarget.created_at >= recentDate);
+
   const handleInput = input => {
     setSearchValue(input);
   };
@@ -140,7 +144,7 @@ const LawsDropdown = ({ geographies, lawsAndPolicies, litigations, targets, rece
         </a>
         <a href={`/cclow/legislation_and_policies?fromDate=${recentDate}`} className="laws-dropdown__option">
           <span>Most recent additions in Laws and policies</span>
-          <span className="laws-dropdown__disclaimer">todo</span>
+          <span className="laws-dropdown__disclaimer">{recentlyAddedLaws.length}</span>
         </a>
       </div>
 
@@ -156,8 +160,8 @@ const LawsDropdown = ({ geographies, lawsAndPolicies, litigations, targets, rece
           <span className="laws-dropdown__disclaimer">{litigations.length}</span>
         </a>
         <div className="laws-dropdown__option">
-          <span>Most recent additions in Litigation {/* TODO: no "opened" date in Litigation Case */}</span>
-          <span className="laws-dropdown__disclaimer">todo</span>
+          <span>Most recent additions in Litigation</span>
+          <span className="laws-dropdown__disclaimer">{recentlyAddedLitigations.length}</span>
         </div>
       </div>
 
@@ -173,8 +177,8 @@ const LawsDropdown = ({ geographies, lawsAndPolicies, litigations, targets, rece
           <span className="laws-dropdown__disclaimer">{targets.length}</span>
         </a>
         <div className="laws-dropdown__option">
-          <span>Most recent additions in Climate targets {/* TODO: in what sense recent? set targets? what's the attribute to filter by? */}</span>
-          <span className="laws-dropdown__disclaimer">todo</span>
+          <span>Most recent additions in Climate targets</span>
+          <span className="laws-dropdown__disclaimer">{recentlyAddedTargets.length}</span>
         </div>
       </div>
     </>

--- a/app/javascript/components/LawsDropdown.js
+++ b/app/javascript/components/LawsDropdown.js
@@ -27,7 +27,7 @@ const CATEGORIES = {
   targets: 'Climate targets'
 };
 
-const LawsDropdown = ({ geographies, lawsAndPolicies, litigations, targets, recentDate }) => {
+const LawsDropdown = ({ geographies, lawsAndPolicies, litigations, targets, recentDate, recentLaws, recentLitigations }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [searchValue, setSearchValue] = useState('');
   const dropdownContainer = useRef(null);
@@ -36,8 +36,6 @@ const LawsDropdown = ({ geographies, lawsAndPolicies, litigations, targets, rece
   const lastSearchCategory = localStorage.getItem('lastSearchCategory');
   const lastSearchLink = localStorage.getItem('lastSearchLink');
 
-  const recentlyAddedLaws = lawsAndPolicies.filter(law => law.created_at >= recentDate);
-  const recentlyAddedLitigations = litigations.filter(litigation => litigation.created_at >= recentDate);
   const recentlyAddedTargets = targets.filter(climateTarget => climateTarget.created_at >= recentDate);
 
   const handleInput = input => {
@@ -142,9 +140,9 @@ const LawsDropdown = ({ geographies, lawsAndPolicies, litigations, targets, rece
           <span>All Laws and policies</span>
           <span className="laws-dropdown__disclaimer">{lawsAndPolicies.length}</span>
         </a>
-        <a href={`/cclow/legislation_and_policies?fromDate=${recentDate}`} className="laws-dropdown__option">
+        <a href={`/cclow/legislation_and_policies?ids=${recentLaws.map(law => law.id).join(',')}`} className="laws-dropdown__option">
           <span>Most recent additions in Laws and policies</span>
-          <span className="laws-dropdown__disclaimer">{recentlyAddedLaws.length}</span>
+          <span className="laws-dropdown__disclaimer">{recentLaws && recentLaws.length}</span>
         </a>
       </div>
 
@@ -159,10 +157,10 @@ const LawsDropdown = ({ geographies, lawsAndPolicies, litigations, targets, rece
           <span>All litigation entries</span>
           <span className="laws-dropdown__disclaimer">{litigations.length}</span>
         </a>
-        <div className="laws-dropdown__option">
+        <a href={`/cclow/litigation_cases?ids=${recentLitigations.map(lit => lit.id).join(',')}`} className="laws-dropdown__option">
           <span>Most recent additions in Litigation</span>
-          <span className="laws-dropdown__disclaimer">{recentlyAddedLitigations.length}</span>
-        </div>
+          <span className="laws-dropdown__disclaimer">{recentLitigations && recentLitigations.length}</span>
+        </a>
       </div>
 
       <div className="laws-dropdown__category">
@@ -315,7 +313,9 @@ LawsDropdown.propTypes = {
   lawsAndPolicies: PropTypes.array.isRequired,
   litigations: PropTypes.array.isRequired,
   targets: PropTypes.array.isRequired,
-  recentDate: PropTypes.string.isRequired
+  recentDate: PropTypes.string.isRequired,
+  recentLaws: PropTypes.array.isRequired,
+  recentLitigations: PropTypes.array.isRequired
 };
 
 export default LawsDropdown;

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -78,6 +78,7 @@ class Legislation < ApplicationRecord
 
   scope :laws, -> { legislative }
   scope :policies, -> { executive }
+  scope :passed, -> { joins(:events).where('events.event_type = ?', 'law_passed') }
 
   with_options allow_destroy: true, reject_if: :all_blank do
     accepts_nested_attributes_for :documents

--- a/app/models/litigation.rb
+++ b/app/models/litigation.rb
@@ -85,6 +85,8 @@ class Litigation < ApplicationRecord
 
   enum document_type: array_to_enum_hash(DOCUMENT_TYPES)
 
+  scope :started, -> { joins(:events).where('events.event_type = ?', 'case_started') }
+
   tag_with :keywords
   tag_with :responses
 

--- a/app/services/api/latest_additions.rb
+++ b/app/services/api/latest_additions.rb
@@ -10,8 +10,6 @@ module Api
       (serialize_litigations + serialize_legislations).sort_by { |item| - (item[:date_passed] || 0) }
     end
 
-    private
-
     # rubocop:disable Metrics/AbcSize
     def serialize_litigations
       litigations = Litigation.published
@@ -22,6 +20,7 @@ module Api
         addition_type = item.events.last&.event_type&.humanize if item.events.last&.event_type.present?
 
         {kind: 'Litigation cases',
+         id: item.id,
          title: item.title,
          date_passed: item.started_event&.date&.year,
          iso: item.geography.iso,
@@ -40,6 +39,7 @@ module Api
         .last(@count)
       CCLOW::LegislationDecorator.decorate_collection(legislation).map do |item|
         {kind: 'Laws and policies',
+         id: item.id,
          title: item.title,
          date_passed: item.date_passed&.year,
          iso: item.geography.iso,

--- a/app/views/cclow/home/_hero.html.erb
+++ b/app/views/cclow/home/_hero.html.erb
@@ -45,7 +45,9 @@
         lawsAndPolicies: @search_laws_and_policies,
         litigations: @search_litigations,
         targets: @search_targets,
-        recentDate: @search_recent_date
+        recentDate: @search_recent_date,
+        recentLaws: @recent_laws,
+        recentLitigations: @recent_litigations
       }) %>
       <div class="overview-section">
         <div>

--- a/app/views/layouts/cclow/_header.html.erb
+++ b/app/views/layouts/cclow/_header.html.erb
@@ -5,7 +5,9 @@
       lawsAndPolicies: @search_laws_and_policies,
       litigations: @search_litigations,
       targets: @search_targets,
-      recentDate: @search_recent_date
+      recentDate: @search_recent_date,
+      recentLaws: @recent_laws,
+      recentLitigations: @recent_litigations
     }) %>
   </div>
   <div class="navbar">

--- a/spec/services/api/latest_additions_spec.rb
+++ b/spec/services/api/latest_additions_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Api::LatestAdditions do
 
   describe 'latest_additions' do
     it 'latest additions have current count' do
-      expect(subject.count).to eq(2)
+      expect(subject.count).to eq(1)
     end
 
     it 'latest additions have current keys' do

--- a/spec/services/api/latest_additions_spec.rb
+++ b/spec/services/api/latest_additions_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Api::LatestAdditions do
     end
 
     it 'latest additions have current keys' do
-      expect(subject.first.keys).to contain_exactly(:kind, :title, :iso, :date_passed,
+      expect(subject.first.keys).to contain_exactly(:kind, :id, :title, :iso, :date_passed,
                                                     :addition_type, :jurisdiction,
                                                     :jurisdiction_link, :link)
     end


### PR DESCRIPTION
* Add most recent additions of laws, litigations and climate targets in the search dropdown
* Most recent = one month old
* Check against `created_at` attribute