### PR TITLE
Make TPI sections clickable

### DIFF
--- a/app/admin/companies.rb
+++ b/app/admin/companies.rb
@@ -180,8 +180,10 @@ ActiveAdmin.register Company do
 
       f.input :ca100
 
-      f.input :latest_information
-      f.input :historical_comments
+      f.input :latest_information,
+              hint: 'Information displayed on the company page of TPI'
+      f.input :historical_comments,
+              hint: 'Name changes, or other historical information, not displayed on the public interface'
     end
 
     f.actions

--- a/app/assets/images/icons/minus.svg
+++ b/app/assets/images/icons/minus.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: sketchtool 60.1 (101010) - https://sketch.com -->
+    <title>5FEE0DB2-94A0-4B56-933C-241FA7DCDEAE</title>
+    <desc>Created with sketchtool.</desc>
+    <g id="Asset-Artboard-Page" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Icons/24px/arrow-left-Copy-12-Icons/24px/minus" fill="#FFFFFF" fill-rule="nonzero">
+            <g id="minus" transform="translate(4.000000, 11.000000)">
+                <path d="M15,0 L1,0 C0.44771525,0 0,0.44771525 0,1 C0,1.55228475 0.44771525,2 1,2 L15,2 C15.5522847,2 16,1.55228475 16,1 C16,0.44771525 15.5522847,0 15,0 Z" id="Path"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/app/assets/images/icons/plus-blue.svg
+++ b/app/assets/images/icons/plus-blue.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="14px" height="14px" viewBox="0 0 14 14" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: sketchtool 60.1 (101010) - https://sketch.com -->
+    <title>C5B80854-8532-44F2-8D9F-B3A6F10158E2</title>
+    <desc>Created with sketchtool.</desc>
+    <g id="TPI-visuals" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="TPI---Home" transform="translate(-117.000000, -940.000000)" fill="#083AAB" fill-rule="nonzero">
+            <g id="Group-7" transform="translate(0.000000, 690.000000)">
+                <g id="Group-6" transform="translate(109.000000, 242.000000)">
+                    <g id="Group-5">
+                        <polygon id="+" points="13.326087 13.326087 13.326087 8 16.673913 8 16.673913 13.326087 22 13.326087 22 16.673913 16.673913 16.673913 16.673913 22 13.326087 22 13.326087 16.673913 8 16.673913 8 13.326087"></polygon>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/app/assets/stylesheets/tpi/_hero.scss
+++ b/app/assets/stylesheets/tpi/_hero.scss
@@ -80,12 +80,29 @@
   }
 }
 
+.section-clickable {
+  &:hover {
+    .subsection-button__container {
+      .section-button {
+        background-color: $yellow;
+        background-image: image-url('icons/plus-blue.svg');
+      }
+
+      .button__title {
+        text-decoration: underline;
+      }
+    }
+  }
+}
+
 .section-title {
   margin-bottom: 20px;
+  color: $white;
 }
 
 .section-description {
   margin-bottom: 20px;
+  color: $white;
 
   @media #{$tablet-portrait} {
     margin-bottom: 64px;
@@ -104,6 +121,9 @@
   justify-content: center;
   align-items: center;
   margin-right: 10px;
+  background-image: image-url('icons/plus.svg');
+  background-repeat: no-repeat;
+  background-position: center;
 }
 
 .subsection-button__container {

--- a/app/assets/stylesheets/tpi/pages/company.scss
+++ b/app/assets/stylesheets/tpi/pages/company.scss
@@ -182,6 +182,18 @@
     }
   }
 
