### PR TITLE
Show research funding partners logos on homepage

### DIFF
--- a/app/controllers/tpi/home_controller.rb
+++ b/app/controllers/tpi/home_controller.rb
@@ -9,7 +9,7 @@ module TPI
         }
       end
 
-      @partners_logos = TPIPage.find_by(slug: 'supporters')&.contents&.find_by(content_type: 'partners')&.images
+      @partners_logos = TPIPage.find_by(slug: 'research-funding-partners')&.contents&.map { |c| c.images }&.flatten
 
       publications = Publication.order(publication_date: :desc).limit(3)
       news = NewsArticle.order(publication_date: :desc).limit(3)


### PR DESCRIPTION
Under Research Funding Partners on the homepage show logos from `research-funding-partners` TPIPage slug.

![image](https://user-images.githubusercontent.com/6136899/72271026-0cce8000-361e-11ea-9f75-3914b54c727c.png)
