### PR TITLE
Upgrade octokit to remove warning from Faraday on server startup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'devise', '>= 4.7.1'
 gem 'cancancan'
 gem 'draper'
 
-gem 'octokit', '~> 4.0'
+gem 'octokit', '~> 4.15.0'
 
 gem 'google-cloud-storage', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
-    faraday (0.17.1)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.3)
     font-awesome-rails (4.7.0.5)
@@ -273,7 +273,8 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
-    octokit (4.14.0)
+    octokit (4.15.0)
+      faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     orm_adapter (0.5.0)
     os (1.0.1)
@@ -291,7 +292,7 @@ GEM
       activerecord (>= 3.0)
       i18n (>= 0.5.0)
       railties (>= 3.0.0)
-    public_suffix (4.0.1)
+    public_suffix (4.0.3)
     puma (4.3.1)
       nio4r (~> 2.0)
     rack (2.0.8)
@@ -506,7 +507,7 @@ DEPENDENCIES
   image_processing
   language_list
   listen (>= 3.0.5, < 3.2)
-  octokit (~> 4.0)
+  octokit (~> 4.15.0)
   pg (>= 0.18, < 2.0)
   pg_search
   public_activity


### PR DESCRIPTION
Fixes this issue: https://github.com/Vizzuality/laws_and_pathways/issues/217
In the Octokit release notes it mentions that the new version removes the deprecation warning. https://github.com/octokit/octokit.rb/releases/tag/v4.15.0