### PR TITLE
Feature/update slugs

### DIFF
--- a/app/controllers/tpi/companies_controller.rb
+++ b/app/controllers/tpi/companies_controller.rb
@@ -3,6 +3,7 @@ module TPI
     include UserDownload
 
     before_action :fetch_company
+    before_action :redirect_if_numeric_or_historic_slug, only: [:show]
     before_action :fetch_cp_assessment, only: [:show, :cp_assessment, :emissions_chart_data]
     before_action :fetch_mq_assessment, only: [:show, :mq_assessment, :assessments_levels_chart_data]
 
@@ -49,6 +50,10 @@ module TPI
 
     def fetch_company
       @company = Company.published.friendly.find(params[:id])
+    end
+
+    def redirect_if_numeric_or_historic_slug
+      redirect_to tpi_company_path(@company.slug), status: :moved_permanently if params[:id] != @company.slug
     end
 
     def fetch_cp_assessment

--- a/app/controllers/tpi/sectors_controller.rb
+++ b/app/controllers/tpi/sectors_controller.rb
@@ -5,6 +5,7 @@ module TPI
     before_action :fetch_companies, only: [:show, :index]
     before_action :fetch_sectors, only: [:show, :index, :user_download_all]
     before_action :fetch_sector, only: [:show, :user_download]
+    before_action :redirect_if_numeric_or_historic_slug, only: [:show]
 
     def index
       @companies_by_sectors = ::Api::Charts::Sector.new(companies_scope(params)).companies_market_cap_by_sector
@@ -94,6 +95,10 @@ module TPI
 
     def fetch_sector
       @sector = TPISector.friendly.find(params[:id])
+    end
+
+    def redirect_if_numeric_or_historic_slug
+      redirect_to tpi_sector_path(@sector.slug), status: :moved_permanently if params[:id] != @sector.slug
     end
 
     def fetch_sectors

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -26,7 +26,7 @@ class Company < ApplicationRecord
   include PublicActivityTrackable
   extend FriendlyId
 
-  friendly_id :name, use: :slugged, routes: :default
+  friendly_id :name, use: [:slugged, :history], routes: :default
 
   MARKET_CAP_GROUPS = %w[small medium large].freeze
 
@@ -50,6 +50,10 @@ class Company < ApplicationRecord
   validates :ca100, inclusion: {in: [true, false]}
   validates_presence_of :name, :slug, :isin, :market_cap_group
   validates_uniqueness_of :slug, :name
+
+  def should_generate_new_friendly_id?
+    name_changed? || super
+  end
 
   def to_s
     name

--- a/app/models/geography.rb
+++ b/app/models/geography.rb
@@ -88,6 +88,10 @@ class Geography < ApplicationRecord
   validates :federal, inclusion: {in: [true, false]}
   validates :region, inclusion: {in: REGIONS}
 
+  def should_generate_new_friendly_id?
+    name_changed? || super
+  end
+
   def indc_url
     return unless national?
 

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -102,6 +102,10 @@ class Legislation < ApplicationRecord
   validates_presence_of :title, :slug
   validates_uniqueness_of :slug
 
+  def should_generate_new_friendly_id?
+    title_changed? || super
+  end
+
   def law?
     legislative?
   end

--- a/app/models/litigation.rb
+++ b/app/models/litigation.rb
@@ -121,6 +121,10 @@ class Litigation < ApplicationRecord
 
   validates_presence_of :title, :slug, :document_type
 
+  def should_generate_new_friendly_id?
+    title_changed? || super
+  end
+
   def started_event
     events
       .where(event_type: EVENT_STARTED_TYPES)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -15,7 +15,7 @@
 class Page < ApplicationRecord
   extend FriendlyId
 
-  friendly_id :title, use: [:slugged, :history], routes: :default
+  friendly_id :title, use: :slugged, routes: :default
 
   has_many :contents, dependent: :destroy
   has_many :images, through: :contents

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -15,7 +15,7 @@
 class Page < ApplicationRecord
   extend FriendlyId
 
-  friendly_id :title, use: :slugged, routes: :default
+  friendly_id :title, use: [:slugged, :history], routes: :default
 
   has_many :contents, dependent: :destroy
   has_many :images, through: :contents
@@ -27,6 +27,10 @@ class Page < ApplicationRecord
   end
 
   after_commit :reload_routes, only: [:create, :update, :destroy]
+
+  def should_generate_new_friendly_id?
+    title_changed? || super
+  end
 
   def reload_routes
     DynamicRouter.reload

--- a/app/models/tpi_sector.rb
+++ b/app/models/tpi_sector.rb
@@ -12,7 +12,7 @@
 
 class TPISector < ApplicationRecord
   extend FriendlyId