+  .latest-information {
+    &__header {
+      margin-top: 50px;
+      margin-bottom: 30px;
+    }
+
+    &__description {
+      line-height: 28px;
+      margin-bottom: 20px;
+    }
+  }
+
   .carbon-performance {
     margin-top: 50px;
     margin-bottom: 50px;

--- a/app/assets/stylesheets/tpi/pages/company.scss
+++ b/app/assets/stylesheets/tpi/pages/company.scss
@@ -1,3 +1,7 @@
+$line-height: 24px;
+$max-lines: 3;
+$dots-space: 1.3rem;
+
 .company-page {
   .companies-header {
     background: $blue;
@@ -183,14 +187,83 @@
   }
 
   .latest-information {
+    &__wrapper {
+      background-color: $blue-dark;
+      color: $white;
+      padding-top: 86px;
+      padding-bottom: 136px;
+    }
+
+    &__container {
+      margin: 0 auto;
+      max-width: 700px;
+    }
+
     &__header {
-      margin-top: 50px;
-      margin-bottom: 30px;
+      margin-bottom: 36px;
+      font-family: $family-sans-serif-bold;
     }
 
     &__description {
-      line-height: 28px;
-      margin-bottom: 20px;
+      line-height: $line-height;
+      font-size: 16px;
+      margin-bottom: 40px;
+    }
+
+    &__description--folded {
+      max-height: calc(#{$line-height} * #{$max-lines});
+      overflow: hidden;
+      position: relative;
+      margin-right: calc(-1 * #{$dots-space});
+      padding-right: $dots-space;
+  
+      &::before {
+        content: "[...]";
+        font-size: 12px;
+        position: absolute;
+        bottom: 0;
+        right: 0;
+      }
+  
+      &::after {
+        content: "";
+        position: absolute;
+        right: 0; /* note: not using bottom */
+        width: 1.7rem;
+        height: 1.7rem;
+        background: $blue-dark;
+        margin-top: 0.2rem;
+        margin-right: 0.1rem;
+      }
+    }
+
+    &__button {
+      height: 30px;
+      width: 30px;
+      background-color: $blue-darker;
+      border-radius: 50%;
+      padding: 8px;
+      margin-right: 14px;
+    }
+
+    &__button-text {
+      font-size: 16px;
+      font-family: $family-sans-serif-bold;
+      color: $white;
+    }
+
+    &__button-container {
+      display: flex;
+      align-items: center;
+      background-color: transparent;
+      border: none;
+      cursor: pointer;
+
+      &:focus {
+        outline-color: $yellow;
+        outline-style: solid;
+        outline-width: 2px;
+      }
     }
   }
 

--- a/app/assets/stylesheets/tpi/pages/company.scss
+++ b/app/assets/stylesheets/tpi/pages/company.scss
@@ -233,7 +233,7 @@ $dots-space: 1.3rem;
         height: 1.7rem;
         background: $blue-dark;
         margin-top: 0.2rem;
-        margin-right: 0.1rem;
+        margin-right: -5px;
       }
     }
 

--- a/app/javascript/components/LatestInformation.js
+++ b/app/javascript/components/LatestInformation.js
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import plusIcon from 'images/icons/plus.svg';
+import minusIcon from 'images/icons/minus.svg';
+
+const LatestInformation = ({ company }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const buttonText = expanded ? 'Read less' : 'Read more';
+
+  return (
+    <section className="container latest-information__wrapper">
+      <div className="latest-information__container">
+        <h6 className="latest-information__header">Latest information available on {company.name}</h6>
+        <p
+          className={cx('latest-information__description', { 'latest-information__description--folded': !expanded })}
+        >
+          {company.latest_information}
+        </p>
+        <button onClick={() => setExpanded(!expanded)} type="button" className="latest-information__button-container">
+          <img src={expanded ? minusIcon : plusIcon} className="latest-information__button" />
+          <span className="latest-information__button-text">{buttonText}</span>
+        </button>
+      </div>
+    </section>
+  );
+};
+
+LatestInformation.propTypes = {
+  company: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    latest_information: PropTypes.string.isRequired
+  }).isRequired
+};
+
+export default LatestInformation;

