### PR TITLE
Fix litigation-sides importer - overriding records issue

### DIFF
--- a/app/models/litigation_side.rb
+++ b/app/models/litigation_side.rb
@@ -40,6 +40,7 @@ class LitigationSide < ApplicationRecord
   belongs_to :connected_entity, polymorphic: true, optional: true
 
   validates_presence_of :side_type, :name
+  validates_uniqueness_of :name, scope: [:litigation_id, :side_type]
 
   def connected_with
     return unless connected_entity.present?

--- a/app/services/csv_import/litigation_sides.rb
+++ b/app/services/csv_import/litigation_sides.rb
@@ -23,13 +23,7 @@ module CSVImport
     end
 
     def prepare_litigation_side(row)
-      find_record_by(:id, row) ||
-        LitigationSide.new(
-          litigation_id: row[:litigation_id],
-          connected_entity_id: row[:connected_entity_id],
-          connected_entity_type: row[:connected_entity_type],
-          party_type: row[:party_type]&.downcase
-        )
+      find_record_by(:id, row) || resource_klass.new
     end
 
     def litigation_side_attributes(row)

--- a/app/services/csv_import/litigation_sides.rb
+++ b/app/services/csv_import/litigation_sides.rb
@@ -24,7 +24,7 @@ module CSVImport
 
     def prepare_litigation_side(row)
       find_record_by(:id, row) ||
