### PR TITLE
Fix links color

### DIFF
--- a/app/assets/stylesheets/cclow/_geography-page.scss
+++ b/app/assets/stylesheets/cclow/_geography-page.scss
@@ -75,6 +75,10 @@ $count-description-lines: 2;
         overflow: hidden;
         -webkit-line-clamp: $count-description-lines;
         -webkit-box-orient: vertical;
+
+        a {
+          color: $red;
+        }
       }
     }
 


### PR DESCRIPTION
This tiny PR sets the correct color of the links on the CCLOW page.