### PR TITLE
Make litigation sides linkable

### DIFF
--- a/app/assets/stylesheets/cclow/_geography-page.scss
+++ b/app/assets/stylesheets/cclow/_geography-page.scss
@@ -197,7 +197,12 @@ $count-description-lines: 2;
 
   .details {
     border: solid 1px $grey;
+    color: $blue-dark;
     padding: 3.12rem;
+
+    a {
+      color: $red;
+    }
   }
 
   .climate-targets-section {
@@ -572,10 +577,24 @@ mark {
       color: $blue-dark;
       font-size: 0.75rem;
       line-height: 0.938rem;
+      flex: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: unset;
+      text-align: center;
+      height: auto;
+      padding: 5px 15px;
 
       &:last-child {
         margin-right: 0;
       }
     }
   }
+}
+
+.tag__container {
+  display: flex;
+  max-width: 100px;
+  align-items: center;
 }

--- a/app/controllers/cclow/geography/litigation_cases_controller.rb
+++ b/app/controllers/cclow/geography/litigation_cases_controller.rb
@@ -9,7 +9,6 @@ module CCLOW
         @litigations = CCLOW::LitigationDecorator.decorate_collection(@litigations)
       end
 
-      # rubocop:disable Metrics/AbcSize
       def show
         @litigation = Litigation.find(params[:id])
         @legislations = CCLOW::LegislationDecorator.decorate_collection(@litigation.legislations)
@@ -18,13 +17,8 @@ module CCLOW
         @sectors = @litigation.laws_sectors.order(:name)
         @keywords = @litigation.keywords.order(:name)
         @responses = @litigation.responses.order(:name)
-        @jurisdiction = @litigation.jurisdiction
-        @party_types = @litigation.litigation_sides&.pluck(:party_type)
-        @sides_a = @litigation.litigation_sides.where(litigation_sides: {side_type: 'a'}).pluck(:name)
-        @sides_b = @litigation.litigation_sides.where(litigation_sides: {side_type: 'b'}).pluck(:name)
-        @sides_c = @litigation.litigation_sides.where(litigation_sides: {side_type: 'c'}).pluck(:name)
+        @litigation_sides = @litigation.litigation_sides.map { |ls| LitigationSideDecorator.decorate(ls) }
       end
-      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/app/controllers/cclow/geography/litigation_cases_controller.rb
+++ b/app/controllers/cclow/geography/litigation_cases_controller.rb
@@ -17,7 +17,7 @@ module CCLOW
         @sectors = @litigation.laws_sectors.order(:name)
         @keywords = @litigation.keywords.order(:name)
         @responses = @litigation.responses.order(:name)
-        @litigation_sides = @litigation.litigation_sides.map { |ls| LitigationSideDecorator.decorate(ls) }
+        @litigation_sides = @litigation.litigation_sides.map { |ls| CCLOW::LitigationSideDecorator.decorate(ls) }
       end
     end
   end

--- a/app/controllers/cclow/geography/litigation_cases_controller.rb
+++ b/app/controllers/cclow/geography/litigation_cases_controller.rb
@@ -9,6 +9,7 @@ module CCLOW
         @litigations = CCLOW::LitigationDecorator.decorate_collection(@litigations)
       end
 
+      # rubocop:disable Metrics/AbcSize
       def show
         @litigation = Litigation.find(params[:id])
         @legislations = CCLOW::LegislationDecorator.decorate_collection(@litigation.legislations)
@@ -17,7 +18,13 @@ module CCLOW
         @sectors = @litigation.laws_sectors.order(:name)
         @keywords = @litigation.keywords.order(:name)
         @responses = @litigation.responses.order(:name)
+        @jurisdiction = @litigation.jurisdiction
+        @party_types = @litigation.litigation_sides&.pluck(:party_type)
+        @sides_a = @litigation.litigation_sides.where(litigation_sides: {side_type: 'a'}).pluck(:name)
+        @sides_b = @litigation.litigation_sides.where(litigation_sides: {side_type: 'b'}).pluck(:name)
+        @sides_c = @litigation.litigation_sides.where(litigation_sides: {side_type: 'c'}).pluck(:name)
       end
