### PR TITLE
Feature/allow multiple sectors for publications

### DIFF
--- a/app/admin/news_article.rb
+++ b/app/admin/news_article.rb
@@ -7,8 +7,8 @@ ActiveAdmin.register NewsArticle do
   decorate_with NewsArticleDecorator
 
   permit_params :title, :content, :publication_date, :article_type,
-                :created_by_id, :updated_by_id, :sector_id,
-                :image, :keywords_string
+                :created_by_id, :updated_by_id,
+                :image, :keywords_string, tpi_sector_ids: []
 
   filter :title
   filter :content
@@ -22,7 +22,7 @@ ActiveAdmin.register NewsArticle do
           row :article_type
           row :content
           row :publication_date
-          row :sector
+          list_row 'Sectors', :tpi_sector_links
           row 'Keywords', &:keywords_string
           row :image do |t|
             image_tag(url_for(t.image)) if t.image.present?
@@ -53,7 +53,6 @@ ActiveAdmin.register NewsArticle do
     column :article_type
     column :content
     column :publication_date
-    column(:sector) { |l| l.sector&.name }
   end
 
   form html: {'data-controller' => 'check-modified'} do |f|
@@ -64,7 +63,8 @@ ActiveAdmin.register NewsArticle do
       f.input :article_type, as: :select, collection: array_to_select_collection(NewsArticle::ARTICLE_TYPES)
       f.input :content, as: :trix
       f.input :publication_date
-      f.input :sector
+      f.input :tpi_sector_ids, label: 'Sectors', as: :select,
+                               collection: TPISector.order(:name), input_html: {multiple: true}
       f.input :keywords_string, label: 'Keywords', hint: t('hint.tag'), as: :tags, collection: Keyword.pluck(:name)
       f.input :image, as: :file
     end
@@ -76,7 +76,7 @@ ActiveAdmin.register NewsArticle do
     include DiscardableController
 
     def scoped_collection
-      super.includes(:sector, :keywords)
+      super.includes(:tpi_sectors, :keywords)
     end
 
     def apply_filtering(chain)

--- a/app/admin/publication.rb
+++ b/app/admin/publication.rb
@@ -8,7 +8,7 @@ ActiveAdmin.register Publication do
 
   permit_params :title, :short_description, :publication_date,
                 :file, :image, :created_by_id, :updated_by_id,
-                :sector_id, :keywords_string
+                :keywords_string, tpi_sector_ids: []
 
   filter :title
   filter :short_description
@@ -21,7 +21,7 @@ ActiveAdmin.register Publication do
           row :title
           row :short_description
           row :publication_date
-          row :sector
+          list_row 'Sectors', :tpi_sector_links
           row 'Keywords', &:keywords_string
           row :image do |t|
             image_tag(url_for(t.image)) if t.image.present?
@@ -55,7 +55,8 @@ ActiveAdmin.register Publication do
       f.input :title
       f.input :short_description, as: :text
       f.input :publication_date
-      f.input :sector
+      f.input :tpi_sector_ids, label: 'Sectors', as: :select,
+                               collection: TPISector.order(:name), input_html: {multiple: true}
       f.input :keywords_string, label: 'Keywords', hint: t('hint.tag'), as: :tags, collection: Keyword.pluck(:name)
       f.input :file, as: :file
       f.input :image, as: :file
@@ -68,7 +69,7 @@ ActiveAdmin.register Publication do
     include DiscardableController
 
     def scoped_collection
-      super
+      super.includes(:tpi_sectors)
     end
 
     def apply_filtering(chain)

--- a/app/controllers/tpi/publications_controller.rb
+++ b/app/controllers/tpi/publications_controller.rb
@@ -38,8 +38,8 @@ module TPI
     end
 
     def fetch_sectors
-      @sectors = (Publication.joins(:sector).select('tpi_sectors.name as sector_name').map(&:sector_name) +
-       NewsArticle.joins(:sector).select('tpi_sectors.name as sector_name').map(&:sector_name)).uniq
+      @sectors = (Publication.joins(:tpi_sectors).select('tpi_sectors.name as sector_name').map(&:sector_name) +
+       NewsArticle.joins(:tpi_sectors).select('tpi_sectors.name as sector_name').map(&:sector_name)).uniq
     end
   end
 end

--- a/app/decorators/news_article_decorator.rb
+++ b/app/decorators/news_article_decorator.rb
@@ -4,4 +4,13 @@ class NewsArticleDecorator < Draper::Decorator
   def title_link
     h.link_to model.title, h.admin_news_article_path(model)
   end
+
+  def tpi_sector_links
+    model.tpi_sectors.map do |sector|
+      h.link_to sector.name,
+                h.admin_tpi_sector_path(sector),
+                target: '_blank',
+                title: sector.name
+    end
+  end
 end

--- a/app/decorators/publication_decorator.rb
+++ b/app/decorators/publication_decorator.rb
@@ -8,4 +8,13 @@ class PublicationDecorator < Draper::Decorator
   def file_link
     h.link_to model.file.filename, h.rails_blob_path(model.file, disposition: 'attachment')
   end
