### PR TITLE
Add more information to the events on the timeline

### DIFF
--- a/app/assets/stylesheets/cclow.scss
+++ b/app/assets/stylesheets/cclow.scss
@@ -7,6 +7,7 @@
 @import "cclow/laws-dropdown";
 @import "cclow/world-map";
 @import "cclow/filters";
+@import "cclow/tooltip";
 
 @import "bulma/sass/utilities/all";
 @import "bulma/sass/base/all";
@@ -15,16 +16,11 @@
 @import "bulma/sass/grid/all";
 @import "bulma/sass/layout/all";
 @import "bulma/sass/form/all";
+
 @import "slick-carousel/slick/slick";
 @import "rc-slider/assets";
 
 @import "cclow/buttons";
-
-@import "cclow/geography-page";
-@import "cclow/hero";
-@import "cclow/latest-additions-slider";
-@import "cclow/laws-dropdown";
-@import "cclow/world-map";
 @import "cclow/pages";
 
 @import "font-awesome";

--- a/app/assets/stylesheets/cclow/_events_timeline.scss
+++ b/app/assets/stylesheets/cclow/_events_timeline.scss
@@ -10,6 +10,8 @@ $arrow-btn-width: 48px;
 
   .timeline {
     display: flex;
+    align-items: center;
+    min-height: 150px;
     position: relative;
   }
 
@@ -53,6 +55,7 @@ $arrow-btn-width: 48px;
     margin: auto;
     width: 12px;
     position: relative;
