### PR TITLE
Add dotted timeline to a single point event

### DIFF
--- a/app/assets/stylesheets/cclow/_events_timeline.scss
+++ b/app/assets/stylesheets/cclow/_events_timeline.scss
@@ -6,7 +6,6 @@ $arrow-btn-width: 48px;
   display: flex;
   position: relative;
   overflow: hidden;
-  margin-left: $arrow-btn-width;
   width: calc(100% - #{$arrow-btn-width * 2});
 
   .timeline {

--- a/app/assets/stylesheets/cclow/_events_timeline.scss
+++ b/app/assets/stylesheets/cclow/_events_timeline.scss
@@ -17,37 +17,37 @@ $arrow-btn-width: 48px;
     position: relative;
     text-align: center;
     width: 275px;
-  }
 
-  .time-point.time-point-multiple-events {
-    &:first-child {
-      text-align: left;
-      width: 145px;
-    }
-  }
-
-  .time-point-multiple-events {
-    &:last-child {
-      .point {
-        &:after {
-          border: none;
-        }
+    &.time-point-multiple-events {
+      &:first-child {
+        text-align: left;
+        width: 145px;
       }
     }
 
-    &:first-child {
-      .point {
-        &:before {
-          border: none;
+    &-multiple-events {
+      &:last-child {
+        .point {
+          &:after {
+            border: none;
+          }
         }
       }
-
-      .event-title {
-        justify-content: flex-start;
-      }
-
-      .point {
-        margin: unset;
+  
+      &:first-child {
+        .point {
+          &:before {
+            border: none;
+          }
+        }
+  
+        .event-title {
+          justify-content: flex-start;
+        }
+  
+        .point {
+          margin: unset;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/cclow/_events_timeline.scss
+++ b/app/assets/stylesheets/cclow/_events_timeline.scss
@@ -18,13 +18,6 @@ $arrow-btn-width: 48px;
     text-align: center;
     width: 275px;
 
-    &.time-point-multiple-events {
-      &:first-child {
-        text-align: left;
-        width: 145px;
-      }
-    }
-
     &-multiple-events {
       &:last-child {
         .point {
@@ -35,6 +28,9 @@ $arrow-btn-width: 48px;
       }
   
       &:first-child {
+        text-align: left;
+        width: 145px;
+
         .point {
           &:before {
             border: none;

--- a/app/assets/stylesheets/cclow/_events_timeline.scss
+++ b/app/assets/stylesheets/cclow/_events_timeline.scss
@@ -19,6 +19,13 @@ $arrow-btn-width: 48px;
     width: 275px;
   }
 
+  .time-point.time-point-multiple-events {
+    &:first-child {
+      text-align: left;
+      width: 145px;
+    }
+  }
+
   .time-point-multiple-events {
     &:last-child {
       .point {
@@ -33,6 +40,14 @@ $arrow-btn-width: 48px;
         &:before {
           border: none;
         }
+      }
+
+      .event-title {
+        justify-content: flex-start;
+      }
+
+      .point {
+        margin: unset;
       }
     }
   }

--- a/app/assets/stylesheets/cclow/_events_timeline.scss
+++ b/app/assets/stylesheets/cclow/_events_timeline.scss
@@ -32,6 +32,8 @@ $arrow-btn-width: 48px;
         width: 145px;
 
         .point {
+          margin: unset;
+
           &:before {
             border: none;
           }
@@ -39,10 +41,6 @@ $arrow-btn-width: 48px;
   
         .event-title {
           justify-content: flex-start;
-        }
-  
-        .point {
-          margin: unset;
         }
       }
     }

--- a/app/assets/stylesheets/cclow/_events_timeline.scss
+++ b/app/assets/stylesheets/cclow/_events_timeline.scss
@@ -18,7 +18,9 @@ $arrow-btn-width: 48px;
     position: relative;
     text-align: center;
     width: 275px;
+  }
 
+  .time-point-multiple-events {
     &:last-child {
       .point {
         &:after {

--- a/app/javascript/components/EventsTimeline.js
+++ b/app/javascript/components/EventsTimeline.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { format } from 'date-fns';
+import cx from 'classnames';
 import Testimonials from './Testimonials';
 import MultiSelect from './MultiSelect';
 
@@ -93,7 +94,7 @@ const EventsTimeline = ({ events, options, isFiltered = false }) => {
         <div ref={eventsContainerEl} onScroll={checkButtons} className="events-container">
           <div className="timeline">
             {currentEvents.map((event) => (
-              <div key={event.title} className="time-point">
+              <div key={event.title} className={cx('time-point', { 'time-point-multiple-events': currentEvents.length > 1 })}>
                 <div className="event-title">{ event.title }</div>
                 <div className="point" />
                 <div className="date">{ format(new Date(event.date), 'MMMM Y') }</div>


### PR DESCRIPTION
* If there's only one event on the timeline, keep the dotted line
* All left-aligned as per client's request except when there is only one event in order to show the dotted timeline

**Single event**:

![image](https://user-images.githubusercontent.com/6136899/72064474-dc13e100-32d3-11ea-8790-4a6872c844de.png)

**Two events**: 
![image](https://user-images.githubusercontent.com/6136899/72065667-acb2a380-32d6-11ea-92d1-95619ae7738a.png)

**More events**
![image](https://user-images.githubusercontent.com/6136899/72065780-ebe0f480-32d6-11ea-8a99-01f502457bcf.png)