--- a/app/javascript/components/LatestInformation.js
+++ b/app/javascript/components/LatestInformation.js
@@ -8,6 +8,9 @@ const LatestInformation = ({ company }) => {
   const [expanded, setExpanded] = useState(false);
 
   const buttonText = expanded ? 'Read less' : 'Read more';
+  const textLength = company.latest_information.length;
+  const MAX_CHARACTERS_FOR_THREE_LINES = 270;
+  const showButton = textLength > MAX_CHARACTERS_FOR_THREE_LINES;
 
   return (
     <section className="container latest-information__wrapper">
@@ -18,10 +21,12 @@ const LatestInformation = ({ company }) => {
         >
           {company.latest_information}
         </p>
-        <button onClick={() => setExpanded(!expanded)} type="button" className="latest-information__button-container">
-          <img src={expanded ? minusIcon : plusIcon} className="latest-information__button" />
-          <span className="latest-information__button-text">{buttonText}</span>
-        </button>
+        {showButton && (
+          <button onClick={() => setExpanded(!expanded)} type="button" className="latest-information__button-container">
+            <img src={expanded ? minusIcon : plusIcon} className="latest-information__button" />
+            <span className="latest-information__button-text">{buttonText}</span>
+          </button>
+        )}
       </div>
     </section>
   );

--- a/app/views/tpi/companies/show.html.erb
+++ b/app/views/tpi/companies/show.html.erb
@@ -162,9 +162,6 @@
     </section>
   <% end %>
   <% if @company.latest_information.present? %>
-    <section class="container">
-      <h4 class="latest-information__header">Latest information available on <%= @company.name %></h4>
-      <p class="latest-information__description"><%= @company.latest_information %></p>
-    </section>
+    <%= react_component("LatestInformation", { company: @company }) %>
   <% end %>
 </div>

--- a/app/views/tpi/companies/show.html.erb
+++ b/app/views/tpi/companies/show.html.erb
@@ -162,9 +162,9 @@
     </section>
   <% end %>
   <% if @company.latest_information.present? %>
-    <div>
-      <h4>Latest information available on <%= @company.name %></h4>
-      <p><%= @company.latest_information %></p>
-    </div>
+    <section class="container">
+      <h4 class="latest-information__header">Latest information available on <%= @company.name %></h4>
+      <p class="latest-information__description"><%= @company.latest_information %></p>
+    </section>
   <% end %>
 </div>

--- a/app/views/tpi/companies/show.html.erb
+++ b/app/views/tpi/companies/show.html.erb
@@ -161,4 +161,10 @@
       </div>
     </section>
   <% end %>
+  <% if @company.latest_information.present? %>
+    <div>
+      <h4>Latest information available on <%= @company.name %></h4>
+      <p><%= @company.latest_information %></p>
+    </div>
+  <% end %>
 </div>

--- a/app/views/tpi/home/index.html.erb
+++ b/app/views/tpi/home/index.html.erb
@@ -22,19 +22,18 @@
 <section class="section tpi-home__hero is-secondary">
   <div class="container tpi-hero__body">
     <div class="columns">
-      <div class="column is-half section-separator">
+      <%= link_to '/tpi/investors', class: "column is-half section-separator section-clickable" do %>
         <h4 class="section-title">How investors can use the TPI</h4>
 
         <p class="section-description">
           The TPI is designed to support investors. Find out how they can use its findings.
         </p>
         <div class="subsection-button__container">
-          <button class="section-button"><%= image_tag "icons/plus.svg" %></button>
-          <a href="tpi/investors" class="button__title">TPI for investors</a>
+          <button class="section-button"></button>
+          <span class="button__title">TPI for investors</span>
         </div>
-      </div>
-
-      <div class="column is-half right-column">
+      <% end %>
+      <%= link_to '/tpi/supporters', class: "column is-half right-column section-clickable" do %>
         <h4 class="section-title">Supporters</h4>
 
         <p class="section-description">
@@ -42,10 +41,10 @@
         </p>
 
         <div class="subsection-button__container">
-          <button class="section-button"><%= image_tag "icons/plus.svg" %></button>
-          <a href="/tpi/supporters" class="button__title">Who supports the TPI?</a>
+          <button class="section-button"></button>
+          <span class="button__title">Who supports the TPI?</span>
         </div>
-      </div>
+      <% end %>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Make the whole sections cards clickable on TPI homepage (Investors and Supporters) and add styles for hovering.

<img width="652" alt="Screenshot 2019-12-17 at 17 18 52" src="https://user-images.githubusercontent.com/6136899/71018972-657b2d80-20f1-11ea-8230-3a61c7be5a4f.png">