+    cursor: pointer;
 
     &:before {
       content: "";
@@ -150,7 +153,7 @@ $arrow-btn-width: 48px;
     position: absolute;
     z-index: 1;
     border-radius: 50%;
-    top: 50px;
+    top: calc(50% - #{$arrow-btn-width / 2});
     cursor: pointer;
     display: flex;
     align-items: center;

--- a/app/assets/stylesheets/cclow/_geography-page.scss
+++ b/app/assets/stylesheets/cclow/_geography-page.scss
@@ -580,14 +580,14 @@ mark {
     }
 
     &__tags {
-      display: flex;
+      line-height: 36px;
     }
 
     &__tag:not(body) {
       margin-top: 10px;
       border: none;
       border-radius: 0;
-      margin-right: 12px;
+      margin-right: 6px;
       background-color: $grey-light;
       color: $blue-dark;
       font-size: 0.75rem;

--- a/app/assets/stylesheets/cclow/_tooltip.scss
+++ b/app/assets/stylesheets/cclow/_tooltip.scss
@@ -1,0 +1,18 @@
+@import 'colors';
+@import 'variables';
+
+.cclow-tooltip {
+  background: $white !important;
+  box-shadow: 0 2px 4px 0 rgba(0,0,0,0.1), 0 0 20px 0 rgba(46,49,82,0.05);
+  color: $storm-gray !important;
+  opacity: 1 !important;
+  border: 1px solid $grey;
+  padding: 10px;
+  font-size: 12px;
+  line-height: 18px;
+  max-width: 200px;
+
+  &:after {
+    display: none;
+  }
+}

--- a/app/controllers/cclow/geography/legislations_controller.rb
+++ b/app/controllers/cclow/geography/legislations_controller.rb
@@ -23,7 +23,10 @@ module CCLOW
         @sectors = @legislation.laws_sectors.order(:name)
         @keywords = @legislation.keywords.order(:name)
         @responses = @legislation.responses.order(:name)
-        @legislation_events = @legislation.events_with_eventable_title
+        @legislation_events = @legislation.events_with_eventable_title.order(:date)
+        @legislation_events_with_links = @legislation_events.map do |e|
+          ::Api::Presenters::Event.call(e)
+        end
       end
 
       private

--- a/app/controllers/cclow/geography/legislations_controller.rb
+++ b/app/controllers/cclow/geography/legislations_controller.rb
@@ -23,8 +23,8 @@ module CCLOW
         @sectors = @legislation.laws_sectors.order(:name)
         @keywords = @legislation.keywords.order(:name)
         @responses = @legislation.responses.order(:name)
-        @legislation_events = @legislation.events.order(:date)
-        @legislation_events_with_links = @legislation_events.map do |e|
+        legislation_events = @legislation.events.order(:date)
+        @legislation_events_with_links = legislation_events.map do |e|
           ::Api::Presenters::Event.call(e, :legislation)
         end
       end

--- a/app/controllers/cclow/geography/legislations_controller.rb
+++ b/app/controllers/cclow/geography/legislations_controller.rb
@@ -23,6 +23,7 @@ module CCLOW
         @sectors = @legislation.laws_sectors.order(:name)
         @keywords = @legislation.keywords.order(:name)
         @responses = @legislation.responses.order(:name)
+        @legislation_events = @legislation.events_with_eventable_title
       end
 
       private

--- a/app/controllers/cclow/geography/legislations_controller.rb
+++ b/app/controllers/cclow/geography/legislations_controller.rb
@@ -23,9 +23,9 @@ module CCLOW
         @sectors = @legislation.laws_sectors.order(:name)
         @keywords = @legislation.keywords.order(:name)
         @responses = @legislation.responses.order(:name)
-        @legislation_events = @legislation.events_with_eventable_title.order(:date)
+        @legislation_events = @legislation.events.order(:date)
         @legislation_events_with_links = @legislation_events.map do |e|
-          ::Api::Presenters::Event.call(e)
+          ::Api::Presenters::Event.call(e, :legislation)
         end
       end
 

--- a/app/controllers/cclow/geography/litigation_cases_controller.rb
+++ b/app/controllers/cclow/geography/litigation_cases_controller.rb
@@ -19,9 +19,9 @@ module CCLOW
         @keywords = @litigation.keywords.order(:name)
         @responses = @litigation.responses.order(:name)
         @litigation_sides = @litigation.litigation_sides.map { |ls| CCLOW::LitigationSideDecorator.decorate(ls) }
-        @litigation_events = @litigation.events_with_eventable_title.order(:date)
+        @litigation_events = @litigation.events.order(:date)
         @litigation_events_with_links = @litigation_events.map do |e|
-          ::Api::Presenters::Event.call(e)
+          ::Api::Presenters::Event.call(e, :litigation)
         end
       end
       # rubocop:enable Metrics/AbcSize

--- a/app/controllers/cclow/geography/litigation_cases_controller.rb
+++ b/app/controllers/cclow/geography/litigation_cases_controller.rb
@@ -18,6 +18,7 @@ module CCLOW
         @keywords = @litigation.keywords.order(:name)
         @responses = @litigation.responses.order(:name)
         @litigation_sides = @litigation.litigation_sides.map { |ls| CCLOW::LitigationSideDecorator.decorate(ls) }
+        @litigation_events = @litigation.events_with_eventable_title
       end
     end
   end

--- a/app/controllers/cclow/geography/litigation_cases_controller.rb
+++ b/app/controllers/cclow/geography/litigation_cases_controller.rb
@@ -9,6 +9,7 @@ module CCLOW
         @litigations = CCLOW::LitigationDecorator.decorate_collection(@litigations)
       end
 
+      # rubocop:disable Metrics/AbcSize
       def show
         @litigation = Litigation.find(params[:id])
         @legislations = CCLOW::LegislationDecorator.decorate_collection(@litigation.legislations)
@@ -18,8 +19,12 @@ module CCLOW
         @keywords = @litigation.keywords.order(:name)
         @responses = @litigation.responses.order(:name)
         @litigation_sides = @litigation.litigation_sides.map { |ls| CCLOW::LitigationSideDecorator.decorate(ls) }
-        @litigation_events = @litigation.events_with_eventable_title
+        @litigation_events = @litigation.events_with_eventable_title.order(:date)
+        @litigation_events_with_links = @litigation_events.map do |e|
+          ::Api::Presenters::Event.call(e)
+        end
       end
+      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/app/controllers/concerns/cclow/geography_controller.rb
+++ b/app/controllers/concerns/cclow/geography_controller.rb
@@ -19,6 +19,8 @@ module CCLOW
 
     def set_geography
       @geography = GeographyDecorator.decorate(::Geography.find(params[:geography_id] || params[:id]))
+
+      @geography_events = @geography.self_and_related_events
     end
 
     def set_geography_overview

--- a/app/controllers/concerns/cclow/geography_controller.rb
+++ b/app/controllers/concerns/cclow/geography_controller.rb
@@ -22,7 +22,7 @@ module CCLOW
 
       @geography_events = @geography.self_and_related_events
       @geography_events_with_links = @geography_events.map do |e|
-        ::Api::Presenters::Event.call(e)
+        ::Api::Presenters::Event.call(e, :geography)
       end
     end
 

--- a/app/controllers/concerns/cclow/geography_controller.rb
+++ b/app/controllers/concerns/cclow/geography_controller.rb
@@ -21,6 +21,9 @@ module CCLOW
       @geography = GeographyDecorator.decorate(::Geography.find(params[:geography_id] || params[:id]))
 
       @geography_events = @geography.self_and_related_events
+      @geography_events_with_links = @geography_events.map do |e|
+        ::Api::Presenters::Event.call(e)
+      end
     end
 
     def set_geography_overview

--- a/app/javascript/components/EventsTimeline.js
+++ b/app/javascript/components/EventsTimeline.js
@@ -95,10 +95,10 @@ const EventsTimeline = ({ events, options, isFiltered = false }) => {
         )}
         <div ref={eventsContainerEl} onScroll={checkButtons} className="events-container">
           <div className="timeline">
-            {currentEvents.map((event) => (
-              <div key={event.title} className={cx('time-point', { 'time-point-multiple-events': currentEvents.length > 1 })}>
-                <div className="event-title">{ event.title }</div>
-                <div className="point" data-tip onMouseEnter={() => setTooltip(event.eventable_title)} />
+            {currentEvents.map((event, i) => (
+              <div key={`${event.title}-${i}`} className={cx('time-point', { 'time-point-multiple-events': currentEvents.length > 1 })}>
+                <div className="event-title">{event.title}</div>
+                <div className="point" data-tip onClick={() => window.open(event.link, '_self')} onMouseEnter={() => setTooltip(event.eventable_title)} />
                 <div className="date">{ format(new Date(event.date), 'MMMM Y') }</div>
               </div>
             ))}

--- a/app/javascript/components/EventsTimeline.js
+++ b/app/javascript/components/EventsTimeline.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { format } from 'date-fns';
+import ReactTooltip from 'react-tooltip';
 import cx from 'classnames';
 import Testimonials from './Testimonials';
 import MultiSelect from './MultiSelect';
@@ -43,6 +44,7 @@ const EventsTimeline = ({ events, options, isFiltered = false }) => {
   const [currentTypes, setCurrentTypes] = useState(false);
   const [isShowRightBtn, setIsShowRightBtn] = useState(true);
   const [isShowLeftBtn, setIsShowLeftBtn] = useState(true);
+  const [tooltip, setTooltip] = useState(null);
   const eventsContainerEl = React.createRef();
   useEffect(() => checkButtons());
 
@@ -96,7 +98,7 @@ const EventsTimeline = ({ events, options, isFiltered = false }) => {
             {currentEvents.map((event) => (
               <div key={event.title} className={cx('time-point', { 'time-point-multiple-events': currentEvents.length > 1 })}>
                 <div className="event-title">{ event.title }</div>
-                <div className="point" />
+                <div className="point" data-tip onMouseEnter={() => setTooltip(event.eventable_title)} />
                 <div className="date">{ format(new Date(event.date), 'MMMM Y') }</div>
               </div>
             ))}
@@ -108,6 +110,11 @@ const EventsTimeline = ({ events, options, isFiltered = false }) => {
           </div>
         )}
       </div>
+      {tooltip && (
+        <ReactTooltip class="cclow-tooltip">
+          {tooltip}
+        </ReactTooltip>
+      )}
     </div>
   );
 };

--- a/app/javascript/components/EventsTimeline.js
+++ b/app/javascript/components/EventsTimeline.js
@@ -47,6 +47,11 @@ const EventsTimeline = ({ events, options, isFiltered = false }) => {
   const [tooltip, setTooltip] = useState(null);
   const eventsContainerEl = React.createRef();
   useEffect(() => checkButtons());
+  useEffect(() => {
+    if (isShowRightBtn) {
+      eventsContainerEl.current.scrollBy({left: events.length * eventSliderMoveBy});
+    }
+  }, []);
 
   let currentEvents = events.concat();
   if (isFiltered && (currentTypes || []).length !== 0) {

--- a/app/models/geography.rb
+++ b/app/models/geography.rb
@@ -98,16 +98,30 @@ class Geography < ApplicationRecord
     EU_COUNTRIES.include?(iso)
   end
 
+  def events_with_eventable_title
+    events
+      .joins('INNER JOIN geographies ON geographies.id = events.eventable_id')
+      .select('events.*, geographies.name as eventable_title')
+  end
+
   def self_and_related_events
     laws_events = Event.where(eventable_type: 'Legislation')
       .joins('INNER JOIN legislations ON legislations.id = events.eventable_id')
+      .select('events.*, legislations.title as eventable_title')
       .where('legislations.geography_id = ?', id)
 
     litigations_events = Event.where(eventable_type: 'Litigation')
       .joins('INNER JOIN litigations ON litigations.id = events.eventable_id')
+      .select('events.*, litigations.title as eventable_title')
       .where('litigations.geography_id = ?', id)
 
-    Event.from("(#{laws_events.to_sql} UNION #{litigations_events.to_sql} UNION #{events.to_sql}) AS events")
+    Event
+      .from(
+        "(#{laws_events.to_sql}
+        UNION #{litigations_events.to_sql}
+        UNION #{events_with_eventable_title.to_sql})
+        AS events"
+      )
       .order(date: :asc)
   end
 

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -110,6 +110,12 @@ class Legislation < ApplicationRecord
     executive?
   end
 
+  def events_with_eventable_title
+    events
+      .joins('INNER JOIN legislations ON legislations.id = events.eventable_id')
+      .select('events.*, legislations.title as eventable_title')
+  end
+
   def date_passed
     events.where(event_type: 'law_passed').first&.date
   end

--- a/app/models/litigation.rb
+++ b/app/models/litigation.rb
@@ -133,4 +133,10 @@ class Litigation < ApplicationRecord
       .order(:date)
       .last
   end
+
+  def events_with_eventable_title
+    events
+      .joins('INNER JOIN litigations ON litigations.id = events.eventable_id')
+      .select('events.*, litigations.title as eventable_title')
+  end
 end

--- a/app/services/api/presenters/event.rb
+++ b/app/services/api/presenters/event.rb
@@ -1,16 +1,18 @@
 module Api
   module Presenters
     class Event
-      attr_reader :event
+      attr_reader :event, :timeline_type
 
-      def self.call(event)
-        new(event).call
+      def self.call(event, timeline_type)
+        new(event, timeline_type).call
       end
 
-      def initialize(event)
+      def initialize(event, timeline_type)
         @event = event
+        @timeline_type = timeline_type
       end
 
+      # rubocop:disable Metrics/AbcSize
       def call
         {
           id: event.id,
@@ -20,10 +22,11 @@ module Api
           event_type: event.event_type,
           date: event.date,
           description: event.description,
-          eventable_title: event.eventable_title,
+          eventable_title: timeline_type.eql?(:geography) ? event.eventable_title : event.description || event.title,
           link: link(event.eventable_type, event.eventable_id)
         }
       end
+      # rubocop:enable Metrics/AbcSize
 
       private
 

--- a/app/services/api/presenters/event.rb
+++ b/app/services/api/presenters/event.rb
@@ -1,0 +1,56 @@
+module Api
+  module Presenters
+    class Event
+      attr_reader :event
+
+      def self.call(event)
+        new(event).call
+      end
+
+      def initialize(event)
+        @event = event
+      end
+
+      def call
+        {
+          id: event.id,
+          eventable_id: event.eventable_id,
+          eventable_type: event.eventable_type,
+          title: event.title,
+          event_type: event.event_type,
+          date: event.date,
+          description: event.description,
+          eventable_title: event.eventable_title,
+          link: link(event.eventable_type, event.eventable_id)
+        }
+      end
+
+      private
+
+      def link(eventable_type, eventable_id)
+        if eventable_type.eql?('Legislation')
+          legislation_route(Legislation.find(eventable_id)&.geography_id, Legislation.find(eventable_id))
+        elsif eventable_type.eql?('Litigation')
+          url.cclow_geography_litigation_case_path(
+            Litigation.find(eventable_id)&.geography_id,
+            Litigation.find(eventable_id)
+          )
+        elsif eventable_type.eql?('Geography')
+          url.cclow_geography_path(eventable_id)
+        end
+      end
+
+      def legislation_route(geography, legislation)
+        if legislation.law?
+          url.cclow_geography_law_path(geography, legislation)
+        else
+          url.cclow_geography_policy_path(geography, legislation)
+        end
+      end
+
+      def url
+        Rails.application.routes.url_helpers
+      end
+    end
+  end
+end

--- a/app/views/cclow/geographies/show.html.erb
+++ b/app/views/cclow/geographies/show.html.erb
@@ -3,10 +3,10 @@
 <div class="content-show overview-page">
   <h3>Overview and context</h3>
   <%= render 'cclow/geographies/overview', geography_overview: @geography_overview, geography: @geography %>
-  <% if @geography.self_and_related_events.any? %>
+  <% if @geography_events.any? %>
     <section class="section is-large">
       <% event_options = Geography::EVENT_TYPES.map{|type| {value: type, label: type.humanize}} %>
-      <%= react_component("EventsTimeline", { events: @geography.self_and_related_events, options: event_options, isFiltered: true }) %>
+      <%= react_component("EventsTimeline", { events: @geography_events, options: event_options, isFiltered: true }) %>
     </section>
   <% end %>
   <hr>

--- a/app/views/cclow/geographies/show.html.erb
+++ b/app/views/cclow/geographies/show.html.erb
@@ -6,7 +6,7 @@
   <% if @geography_events.any? %>
     <section class="section is-large">
       <% event_options = Geography::EVENT_TYPES.map{|type| {value: type, label: type.humanize}} %>
-      <%= react_component("EventsTimeline", { events: @geography_events, options: event_options, isFiltered: true }) %>
+      <%= react_component("EventsTimeline", { events: @geography_events_with_links, options: event_options, isFiltered: true }) %>
     </section>
   <% end %>
   <hr>

--- a/app/views/cclow/geography/legislations/show.html.erb
+++ b/app/views/cclow/geography/legislations/show.html.erb
@@ -8,7 +8,7 @@
     <div class="categories__container">
       <p class="categories__title">Responses</p>
 
-      <div class="categories_tags">
+      <div class="categories__tags">
         <% @responses.each do |response| %>
           <span class="tag categories__tag"><%= response.name %></span>
         <% end %>
@@ -20,7 +20,7 @@
     <div class="categories__container">
       <p class="categories__title">Sectors</p>
 
-      <div class="categories_tags">
+      <div class="categories__tags">
       <% @sectors.each do |sector| %>
         <span class="tag categories__tag"><%= sector.name %></span>
       <% end %>
@@ -32,7 +32,7 @@
     <div class="categories__container">
       <p class="categories__title">Keywords</p>
 
-      <div class="categories_tags">
+      <div class="categories__tags">
       <% @keywords.each do |keyword| %>
         <span class="tag categories__tag"><%= keyword.name %></span>
       <% end %>

--- a/app/views/cclow/geography/legislations/show.html.erb
+++ b/app/views/cclow/geography/legislations/show.html.erb
@@ -64,7 +64,7 @@
   </section>
   <% if @legislation_events.any? %>
     <section class="section is-medium">
-      <%= react_component("EventsTimeline", { events: @legislation_events.order(:date) }) %>
+      <%= react_component("EventsTimeline", { events: @legislation_events_with_links }) %>
     </section>
   <% end %>
   <hr>

--- a/app/views/cclow/geography/legislations/show.html.erb
+++ b/app/views/cclow/geography/legislations/show.html.erb
@@ -62,7 +62,7 @@
   <section class="section is-medium">
     <%= @legislation.description&.html_safe %>
   </section>
-  <% if @legislation_events.any? %>
+  <% if @legislation_events_with_links.any? %>
     <section class="section is-medium">
       <%= react_component("EventsTimeline", { events: @legislation_events_with_links }) %>
     </section>

--- a/app/views/cclow/geography/legislations/show.html.erb
+++ b/app/views/cclow/geography/legislations/show.html.erb
@@ -62,9 +62,9 @@
   <section class="section is-medium">
     <%= @legislation.description&.html_safe %>
   </section>
-  <% if @legislation.events.any? %>
+  <% if @legislation_events.any? %>
     <section class="section is-medium">
-      <%= react_component("EventsTimeline", { events: @legislation.events.order(:date) }) %>
+      <%= react_component("EventsTimeline", { events: @legislation_events.order(:date) }) %>
     </section>
   <% end %>
   <hr>

--- a/app/views/cclow/geography/litigation_cases/show.html.erb
+++ b/app/views/cclow/geography/litigation_cases/show.html.erb
@@ -49,9 +49,9 @@
   <section class="section is-medium">
     <%= render 'cclow/geography/litigation_cases/details_card', litigation: @litigation %>
   </section>
-  <% if @litigation.events.present? %>
+  <% if @litigation_events.present? %>
     <section class="section is-medium">
-      <%= react_component("EventsTimeline", { events: @litigation.events.order(:date) }) %>
+      <%= react_component("EventsTimeline", { events: @litigation_events.order(:date) }) %>
     </section>
   <% end %>
   <hr>

--- a/app/views/cclow/geography/litigation_cases/show.html.erb
+++ b/app/views/cclow/geography/litigation_cases/show.html.erb
@@ -8,7 +8,7 @@
     <div class="categories__container">
       <p class="categories__title">Responses</p>
 
-      <div class="categories_tags">
+      <div class="categories__tags">
         <% @responses.each do |response| %>
           <div class="tag__container">
             <span class="tag categories__tag"><%= response.name %></span>
@@ -22,7 +22,7 @@
     <div class="categories__container">
       <p class="categories__title">Sectors</p>
 
-      <div class="categories_tags">
+      <div class="categories__tags">
         <% @sectors.each do |sector| %>
           <span class="tag categories__tag"><%= sector.name %></span>
         <% end %>
@@ -34,7 +34,7 @@
     <div class="categories__container">
       <p class="categories__title">Keywords</p>
 
-      <div class="categories_tags">
+      <div class="categories__tags">
       <% @keywords.each do |keyword| %>
         <span class="tag categories__tag"><%= keyword.name %></span>
       <% end %>

--- a/app/views/cclow/geography/litigation_cases/show.html.erb
+++ b/app/views/cclow/geography/litigation_cases/show.html.erb
@@ -51,7 +51,7 @@
   </section>
   <% if @litigation_events.present? %>
     <section class="section is-medium">
-      <%= react_component("EventsTimeline", { events: @litigation_events.order(:date) }) %>
+      <%= react_component("EventsTimeline", { events: @litigation_events_with_links }) %>
     </section>
   <% end %>
   <hr>


### PR DESCRIPTION
This PR adds additional information to the events that are showing on the timeline (Geography, Legislation, Litigation).
On point hover, we are showing a tooltip with the title of the related `eventable`. 

<img width="1057" alt="Screenshot 2020-01-16 at 17 47 43" src="https://user-images.githubusercontent.com/6136899/72549313-5b7f5280-3888-11ea-8ba3-e9b8205199b3.png">

PT: https://www.pivotaltracker.com/story/show/170645003