### PR TITLE
Instead of defining height, define width for the homepage logos

### DIFF
--- a/app/assets/stylesheets/tpi/_banner.scss
+++ b/app/assets/stylesheets/tpi/_banner.scss
@@ -48,7 +48,7 @@
 
   a {
     img {
-      height: 50px;
+      width: 150px;
     }
   }
 }


### PR DESCRIPTION
Set a width instead of height, so the height will be calculated automatically. This is a fix for the logos on the TPI homepage.