+
+  def tpi_sector_links
+    model.tpi_sectors.map do |sector|
+      h.link_to sector.name,
+                h.admin_tpi_sector_path(sector),
+                target: '_blank',
+                title: sector.name
+    end
+  end
 end

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -31,12 +31,16 @@ class NewsArticle < ApplicationRecord
 
   enum article_type: array_to_enum_hash(ARTICLE_TYPES)
 
-  belongs_to :sector, class_name: 'TPISector', foreign_key: 'sector_id', optional: true
+  has_and_belongs_to_many :tpi_sectors
 
   validates_presence_of :title, :content
 
   def self.search(query)
     where('title ilike ? OR content ilike ?',
           "%#{query}%", "%#{query}%")
+  end
+
+  def tags_and_sectors
+    (keywords.map(&:name) + tpi_sectors.map(&:name)).compact.uniq.sort
   end
 end

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -11,7 +11,6 @@
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  article_type     :string
-#  sector_id        :bigint
 #
 
 class NewsArticle < ApplicationRecord

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -25,7 +25,7 @@ class Publication < ApplicationRecord
 
   tag_with :keywords
 
-  belongs_to :sector, class_name: 'TPISector', foreign_key: 'sector_id', optional: true
+  has_and_belongs_to_many :tpi_sectors
 
   validates :file, attached: true
   validates_presence_of :title, :short_description, :publication_date
@@ -33,5 +33,9 @@ class Publication < ApplicationRecord
   def self.search(query)
     where('title ilike ? OR short_description ilike ?',
           "%#{query}%", "%#{query}%")
+  end
+
+  def tags_and_sectors
+    (keywords.map(&:name) + tpi_sectors.map(&:name)).compact.uniq.sort
   end
 end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -12,7 +12,6 @@
 #  updated_by_id     :bigint
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  sector_id         :bigint
 #
 
 class Publication < ApplicationRecord

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -17,6 +17,7 @@
 #  updated_by_id     :bigint
 #  discarded_at      :datetime
 #  sector_id         :bigint
+#  source            :string
 #
 
 class Target < ApplicationRecord

--- a/app/services/queries/tpi/news_publications_query.rb
+++ b/app/services/queries/tpi/news_publications_query.rb
@@ -36,7 +36,7 @@ module Queries
       def filter_by_sectors(scope)
         return scope if sectors.blank?
 
-        scope.joins(:sector).where('tpi_sectors.name IN (?)', sectors.split(', '))
+        scope.joins(:tpi_sectors).where('tpi_sectors.name IN (?)', sectors.split(', '))
       end
     end
   end

--- a/app/views/tpi/publications/_promoted.html.erb
+++ b/app/views/tpi/publications/_promoted.html.erb
@@ -8,10 +8,10 @@
         <% end %>
 
         <div class="publication__content">
-          <% if publication.keywords.any? %>
+          <% if publication.keywords.any? || publication.tpi_sectors.any? %>
             <div class="publication__tags">
-              <% publication.keywords.each do |tag| %>
-                <span class="tag"><%= tag.name %></span>
+              <% publication.tags_and_sectors.each do |tag| %>
+                <span class="tag"><%= tag %></span>
               <% end %>
             </div>
           <% end %>

--- a/db/migrate/20191217083323_create_join_table_publications_tpi_sectors.rb
+++ b/db/migrate/20191217083323_create_join_table_publications_tpi_sectors.rb
@@ -1,0 +1,9 @@
+class CreateJoinTablePublicationsTPISectors < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :publications, :sector_id, :bigint
+    create_join_table :publications, :tpi_sectors do |t|
+      t.index :publication_id
+      t.index :tpi_sector_id
+    end
+  end
+end

