### PR TITLE
Add missing spacer on mobile homepage + responsive slider

### DIFF
--- a/app/assets/stylesheets/cclow/_hero.scss
+++ b/app/assets/stylesheets/cclow/_hero.scss
@@ -110,16 +110,17 @@ $logos-container-padding: 1.5rem;
     grid-template-columns: repeat(2, 1fr);
     grid-template-areas:
       "lawsAndPolicies climateLitigation"
+      "spacer spacer"
       "featuredCountryProfiles featuredCountryProfiles";
-    grid-row-gap: 42px;
+    grid-row-gap: 36px;
     margin-top: 50px;
-    padding: 0 1.6rem;
 
     @include desktop {
       grid-template-areas: unset;
       grid-template-columns: repeat(4, 1fr);
       grid-row-gap: 0;
       margin-top: 82px;
+      padding: 0 1.6rem;
     }
 
     .section__cell {
@@ -133,6 +134,18 @@ $logos-container-padding: 1.5rem;
 
       @include desktop {
         display: block;
+      }
+    }
+
+    .spacer {
+      height: 1px;
+      width: 100%;
+      background-color: $grey-text;
+      grid-area: spacer;
+
+      @include desktop {
+        display: none;
+        grid-area: unset;
       }
     }
 

--- a/app/assets/stylesheets/cclow/_pages.scss
+++ b/app/assets/stylesheets/cclow/_pages.scss
@@ -43,13 +43,18 @@
   align-items: center;
 }
 
-.section__map {
-  margin-top: 2rem;
+.latest_additions__container {
   padding-bottom: 0;
-  padding-top: 0;
+}
+
+.section__map {
+  margin-top: 44px;
+  padding-bottom: 0;
+  padding-top: 0 !important;
   margin-bottom: 52px;
 
   @include desktop {
+    margin-top: 68px;
     margin-bottom: 74px;
   }
 

--- a/app/javascript/shared/controllers/slider_controller.js
+++ b/app/javascript/shared/controllers/slider_controller.js
@@ -4,7 +4,17 @@ export default class extends Controller {
   connect() {
     $(this.element).slick({
       prevArrow: '<button type="button" class="slick-prev"><i class="fa fa-1x fa-arrow-left"></i></button>',
-      nextArrow: '<button type="button" class="slick-next"><i class="fa fa-1x fa-arrow-right"></i></button>'
+      nextArrow: '<button type="button" class="slick-next"><i class="fa fa-1x fa-arrow-right"></i></button>',
+      responsive: [
+        {
+          breakpoint: 768,
+          settings: {
+            slidesToShow: 1,
+            slidesToScroll: 1,
+            arrows: false
+          }
+        }
+      ]
     });
   }
 

--- a/app/views/cclow/home/_hero.html.erb
+++ b/app/views/cclow/home/_hero.html.erb
@@ -76,6 +76,7 @@
             </div>
           </div>
         </div>
+        <div class="section__cell spacer"></div>
         <div class="section__cell country-profiles-section">
           <div class="item-name-block">
             <div class="img-type-container">

--- a/app/views/cclow/home/index.html.erb
+++ b/app/views/cclow/home/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, 'Climate Laws - Home' %>
-<section class="section is-medium">
+<section class="section is-medium latest_additions__container">
   <h5 class="title">
     Latest additions
   </h5>


### PR DESCRIPTION
* Add missing spacer between sections on homepage on mobile
* Add responsive version of Latest Additions section

<img width="579" alt="missingSpacer" src="https://user-images.githubusercontent.com/6136899/70715101-7ab31f00-1ce1-11ea-9236-8a45eeab4e0d.png">

<img width="525" alt="responsiveLatestAdditions" src="https://user-images.githubusercontent.com/6136899/70715106-7e46a600-1ce1-11ea-9a78-355f89f32373.png">
