### PR TITLE
Make investors and supporters clickable on TPI homepage

### DIFF
--- a/app/assets/images/icons/plus-blue.svg
+++ b/app/assets/images/icons/plus-blue.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="14px" height="14px" viewBox="0 0 14 14" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: sketchtool 60.1 (101010) - https://sketch.com -->
+    <title>C5B80854-8532-44F2-8D9F-B3A6F10158E2</title>
+    <desc>Created with sketchtool.</desc>
+    <g id="TPI-visuals" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="TPI---Home" transform="translate(-117.000000, -940.000000)" fill="#083AAB" fill-rule="nonzero">
+            <g id="Group-7" transform="translate(0.000000, 690.000000)">
+                <g id="Group-6" transform="translate(109.000000, 242.000000)">
+                    <g id="Group-5">
+                        <polygon id="+" points="13.326087 13.326087 13.326087 8 16.673913 8 16.673913 13.326087 22 13.326087 22 16.673913 16.673913 16.673913 16.673913 22 13.326087 22 13.326087 16.673913 8 16.673913 8 13.326087"></polygon>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/app/assets/stylesheets/tpi/_hero.scss
+++ b/app/assets/stylesheets/tpi/_hero.scss
@@ -80,12 +80,29 @@
   }
 }
 
+.section-clickable {
+  &:hover {
+    .subsection-button__container {
+      .section-button {
+        background-color: $yellow;
+        background-image: image-url('icons/plus-blue.svg');
+      }
+
+      .button__title {
+        text-decoration: underline;
+      }
+    }
+  }
+}
+
 .section-title {
   margin-bottom: 20px;
+  color: $white;
 }
 
 .section-description {
   margin-bottom: 20px;
+  color: $white;
 
   @media #{$tablet-portrait} {
     margin-bottom: 64px;
@@ -104,6 +121,9 @@
   justify-content: center;
   align-items: center;
   margin-right: 10px;
+  background-image: image-url('icons/plus.svg');
+  background-repeat: no-repeat;
+  background-position: center;
 }
 
 .subsection-button__container {

--- a/app/views/tpi/home/index.html.erb
+++ b/app/views/tpi/home/index.html.erb
@@ -22,19 +22,18 @@
 <section class="section tpi-home__hero is-secondary">
   <div class="container tpi-hero__body">
     <div class="columns">
-      <div class="column is-half section-separator">
+      <%= link_to '/tpi/investors', class: "column is-half section-separator section-clickable" do %>
         <h4 class="section-title">How investors can use the TPI</h4>
 
         <p class="section-description">
           The TPI is designed to support investors. Find out how they can use its findings.
         </p>
         <div class="subsection-button__container">
-          <button class="section-button"><%= image_tag "icons/plus.svg" %></button>
-          <a href="tpi/investors" class="button__title">TPI for investors</a>
+          <button class="section-button"></button>
+          <span class="button__title">TPI for investors</span>
         </div>
-      </div>
-
-      <div class="column is-half right-column">
+      <% end %>
+      <%= link_to '/tpi/supporters', class: "column is-half right-column section-clickable" do %>
         <h4 class="section-title">Supporters</h4>
 
         <p class="section-description">
@@ -42,10 +41,10 @@
         </p>
 
         <div class="subsection-button__container">
-          <button class="section-button"><%= image_tag "icons/plus.svg" %></button>
-          <a href="/tpi/supporters" class="button__title">Who supports the TPI?</a>
+          <button class="section-button"></button>
+          <span class="button__title">Who supports the TPI?</span>
         </div>
-      </div>
+      <% end %>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Make the whole sections cards clickable on TPI homepage (Investors and Supporters) and add styles for hovering.
<img width="652" alt="Screenshot 2019-12-17 at 17 18 52" src="https://user-images.githubusercontent.com/6136899/71019284-fc47ea00-20f1-11ea-9c4d-7a06b4240cef.png">
