### PR TITLE
fix exporting litigations

### DIFF
--- a/app/admin/litigations.rb
+++ b/app/admin/litigations.rb
@@ -61,8 +61,8 @@ ActiveAdmin.register Litigation do
     column :id
     column :title
     column :document_type
-    column(:geography_iso) { |l| l.geography.iso }
-    column(:geography) { |l| l.geography.name }
+    column(:geography_iso) { |l| l.geography&.iso }
+    column(:geography) { |l| l.geography&.name }
     column :jurisdiction
     column :citation_reference_number
     column :summary


### PR DESCRIPTION
Quick fix for admin litigations export.

Geography is optional I see. Should it be? International cases do not have a geography. I thought there should be a special "International" geography, with flag and without region. That could be case for a new story to create it and properly apply filters when searching litigations.