### PR TITLE
Use cp assessment publication date to select benchmark instead of assessment date.

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -60,7 +60,7 @@ class Company < ApplicationRecord
   end
 
   def latest_sector_benchmarks_before_last_assessment
-    sector.latest_benchmarks_for_date(latest_cp_assessment&.assessment_date)
+    sector.latest_benchmarks_for_date(latest_cp_assessment&.publication_date)
   end
 
   def isin_array

--- a/app/models/tpi_sector.rb
+++ b/app/models/tpi_sector.rb
@@ -41,8 +41,8 @@ class TPISector < ApplicationRecord
   #
   # @example Company has assessment:
   # - benchmarks available for 04.2017 and 05.2018
-  # - if assessment date is 06.2018 - we take benchmarks from 05.2018
-  # - if assessment date is 06.2017 - we take benchmarks from 04.2017
+  # - if assessment publication date is 06.2018 - we take benchmarks from 05.2018
+  # - if assessment publication date is 06.2017 - we take benchmarks from 04.2017
   def latest_benchmarks_for_date(date)
     return latest_released_benchmarks unless date
 
@@ -50,7 +50,7 @@ class TPISector < ApplicationRecord
 
     last_release_date_before_given_date =
       sector_benchmarks_dates
-        .select { |d| d < date }
+        .select { |d| d <= date }
         .last
 
     release_date =

--- a/app/services/api/charts/cp_assessment.rb
+++ b/app/services/api/charts/cp_assessment.rb
@@ -62,7 +62,7 @@ module Api
       def emissions_data_from_sector_benchmarks
         company
           .sector
-          .latest_benchmarks_for_date(assessment.assessment_date)
+          .latest_benchmarks_for_date(assessment.publication_date)
           .sort_by(&:average_emission)
           .map.with_index do |benchmark, index|
             {

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -102,15 +102,15 @@ RSpec.describe Company, type: :model do
     end
     let(:company_assessments) do
       [
-        create(:cp_assessment, assessment_date: '2012-05-01'),
-        create(:cp_assessment, assessment_date: '2013-05-01'),
-        create(:cp_assessment, assessment_date: '2018-05-01') # <- last assessment date
+        create(:cp_assessment, assessment_date: '2012-05-01', publication_date: '2012-05-01'),
+        create(:cp_assessment, assessment_date: '2013-05-01', publication_date: '2013-05-01'),
+        create(:cp_assessment, assessment_date: '2018-05-01', publication_date: '2018-05-01') # <- last assessment date
       ]
     end
     let(:older_company_assessments) do
       [
-        create(:cp_assessment, assessment_date: '2011-05-01'),
-        create(:cp_assessment, assessment_date: '2012-05-01')
+        create(:cp_assessment, assessment_date: '2011-05-01', publication_date: '2011-05-01'),
+        create(:cp_assessment, assessment_date: '2012-05-01', publication_date: '2012-05-01')
       ]
     end
 


### PR DESCRIPTION
Use cp assessment publication date to select benchmark instead of assessment date.

Having two dates is quite confusing, we need to think about it and ask which one is purely informative (I guess now assessment date) and not use it in the any logic probably (like latest assessment etc)