--- a/db/migrate/20191217085001_create_join_table_news_articles_tpi_sectors.rb
+++ b/db/migrate/20191217085001_create_join_table_news_articles_tpi_sectors.rb
@@ -1,0 +1,9 @@
+class CreateJoinTableNewsArticlesTPISectors < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :news_articles, :sector_id, :bigint
+    create_join_table :news_articles, :tpi_sectors do |t|
+      t.index :news_article_id
+      t.index :tpi_sector_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_08_233512) do
+ActiveRecord::Schema.define(version: 2019_12_17_085001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -397,10 +397,15 @@ ActiveRecord::Schema.define(version: 2019_12_08_233512) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "article_type"
-    t.bigint "sector_id"
     t.index ["created_by_id"], name: "index_news_articles_on_created_by_id"
-    t.index ["sector_id"], name: "index_news_articles_on_sector_id"
     t.index ["updated_by_id"], name: "index_news_articles_on_updated_by_id"
+  end
+
+  create_table "news_articles_tpi_sectors", id: false, force: :cascade do |t|
+    t.bigint "news_article_id", null: false
+    t.bigint "tpi_sector_id", null: false
+    t.index ["news_article_id"], name: "index_news_articles_tpi_sectors_on_news_article_id"
+    t.index ["tpi_sector_id"], name: "index_news_articles_tpi_sectors_on_tpi_sector_id"
   end
 
   create_table "pages", force: :cascade do |t|
@@ -423,10 +428,15 @@ ActiveRecord::Schema.define(version: 2019_12_08_233512) do
     t.bigint "updated_by_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "sector_id"
     t.index ["created_by_id"], name: "index_publications_on_created_by_id"
-    t.index ["sector_id"], name: "index_publications_on_sector_id"
     t.index ["updated_by_id"], name: "index_publications_on_updated_by_id"
+  end
+
+  create_table "publications_tpi_sectors", id: false, force: :cascade do |t|
+    t.bigint "publication_id", null: false
+    t.bigint "tpi_sector_id", null: false
+    t.index ["publication_id"], name: "index_publications_tpi_sectors_on_publication_id"
+    t.index ["tpi_sector_id"], name: "index_publications_tpi_sectors_on_tpi_sector_id"
   end
 
   create_table "taggings", force: :cascade do |t|
@@ -516,10 +526,8 @@ ActiveRecord::Schema.define(version: 2019_12_08_233512) do
   add_foreign_key "mq_assessments", "companies", on_delete: :cascade
   add_foreign_key "news_articles", "admin_users", column: "created_by_id"
   add_foreign_key "news_articles", "admin_users", column: "updated_by_id"
-  add_foreign_key "news_articles", "tpi_sectors", column: "sector_id"
   add_foreign_key "publications", "admin_users", column: "created_by_id"
   add_foreign_key "publications", "admin_users", column: "updated_by_id"
-  add_foreign_key "publications", "tpi_sectors", column: "sector_id"
   add_foreign_key "taggings", "tags", on_delete: :cascade
   add_foreign_key "targets", "admin_users", column: "created_by_id"
   add_foreign_key "targets", "admin_users", column: "updated_by_id"

--- a/spec/factories/news_articles.rb
+++ b/spec/factories/news_articles.rb
@@ -18,6 +18,7 @@ FactoryBot.define do
   factory :news_article do
     title { 'MyString' }
     content { 'MyText' }
+    tpi_sectors { |a| [a.association(:tpi_sector)] }
     publication_date { '2019-11-29' }
     image { fixture_file_upload(Rails.root.join('spec', 'support', 'fixtures', 'files', 'test.jpg'), 'jpg') }
 

--- a/spec/factories/news_articles.rb
+++ b/spec/factories/news_articles.rb
@@ -11,7 +11,6 @@
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  article_type     :string
-#  sector_id        :bigint
 #
 
 FactoryBot.define do

--- a/spec/factories/publications.rb
+++ b/spec/factories/publications.rb
@@ -12,7 +12,6 @@
 #  updated_by_id     :bigint
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  sector_id         :bigint
 #
 
 FactoryBot.define do

--- a/spec/factories/publications.rb
+++ b/spec/factories/publications.rb
@@ -17,7 +17,7 @@
 
 FactoryBot.define do
   factory :publication do
-    association :sector, factory: :tpi_sector
+    tpi_sectors { |a| [a.association(:tpi_sector)] }
 
     title { 'MyString' }
     short_description { 'MyText' }

--- a/spec/factories/targets.rb
+++ b/spec/factories/targets.rb
@@ -17,6 +17,7 @@
 #  updated_by_id     :bigint
 #  discarded_at      :datetime
 #  sector_id         :bigint
+#  source            :string
 #
 
 FactoryBot.define do

--- a/spec/models/news_article_spec.rb
+++ b/spec/models/news_article_spec.rb
@@ -11,7 +11,6 @@
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  article_type     :string
-#  sector_id        :bigint
 #
 
 require 'rails_helper'

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -12,7 +12,6 @@
 #  updated_by_id     :bigint
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  sector_id         :bigint
 #
 
 require 'rails_helper'

--- a/spec/models/target_spec.rb
+++ b/spec/models/target_spec.rb
@@ -17,6 +17,7 @@
 #  updated_by_id     :bigint
 #  discarded_at      :datetime
 #  sector_id         :bigint
+#  source            :string
 #
 
 require 'rails_helper'

--- a/spec/services/queries/tpi/news_publications_query_spec.rb
+++ b/spec/services/queries/tpi/news_publications_query_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe Queries::TPI::NewsPublicationsQuery do
       ]
     )
   }
-  let!(:publication_1) { create(:publication, sector: sector_1, keywords: [keyword_1]) }
-  let!(:publication_2) { create(:publication, sector: sector_2) }
+  let!(:publication_1) { create(:publication, tpi_sectors: [sector_1], keywords: [keyword_1]) }
+  let!(:publication_2) { create(:publication, tpi_sectors: [sector_2]) }
 
   subject { described_class }
 


### PR DESCRIPTION
Michal requested that we change the publications and news articles so that they support multiple sectors. In this PR I added this, updated backend, updated frontend, and specs.

These two models are very very similar, we probably should merge them into one. But not on this PR, sorry.