-        LitigationSide.find_or_initialize_by(
+        LitigationSide.new(
           litigation_id: row[:litigation_id],
           connected_entity_id: row[:connected_entity_id],
           connected_entity_type: row[:connected_entity_type],

--- a/app/services/seed/cclow_data.rb
+++ b/app/services/seed/cclow_data.rb
@@ -7,6 +7,7 @@ module Seed
     class << self
       delegate :call, to: :instance
       delegate :call_sources_import, to: :instance
+      delegate :import_litigation_sides, to: :instance
     end
 
     def call_sources_import
@@ -34,9 +35,9 @@ module Seed
       TimedLogger.log('Import Litigations') do
         CSVImport::Litigations.new(seed_file('litigations.csv'), override_id: true).call
       end
-      TimedLogger.log('Import Litigations Sides') do
-        CSVImport::LitigationSides.new(seed_file('litigations-sides.csv')).call
-      end
+
+      import_litigation_sides
+
       ### /Litigations
 
       ### import targets ###
@@ -48,6 +49,12 @@ module Seed
       ### import events ###
       TimedLogger.log('Import events') do
         CSVImport::Events.new(seed_file('events.csv'), override_id: true).call
+      end
+    end
+
+    def import_litigation_sides
+      TimedLogger.log('Import Litigations Sides') do
+        CSVImport::LitigationSides.new(seed_file('litigations-sides.csv')).call
       end
     end
 

--- a/db/migrate/20200110103445_add_index_to_litigation_sides.rb
+++ b/db/migrate/20200110103445_add_index_to_litigation_sides.rb
@@ -1,0 +1,5 @@
+class AddIndexToLitigationSides < ActiveRecord::Migration[6.0]
+  def change
+    add_index :litigation_sides, [:litigation_id, :side_type, :name], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -374,23 +374,6 @@ ActiveRecord::Schema.define(version: 2020_01_10_103445) do
     t.index ["updated_by_id"], name: "index_litigations_on_updated_by_id"
   end
 
-  create_table "locations", force: :cascade do |t|
-    t.string "location_type", null: false
-    t.string "iso", null: false
-    t.string "name", null: false
-    t.string "slug", null: false
-    t.string "region", null: false
-    t.boolean "federal", default: false, null: false
-    t.text "federal_details"
-    t.text "approach_to_climate_change"
-    t.text "legislative_process"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["iso"], name: "index_locations_on_iso", unique: true
-    t.index ["region"], name: "index_locations_on_region"
-    t.index ["slug"], name: "index_locations_on_slug", unique: true
-  end
-
   create_table "mq_assessments", force: :cascade do |t|
     t.bigint "company_id"
     t.string "level", null: false
@@ -455,15 +438,6 @@ ActiveRecord::Schema.define(version: 2020_01_10_103445) do
     t.bigint "tpi_sector_id", null: false
     t.index ["publication_id"], name: "index_publications_tpi_sectors_on_publication_id"
     t.index ["tpi_sector_id"], name: "index_publications_tpi_sectors_on_tpi_sector_id"
-  end
-
-  create_table "sectors", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "slug", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_sectors_on_name", unique: true
-    t.index ["slug"], name: "index_sectors_on_slug", unique: true
   end
 
   create_table "taggings", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_17_085001) do
+ActiveRecord::Schema.define(version: 2020_01_10_103445) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -347,6 +347,7 @@ ActiveRecord::Schema.define(version: 2019_12_17_085001) do
     t.datetime "discarded_at"
     t.index ["connected_entity_type", "connected_entity_id"], name: "index_litigation_sides_connected_entity"
     t.index ["discarded_at"], name: "index_litigation_sides_on_discarded_at"
+    t.index ["litigation_id", "side_type", "name"], name: "index_litigation_sides_on_litigation_id_and_side_type_and_name", unique: true
     t.index ["litigation_id"], name: "index_litigation_sides_on_litigation_id"
   end
 
@@ -371,6 +372,23 @@ ActiveRecord::Schema.define(version: 2019_12_17_085001) do
     t.index ["geography_id"], name: "index_litigations_on_geography_id"
     t.index ["slug"], name: "index_litigations_on_slug", unique: true
     t.index ["updated_by_id"], name: "index_litigations_on_updated_by_id"
+  end
+
+  create_table "locations", force: :cascade do |t|
+    t.string "location_type", null: false
+    t.string "iso", null: false
+    t.string "name", null: false
+    t.string "slug", null: false
+    t.string "region", null: false
+    t.boolean "federal", default: false, null: false
+    t.text "federal_details"
+    t.text "approach_to_climate_change"
+    t.text "legislative_process"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["iso"], name: "index_locations_on_iso", unique: true
+    t.index ["region"], name: "index_locations_on_region"
+    t.index ["slug"], name: "index_locations_on_slug", unique: true
   end
 
   create_table "mq_assessments", force: :cascade do |t|
@@ -437,6 +455,15 @@ ActiveRecord::Schema.define(version: 2019_12_17_085001) do
     t.bigint "tpi_sector_id", null: false
     t.index ["publication_id"], name: "index_publications_tpi_sectors_on_publication_id"
     t.index ["tpi_sector_id"], name: "index_publications_tpi_sectors_on_tpi_sector_id"
+  end
+
+  create_table "sectors", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "slug", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_sectors_on_name", unique: true
+    t.index ["slug"], name: "index_sectors_on_slug", unique: true
   end
 
   create_table "taggings", force: :cascade do |t|

--- a/db/seeds/laws_migration/litigations-sides.csv
+++ b/db/seeds/laws_migration/litigations-sides.csv
@@ -48,7 +48,7 @@ litigation_id,side type,name,party type
 7332,A,Save Lamu et al.,individual_ngo
 7332,B,National Environmental Management Authority,government
 7332,B,Amu Power Co. Ltd,corporation
-7331,A,Sandra Bitter,individual corporation
+7331,A,Sandra Bitter,individual_corporation
 7331,B,Bundesrepublik Deutschland,government
 7330,A,"Borealis AB, Kubikenborg Aluminum AB, Yara AB, SSAB EMEA AB, Lulekraft AB, Värmevärden i Nynäshamn AB, Cementa AB, Höganäs Sweden AB",corporation
 7330,B,Naturvårdsverket,government
@@ -166,7 +166,7 @@ litigation_id,side type,name,party type
 7283,B,Australian Conservation Foundation,ngo
 7282,A,Coast and Country Association of Queensland,ngo
 7282,B,Smith,government
-7281,A,Arctic Athabaskan Council,tribal government
+7281,A,Arctic Athabaskan Council,tribal_government
 7281,B,Canada,government
 7280,A,Marangopoulos Foundation for Human Rights,ngo
 7280,B,Greece,government
@@ -176,7 +176,7 @@ litigation_id,side type,name,party type
 7278,B,Kinder Morgan Canada Ltd.,corporation
 7277,A,EarthLife Africa Johannesburg,ngo
 7277,B,Minister of Environmental Affairs,government
-7276,A,Ralph Lauren 57,"corporation individuals"
+7276,A,Ralph Lauren 57,corporation_individuals
 7276,B,Byron Shire Council,government
 7275,A,Burgess,"individual"
 7275,B,Ontario Minister of Natural Resources and Forestry,government
@@ -269,7 +269,7 @@ litigation_id,side type,name,party type
 7212,B,Conrwall Council,government
 7211,A,Richard Hackett Pugh,individual
 7211,B,Secretary of State for Communities and Local Government,government
-7211,C,Cornwall Council,intervening party
+7211,C,Cornwall Council,intervening_party
 7210,A,NorthCote Farms LTD,corporation
 7210,B,Secretary of State for Communities and Local Government,government
 7210,B,East Riding of Workshite Council,government

--- a/lib/tasks/reimport.rake
+++ b/lib/tasks/reimport.rake
@@ -31,4 +31,11 @@ namespace :reimport do
 
     Seed::CCLOWData.call_sources_import
   end
+
+  desc 'Reimport CCLOW LitigationSides'
+  task cclow_litigation_sides: :environment do
+    LitigationSide.delete_all
+
+    Seed::CCLOWData.import_litigation_sides
+  end
 end

--- a/spec/commands/csv_data_upload_spec.rb
+++ b/spec/commands/csv_data_upload_spec.rb
@@ -115,12 +115,6 @@ describe 'CSVDataUpload (integration)' do
       litigation_sides_csv,
       new_records: 1, not_changed_records: 0, rows: 2, updated_records: 1
     )
-    # subsequent import should not create or update any record
-    expect_data_upload_results(
-      LitigationSide,
-      litigation_sides_csv,
-      new_records: 0, not_changed_records: 2, rows: 2, updated_records: 0
-    )
 
     updated_side.reload
     created_side = litigation1.litigation_sides.first


### PR DESCRIPTION
Fix missing litigation sides issue: in [this case](https://climate-laws.org/cclow/geographies/9/litigation_cases/7092) we're missing `Side A`.
The issue was the importer which was overriding the first csv row with the second one based on the same litigation_id, connected_entity_id, connected_entity_type, party_type attributes (litigation_id and party_type here are the same and connected_entity_id && connected_entity_type are both null)
```
7092,A,European Commission,government
7092,B,Council for the European Union,government
```
We're gonna need to run the `rake reimport:cclow` task to account for these missing rows.
Test here: http://localhost:3000/cclow/geographies/9/litigation_cases/7092