### PR TITLE
Missing climate targets in single law page

### DIFF
--- a/app/assets/stylesheets/cclow/_geography-page.scss
+++ b/app/assets/stylesheets/cclow/_geography-page.scss
@@ -203,6 +203,12 @@ $count-description-lines: 2;
   .climate-targets-section {
     margin-bottom: 3rem;
 
+    .climate-targets__content {
+      border: 1px solid $border-cl;
+      border-bottom: none;
+      border-top: none;
+    }
+
     h5 {
       margin-bottom: 0.875rem;
     }
@@ -220,9 +226,7 @@ $count-description-lines: 2;
     }
 
     li {
-      border-bottom: solid 1px $grey;
-      border-left: solid 1px $grey;
-      border-right: solid 1px $grey;
+      border-bottom: solid 1px $border-cl;
       margin: 0;
       padding: 2.5rem;
     }
@@ -500,6 +504,7 @@ $count-description-lines: 2;
     border-bottom: solid 1px $grey-light;
     padding-bottom: 1rem;
 
+  .tags {
     .tag {
       font-size: $size-8;
       height: 30px;

--- a/app/assets/stylesheets/cclow/_geography-page.scss
+++ b/app/assets/stylesheets/cclow/_geography-page.scss
@@ -503,6 +503,7 @@ $count-description-lines: 2;
   .filter-tags {
     border-bottom: solid 1px $grey-light;
     padding-bottom: 1rem;
+  }
 
   .tags {
     .tag {

--- a/app/views/cclow/geography/legislations/_climate_targets.html.erb
+++ b/app/views/cclow/geography/legislations/_climate_targets.html.erb
@@ -3,7 +3,7 @@
     <h5>Climate targets in this law</h5>
     <span class="counter"><%= pluralize(targets.count, 'target') %></span>
   </div>
-  <ul>
+  <ul class="climate-targets__content">
     <% targets.each do |target| %>
       <li>
         <div>

--- a/app/views/cclow/geography/legislations/show.html.erb
+++ b/app/views/cclow/geography/legislations/show.html.erb
@@ -33,7 +33,10 @@
 <div class="content-show">
   <h3 class="title"><%= @legislation.title %></h3>
   <div class="meta">
-    <div><%= @legislation.legislation_type&.humanize %></div>
+    <div>
+      <img src=<%= asset_path "icons/legislation_types/#{@legislation.legislation_type}.svg"%> alt="">
+      <%= @legislation.legislation_type&.humanize %>
+    </div>
     <div>
       <span>Action plan</span>
       <!--<span class="icon"><i class="fa fa-question"></i></span>-->


### PR DESCRIPTION
* Add a missing icon for legislation type in geography law page
* Fix styles for the climate targets
* Climate targets partial appears only if legislation has targets