### PR TITLE
Disable infinite feature of the carousel

### DIFF
--- a/app/assets/stylesheets/cclow/_latest-additions-slider.scss
+++ b/app/assets/stylesheets/cclow/_latest-additions-slider.scss
@@ -11,6 +11,10 @@ $slide-padding: 10px;
     margin: 0 -$slide-padding;
   }
 
+  .slick-disabled {
+    display: none !important;
+  }
+
   .slick-arrow {
     margin: auto 0;
     position: absolute;

--- a/app/javascript/shared/controllers/slider_controller.js
+++ b/app/javascript/shared/controllers/slider_controller.js
@@ -3,6 +3,7 @@ import { Controller } from 'stimulus';
 export default class extends Controller {
   connect() {
     $(this.element).slick({
+      infinite: false,
       prevArrow: '<button type="button" class="slick-prev"><i class="fa fa-1x fa-arrow-left"></i></button>',
       nextArrow: '<button type="button" class="slick-next"><i class="fa fa-1x fa-arrow-right"></i></button>',
       responsive: [


### PR DESCRIPTION
* Disable infinite feature of the carousel - don't show back arrows if user hasn't interacted with the next-arrow and similarly, don't show next-arrow to go back to the beginning of content (infinite carousel)
* `!important` added as it's a third party element styled with `style` tag that has a higher priority over overriding `slick-disabled` class

![image](https://user-images.githubusercontent.com/6136899/72056729-0dd17b80-32c5-11ea-936e-a5ffef4054dc.png)
