### PR TITLE
Fix hovering on navbar dropdowns in Edge

### DIFF
--- a/app/assets/stylesheets/tpi/_navbar.scss
+++ b/app/assets/stylesheets/tpi/_navbar.scss
@@ -3,6 +3,17 @@
 
 .tpi__navbar {
 
+  // EDGE workaround: Fix the hovering navbar dropdowns issue: https://github.com/jgthms/bulma/issues/2503
+  @include desktop {
+    .navbar-item {
+      &.is-hoverable:hover {
+          .navbar-dropdown {
+              display: block;
+          }
+      }
+    }
+  }
+
   .navbar {    
     &__search {
       background: $white;


### PR DESCRIPTION
Hovering on navbar dropdowns (TPI) was not working in Edge browser. There's an issue with Bulma class that is using `:focus-within` pseudoclass which is not supported in Edge. I added a workaround.