+      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/app/decorators/cclow/litigation_side_decorator.rb
+++ b/app/decorators/cclow/litigation_side_decorator.rb
@@ -1,0 +1,17 @@
+module CCLOW
+  class LitigationSideDecorator < Draper::Decorator
+    delegate_all
+
+    def frontend_name
+      return h.link_to name, connected_entity_frontend_url if connected_entity.present?
+
+      name
+    end
+
+    private
+
+    def connected_entity_frontend_url
+      return h.cclow_geography_path(connected_entity) if connected_entity.is_a?(Geography)
+    end
+  end
+end

--- a/app/decorators/litigation_side_decorator.rb
+++ b/app/decorators/litigation_side_decorator.rb
@@ -7,6 +7,12 @@ class LitigationSideDecorator < Draper::Decorator
     model.name
   end
 
+  def frontend_name
+    return h.link_to model.name, connected_entity_frontend_url if connected_entity.present?
+
+    model.name
+  end
+
   def party_type
     model.party_type&.humanize
   end
@@ -20,5 +26,9 @@ class LitigationSideDecorator < Draper::Decorator
   def connected_entity_url
     return h.admin_company_path(connected_entity) if connected_entity.is_a?(Company)
     return h.admin_geography_path(connected_entity) if connected_entity.is_a?(Geography)
+  end
+
+  def connected_entity_frontend_url
+    return h.cclow_geography_path(connected_entity) if connected_entity.is_a?(Geography)
   end
 end

--- a/app/decorators/litigation_side_decorator.rb
+++ b/app/decorators/litigation_side_decorator.rb
@@ -7,12 +7,6 @@ class LitigationSideDecorator < Draper::Decorator
     model.name
   end
 
-  def frontend_name
-    return h.link_to model.name, connected_entity_frontend_url if connected_entity.present?
-
-    model.name
-  end
-
   def party_type
     model.party_type&.humanize
   end
@@ -26,9 +20,5 @@ class LitigationSideDecorator < Draper::Decorator
   def connected_entity_url
     return h.admin_company_path(connected_entity) if connected_entity.is_a?(Company)
     return h.admin_geography_path(connected_entity) if connected_entity.is_a?(Geography)
-  end
-
-  def connected_entity_frontend_url
-    return h.cclow_geography_path(connected_entity) if connected_entity.is_a?(Geography)
   end
 end

--- a/app/views/cclow/geography/litigation_cases/_details_card.html.erb
+++ b/app/views/cclow/geography/litigation_cases/_details_card.html.erb
@@ -9,15 +9,15 @@
     </p>
     <br>
   <% end %>
-  <% litigation.litigation_sides.each do |side| %>
+  <% @litigation_sides.each do |side| %>
     <p>
-      <b>Side <%=side.side_type.upcase %>: </b> <%= side.name %>
+      <b>Side <%=side.side_type.upcase %>: </b> <%= side.name %> (<%= side.party_type.humanize %>)
     </p>
     <br>
   <% end %>
   <% if litigation.at_issue.present? %>
     <p>
-      <b>Core objectives:</b><%= litigation.at_issue.html_safe %>
+      <b>Core objectives: </b><%= litigation.at_issue.html_safe %>
     </p>
   <% end %>
 </div>

--- a/app/views/cclow/geography/litigation_cases/_details_card.html.erb
+++ b/app/views/cclow/geography/litigation_cases/_details_card.html.erb
@@ -11,7 +11,7 @@
   <% end %>
   <% @litigation_sides.each do |side| %>
     <p>
-      <b>Side <%=side.side_type.upcase %>: </b> <%= side.name %> (<%= side.party_type.humanize %>)
+      <b>Side <%=side.side_type.upcase %>: </b> <%= side.frontend_name %> (<%= side.party_type.humanize %>)
     </p>
     <br>
   <% end %>

--- a/app/views/cclow/geography/litigation_cases/_details_card.html.erb
+++ b/app/views/cclow/geography/litigation_cases/_details_card.html.erb
@@ -11,7 +11,7 @@
   <% end %>
   <% @litigation_sides.each do |side| %>
     <p>
-      <b>Side <%=side.side_type.upcase %>: </b> <%= side.frontend_name %> (<%= side.party_type.humanize %>)
+      <b>Side <%=side.side_type.upcase %>: </b> <%= side.name %> (<%= side.party_type.humanize %>)
     </p>
     <br>
   <% end %>

--- a/app/views/cclow/geography/litigation_cases/show.html.erb
+++ b/app/views/cclow/geography/litigation_cases/show.html.erb
@@ -39,8 +39,66 @@
       </div>
     </div>
   <% end %>
