### PR TITLE
Add latest company assessments csv to tpi user downloads

### DIFF
--- a/app/controllers/concerns/tpi/user_download.rb
+++ b/app/controllers/concerns/tpi/user_download.rb
@@ -20,6 +20,8 @@ module TPI
       timestamp = Time.now.strftime('%d%m%Y')
 
       render zip: (mq_assessments_files || {}).merge(
+        'Company_Latest_Assessments.csv' => CSVExport::User::CompanyLatestAssessments
+          .new(mq_assessments, cp_assessments).call,
         "CP_Assessments_#{timestamp}.csv" => CSVExport::User::CPAssessments.new(cp_assessments).call,
         "Sector_Benchmarks_#{timestamp}.csv" => CSVExport::User::CPBenchmarks.new(cp_benchmarks).call
       ).compact, filename: "#{filename} - #{timestamp}"

--- a/app/services/csv_export/user/company_latest_assessments.rb
+++ b/app/services/csv_export/user/company_latest_assessments.rb
@@ -26,7 +26,7 @@ module CSVExport
         CSV.generate do |csv|
           csv << headers
 
-          @companies.each do |company|
+          @companies.sort_by(&:name).each do |company|
             mq_assessment = @latest_mq_assessments_hash[company.id]
             cp_assessment = @latest_cp_assessments_hash[company.id]
 
@@ -51,10 +51,10 @@ module CSVExport
               cp_assessment&.cp_alignment,
               cp_assessment&.last_reported_year,
               company.sector.cp_unit,
-              cp_assessment&.assumptions,
               year_headers.map do |year|
                 cp_assessment&.emissions.try(:[], year)
-              end
+              end,
+              cp_assessment&.assumptions
             ].flatten
           end
         end

--- a/app/services/csv_export/user/company_latest_assessments.rb
+++ b/app/services/csv_export/user/company_latest_assessments.rb
@@ -1,0 +1,82 @@
+module CSVExport
+  module User
+    class CompanyLatestAssessments
+      def initialize(mq_assessments, cp_assessments)
+        @companies = (mq_assessments.map(&:company) + cp_assessments.map(&:company)).uniq
+        @latest_mq_assessments_hash = get_latest_mq_assessments_hash(mq_assessments)
+        @latest_cp_assessments_hash = get_latest_cp_assessments_hash(cp_assessments)
+      end
+
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/MethodLength
+      def call
+        return if @companies.empty?
+
+        question_headers = @latest_mq_assessments_hash.values.compact.first.questions.map(&:csv_column_name)
+        year_headers = @latest_cp_assessments_hash.values.flat_map(&:emissions_all_years).uniq.sort
+
+        headers = ['Company Name', 'Geography', 'Geography Code', 'Sector',
+                   'CA100 Focus Company', 'Large/Medium Classification',
+                   'ISINs', 'SEDOL', 'MQ Publication Date', 'MQ Assessment Date',
+                   'Level', 'Performance compared to previous year', *question_headers,
+                   'CP Publication Date', 'CP Assessment Date',
+                   'Carbon Performance Alignment', 'History to Projection cutoff year',
+                   'CP Unit', *year_headers, 'Assumptions']
+
+        CSV.generate do |csv|
+          csv << headers
+
+          @companies.each do |company|
+            mq_assessment = @latest_mq_assessments_hash[company.id]
+            cp_assessment = @latest_cp_assessments_hash[company.id]
+
+            csv << [
+              company.name,
+              company.geography.name,
+              company.geography.iso,
+              company.sector.name,
+              company.ca100? ? 'Yes' : 'No',
+              company.market_cap_group,
+              company.isin,
+              company.sedol,
+              mq_assessment&.publication_date,
+              mq_assessment&.assessment_date,
+              mq_assessment&.level,
+              mq_assessment&.status,
+              question_headers.map do |header|
+                mq_assessment&.find_answer_by_key(header.split('|')[0])
+              end,
+              cp_assessment&.publication_date,
+              cp_assessment&.assessment_date,
+              cp_assessment&.cp_alignment,
+              cp_assessment&.last_reported_year,
+              company.sector.cp_unit,
+              cp_assessment&.assumptions,
+              year_headers.map do |year|
+                cp_assessment&.emissions.try(:[], year)
+              end
+            ].flatten
+          end
+        end
+      end
+
+      private
+
+      def get_latest_mq_assessments_hash(assessments)
+        latest_methodology = assessments.max_by(&:methodology_version).methodology_version
+
+        assessments.group_by(&:company_id).map do |company_id, grouped|
+          [company_id, grouped.find { |a| a.methodology_version == latest_methodology }]
+        end.to_h
+      end
+
+      def get_latest_cp_assessments_hash(assessments)
+        assessments.group_by(&:company_id).map do |company_id, grouped|
+          [company_id, grouped.max_by(&:publication_date)]
+        end.to_h
+      end
+    end
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength
+  end
+end


### PR DESCRIPTION
For each company taking mq_assessment for the latest methodology from given mq_assessments collection, and the latest cp assessement by publication_date.

Download per company/sector/all sectors could differ as the latest methodology for all sectors could be different than for a single company or companies within one sector.