### PR TITLE
Fix background color of more options in Firefox

### DIFF
--- a/app/assets/stylesheets/cclow/_geography-page.scss
+++ b/app/assets/stylesheets/cclow/_geography-page.scss
@@ -512,6 +512,7 @@ $count-description-lines: 2;
       cursor: pointer;
       margin-top: 25px;
       border: none;
+      background-color: transparent;
     }
   }
 


### PR DESCRIPTION
* Remove gray background color from the more options button in the litigations search that appears in Firefox