-  friendly_id :name, use: :slugged, routes: :default
+  friendly_id :name, use: [:slugged, :history], routes: :default
 
   has_many :companies, foreign_key: 'sector_id'
   has_many :cp_benchmarks, class_name: 'CP::Benchmark', foreign_key: 'sector_id'
@@ -22,6 +22,10 @@ class TPISector < ApplicationRecord
 
   validates_presence_of :name, :slug
   validates_uniqueness_of :name, :slug
+
+  def should_generate_new_friendly_id?
+    name_changed? || super
+  end
 
   def latest_released_benchmarks
     cp_benchmarks.group_by(&:release_date).max&.last || []

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,107 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+    
+  # This adds an option to treat reserved words as conflicts rather than exceptions.
+  # When there is no good candidate, a UUID will be appended, matching the existing
+  # conflict behavior.
+
+  # config.treat_reserved_as_conflict = true
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # By default, slug has no size limit, but you can change it if you wish.
+  #
+  # config.slug_limit = 255
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  # Note that you must use the :slugged addon **prior** to the line which
+  # configures the sequence separator, or else FriendlyId will raise an undefined
+  # method error.
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id?` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  # Note: Use(include) Slugged module in the config if using the anonymous module.
+  # If you have `friendly_id :name, use: slugged` in the model, Slugged module
+  # is included after the anonymous module defined in the initializer, so it
+  # overrides the `should_generate_new_friendly_id?` method from the anonymous module.
+  #
+  # config.use :slugged
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/db/migrate/20200117184302_create_friendly_id_slugs.rb
+++ b/db/migrate/20200117184302_create_friendly_id_slugs.rb
@@ -1,0 +1,21 @@
+MIGRATION_CLASS =
+  if ActiveRecord::VERSION::MAJOR >= 5
+    ActiveRecord::Migration["#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"]
+  else
+    ActiveRecord::Migration
+  end
+
+class CreateFriendlyIdSlugs < MIGRATION_CLASS
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, [:sluggable_type, :sluggable_id]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type], length: { slug: 140, sluggable_type: 50 }
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], length: { slug: 70, sluggable_type: 50, scope: 70 }, unique: true
+  end
+end

--- a/db/migrate/20200120172400_history_slugs_for_companies_and_tpi_sector.rb
+++ b/db/migrate/20200120172400_history_slugs_for_companies_and_tpi_sector.rb
@@ -1,0 +1,15 @@
+class HistorySlugsForCompaniesAndTPISector < ActiveRecord::Migration[6.0]
+  def up
+    TPISector.find_each do |sector|
+      FriendlyId::Slug.find_or_create_by(sluggable: sector, slug: sector.slug)
+    end
+
+    Company.find_each do |company|
+      FriendlyId::Slug.find_or_create_by(sluggable: company, slug: company.slug)
+    end
+  end
+
+  def down
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_17_122856) do
+ActiveRecord::Schema.define(version: 2020_01_17_184302) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -196,6 +196,17 @@ ActiveRecord::Schema.define(version: 2020_01_17_122856) do
     t.index ["litigation_id"], name: "index_external_legislations_litigations_on_litigation_id"
   end
 
+  create_table "friendly_id_slugs", force: :cascade do |t|
+    t.string "slug", null: false
+    t.integer "sluggable_id", null: false
+    t.string "sluggable_type", limit: 50
+    t.string "scope"
+    t.datetime "created_at"
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
+    t.index ["sluggable_type", "sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_type_and_sluggable_id"
+  end
+
   create_table "geographies", force: :cascade do |t|
     t.string "geography_type", null: false
     t.string "iso", null: false
@@ -248,8 +259,8 @@ ActiveRecord::Schema.define(version: 2020_01_17_122856) do
     t.string "link"
     t.bigint "content_id", null: false
     t.string "name"
-    t.datetime "created_at", default: "2020-01-17 12:59:01", null: false
-    t.datetime "updated_at", default: "2020-01-17 12:59:01", null: false
+    t.datetime "created_at", default: "2020-01-17 18:49:18", null: false
+    t.datetime "updated_at", default: "2020-01-17 18:49:18", null: false
     t.index ["content_id"], name: "index_images_on_content_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_17_184302) do
+ActiveRecord::Schema.define(version: 2020_01_20_172400) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -259,8 +259,8 @@ ActiveRecord::Schema.define(version: 2020_01_17_184302) do
     t.string "link"
     t.bigint "content_id", null: false
     t.string "name"
-    t.datetime "created_at", default: "2020-01-17 18:49:18", null: false
-    t.datetime "updated_at", default: "2020-01-17 18:49:18", null: false
+    t.datetime "created_at", default: "2020-01-17 12:59:01", null: false
+    t.datetime "updated_at", default: "2020-01-17 12:59:01", null: false
     t.index ["content_id"], name: "index_images_on_content_id"
   end
 

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -14,9 +14,17 @@
 
 FactoryBot.define do
   factory :page do
-    title { 'MyString' }
+    sequence(:title) { |n| 'title -' + ('AA'..'ZZ').to_a[n] }
     description { 'MyText' }
-    slug { 'MyString' }
-    type { 'TPIPage' }
+
+    factory :tpi_page do
+      menu { TPIPage::MENU_HEADERS.sample }
+      type { 'TPIPage' }
+    end
+
+    factory :cclow_page do
+      menu { CCLOWPage::MENU_HEADERS.sample }
+      type { 'CCLOWPage' }
+    end
   end
 end

--- a/spec/models/cclow_page_spec.rb
+++ b/spec/models/cclow_page_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe CCLOWPage, type: :model do
+  subject { build(:cclow_page) }
+
+  it { is_expected.to be_valid }
+
+  it 'should update slug when editing title' do
+    page = create(:cclow_page, title: 'Some name')
+    expect(page.slug).to eq('some-name')
+    page.update!(title: 'New name')
+    expect(page.slug).to eq('new-name')
+  end
+end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -58,6 +58,13 @@ RSpec.describe Company, type: :model do
     expect(subject).to have(2).errors_on(:visibility_status)
   end
 
+  it 'should update slug when editing name' do
+    company = create(:company, name: 'Some name')
+    expect(company.slug).to eq('some-name')
+    company.update!(name: 'New name')
+    expect(company.slug).to eq('new-name')
+  end
+
   describe '#latest_cp_assessment' do
     it 'returns last CP assessments with most recent assessment date' do
       company = create(:company, cp_assessments: [

--- a/spec/models/geography_spec.rb
+++ b/spec/models/geography_spec.rb
@@ -51,4 +51,11 @@ RSpec.describe Geography, type: :model do
     subject.visibility_status = nil
     expect(subject).to have(2).errors_on(:visibility_status)
   end
+
+  it 'should update slug when editing title' do
+    geography = create(:geography, name: 'Some name')
+    expect(geography.slug).to eq('some-name')
+    geography.update!(name: 'New name')
+    expect(geography.slug).to eq('new-name')
+  end
 end

--- a/spec/models/legislation_spec.rb
+++ b/spec/models/legislation_spec.rb
@@ -45,4 +45,11 @@ RSpec.describe Legislation, type: :model do
       subject.legislation_type = 'WRONG'
     }.to raise_error(ArgumentError)
   end
+
+  it 'should update slug when editing title' do
+    legislation = create(:legislation, title: 'Some title')
+    expect(legislation.slug).to eq('some-title')
+    legislation.update!(title: 'New title')
+    expect(legislation.slug).to eq('new-title')
+  end
 end

--- a/spec/models/litigation_spec.rb
+++ b/spec/models/litigation_spec.rb
@@ -40,4 +40,11 @@ RSpec.describe Litigation, type: :model do
     subject.visibility_status = nil
     expect(subject).to have(2).errors_on(:visibility_status)
   end
+
+  it 'should update slug when editing title' do
+    litigation = create(:litigation, title: 'Some title')
+    expect(litigation.slug).to eq('some-title')
+    litigation.update!(title: 'New title')
+    expect(litigation.slug).to eq('new-title')
+  end
 end

--- a/spec/models/pages_spec.rb
+++ b/spec/models/pages_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Page, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/tpi_page_spec.rb
+++ b/spec/models/tpi_page_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe TPIPage, type: :model do
+  subject { build(:tpi_page) }
+
+  it { is_expected.to be_valid }
+
+  it 'should update slug when editing title' do
+    page = create(:tpi_page, title: 'Some name')
+    expect(page.slug).to eq('some-name')
+    page.update!(title: 'New name')
+    expect(page.slug).to eq('new-name')
+  end
+end

--- a/spec/models/tpi_sector_spec.rb
+++ b/spec/models/tpi_sector_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe TPISector, type: :model do
     expect(build(:tpi_sector, name: 'Airlines')).to have(1).errors_on(:name)
   end
 
+  it 'should update slug when editing name' do
+    sector = create(:tpi_sector, name: 'Some name')
+    expect(sector.slug).to eq('some-name')
+    sector.update!(name: 'New name')
+    expect(sector.slug).to eq('new-name')
+  end
+
   describe '#latest_benchmarks_for_date' do
     let(:sector) { create(:tpi_sector) }
     let!(:first_benchmark) {


### PR DESCRIPTION
Change slugs whenever title changes for models with friendly_id module.

I added history for TPISectors and Companies as we are using slugs in the url there. Should be also done for Pages, but that's more work. Maybe instead of Dynamic routing we should have one route `get 'tpi/:page'? I could try that in this PR.