+
+  <% if @jurisdiction.present? %>
+    <div class="categories__container">
+      <p class="categories__title">Jurisdiction</p>
+
+      <div class="categories_tags">
+        <span class="tag categories__tag"><%= @jurisdiction %></span>
+      </div>
+    </div>
+  <% end %>
+
+  <% if @party_types.count > 0 %>
+    <div class="categories__container">
+      <p class="categories__title">Party types</p>
+
+      <div class="categories_tags">
+      <% @party_types.each do |party_type| %>
+        <span class="tag categories__tag"><%= party_type %></span>
+      <% end %>
+      </div>
+    </div>
+  <% end %>
+
+  <% if @sides_a.count > 0 %>
+    <div class="categories__container">
+      <p class="categories__title">Side A</p>
+
+      <div class="categories_tags">
+      <% @sides_a.each do |side_a| %>
+        <span class="tag categories__tag"><%= side_a %></span>
+      <% end %>
+      </div>
+    </div>
+  <% end %>
+
+  <% if @sides_b.count > 0 %>
+    <div class="categories__container">
+      <p class="categories__title">Side B</p>
+
+      <div class="categories_tags">
+      <% @sides_b.each do |side_b| %>
+        <span class="tag categories__tag"><%= side_b %></span>
+      <% end %>
+      </div>
+    </div>
+  <% end %>
+
+  <% if @sides_c.count > 0 %>
+    <div class="categories__container">
+      <p class="categories__title">Side C</p>
+
+      <div class="categories_tags">
+      <% @sides_c.each do |side_c| %>
+        <span class="tag categories__tag"><%= side_c %></span>
+      <% end %>
+      </div>
+    </div>
+  <% end %>
 </div>
-<% end %>
+<% end %> 
 
 <div class="content-show">
   <h3 class="title"><%= @litigation.title %></h3>

--- a/app/views/cclow/geography/litigation_cases/show.html.erb
+++ b/app/views/cclow/geography/litigation_cases/show.html.erb
@@ -10,7 +10,9 @@
 
       <div class="categories_tags">
         <% @responses.each do |response| %>
-          <span class="tag categories__tag"><%= response.name %></span>
+          <div class="tag__container">
+            <span class="tag categories__tag"><%= response.name %></span>
+          </div>
         <% end %>
       </div>
     </div>
@@ -35,64 +37,6 @@
       <div class="categories_tags">
       <% @keywords.each do |keyword| %>
         <span class="tag categories__tag"><%= keyword.name %></span>
-      <% end %>
-      </div>
-    </div>
-  <% end %>
-
-  <% if @jurisdiction.present? %>
-    <div class="categories__container">
-      <p class="categories__title">Jurisdiction</p>
-
-      <div class="categories_tags">
-        <span class="tag categories__tag"><%= @jurisdiction %></span>
-      </div>
-    </div>
-  <% end %>
-
-  <% if @party_types.count > 0 %>
-    <div class="categories__container">
-      <p class="categories__title">Party types</p>
-
-      <div class="categories_tags">
-      <% @party_types.each do |party_type| %>
-        <span class="tag categories__tag"><%= party_type %></span>
-      <% end %>
-      </div>
-    </div>
-  <% end %>
-
-  <% if @sides_a.count > 0 %>
-    <div class="categories__container">
-      <p class="categories__title">Side A</p>
-
-      <div class="categories_tags">
-      <% @sides_a.each do |side_a| %>
-        <span class="tag categories__tag"><%= side_a %></span>
-      <% end %>
-      </div>
-    </div>
-  <% end %>
-
-  <% if @sides_b.count > 0 %>
-    <div class="categories__container">
-      <p class="categories__title">Side B</p>
-
-      <div class="categories_tags">
-      <% @sides_b.each do |side_b| %>
-        <span class="tag categories__tag"><%= side_b %></span>
-      <% end %>
-      </div>
-    </div>
-  <% end %>
-
-  <% if @sides_c.count > 0 %>
-    <div class="categories__container">
-      <p class="categories__title">Side C</p>
-
-      <div class="categories_tags">
-      <% @sides_c.each do |side_c| %>
-        <span class="tag categories__tag"><%= side_c %></span>
       <% end %>
       </div>
     </div>


### PR DESCRIPTION
This PR adds some polishing to the litigation show page:
* Makes litigations sides linkable (+ styles) if connected entity is present (we don't have an example of that in the DB but there's an existing decorator that takes care of that)
* Add ellipsis to long tag names (labels)
