### PR TITLE
add params[:q] to permitted params

### DIFF
--- a/app/controllers/concerns/cclow/filter_controller.rb
+++ b/app/controllers/concerns/cclow/filter_controller.rb
@@ -14,7 +14,7 @@ module CCLOW
     end
 
     def filter_params
-      params.permit(:fromDate, :recent, :ids, region: [], geography: [], tags: [])
+      params.permit(:q, :fromDate, :recent, :ids, region: [], geography: [], tags: [])
     end
   end
 end

--- a/spec/controllers/cclow/climate_targets_controller_spec.rb
+++ b/spec/controllers/cclow/climate_targets_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe CCLOW::ClimateTargetsController, type: :controller do
+  let!(:geography) { create(:geography, iso: 'ABC') }
+  let!(:target1) {
+    create(:target,
+           year: 2025, geography_id: geography.id,
+           description: 'Sumol', visibility_status: 'published')
+  }
+  let!(:target2) {
+    create(:target,
+           year: 2020, geography_id: geography.id,
+           description: 'Coca Cola', visibility_status: 'published')
+  }
+
+  describe 'Get index with query param without matches' do
+    subject { get :index, params: {q: 'Compal'} }
+
+    it { is_expected.to be_successful }
+
+    it('should return no targets') do
+      subject
+      expect(assigns(:climate_targets).size).to eq(0)
+    end
+  end
+
+  describe 'Get index with query param with matches' do
+    subject { get :index, params: {q: 'Sumol'} }
+
+    it { is_expected.to be_successful }
+
+    it('should return targets') do
+      subject
+      expect(assigns(:climate_targets).size).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
Search results weren't being filtered because the query param was not on the list of permitted params.