### PR TITLE
Fix publications layout

### DIFF
--- a/app/assets/stylesheets/tpi/_publications.scss
+++ b/app/assets/stylesheets/tpi/_publications.scss
@@ -72,9 +72,14 @@ $max-lines: 3;
   min-height: 200px;
 
   &__avatar {
-    max-height: 150px;
     margin: 0 auto;
     margin-bottom: 20px;
+    
+    width: 100%;
+    height: 200px;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
 
     @include desktop {
       margin-bottom: 20px;
@@ -137,9 +142,11 @@ $max-lines: 3;
     display: flex;
     align-items: flex-start;
     margin-bottom: 22px;
+    flex-wrap: wrap;
 
     & > .tag {
       margin-right: 12px;
+      margin-bottom: 8px;
       
       &:last-child {
         margin-right: 0;
@@ -153,7 +160,7 @@ $max-lines: 3;
   grid-row-gap: 30px;
   grid-column-gap: 30px;
   grid-template-columns: repeat(1, 1fr);
-  align-items: center;
+  align-items: flex-start;
   padding: 1.75rem;
 
   @include desktop {

--- a/app/views/tpi/publications/_promoted.html.erb
+++ b/app/views/tpi/publications/_promoted.html.erb
@@ -4,7 +4,7 @@
     <% @publications_and_articles.each do |publication| %>
       <div class="publication">
         <% if publication.thumbnail.present? %>
-          <%= image_tag(publication.thumbnail, class: "publication__avatar") %>
+          <div class="publication__avatar" style="background-image: url(<%= url_for(publication.thumbnail) %>)"></div>
         <% end %>
 
         <div class="publication__content">


### PR DESCRIPTION
This PR fixes the publications layout:
`/tpi/publications`
`/tpi/sectors/:sectorWhoseTagsAreInSomePublicationsOrArticles`
* Fix the stretching of columns (disrupted by too many tags)
* Wrap the tags to another line if there are more
* Align the images to the top of the container
* Use background-image to have more control of the images that are added

![image](https://user-images.githubusercontent.com/6136899/71089102-03293800-2198-11ea-9146-95b427c5b1de.png)
 