### PR TITLE
Add Litigation Cases exception for USA

### DIFF
--- a/app/views/cclow/geographies/_overview.html.erb
+++ b/app/views/cclow/geographies/_overview.html.erb
@@ -17,11 +17,7 @@
           <div><%= item[:caption] %></div>
           <div class="indicator-value">
             <div class="value-container">
-              <% if item[:count] > 0 %>
-                <%= link_to item[:count], item[:link] %>
-              <% else %>
-                <%= item[:count] %>
-              <% end %>
+              <%= link_to item[:count], item[:link] %>
             </div>
             <div class="item-name-block">
               <div class="img-type-container">

--- a/app/views/cclow/geography/legislations/index.html.erb
+++ b/app/views/cclow/geography/legislations/index.html.erb
@@ -2,10 +2,14 @@
 <div class="geography-laws">
   <div class="container">
     <h3><%= params[:scope] == :laws ? 'Laws' : 'Policies' %></h3>
-    <ul class="content-list">
-      <% @legislations.uniq.each do |l| %>
-        <%= render 'cclow/geography/legislations/list_item', legislation: l %>
-      <% end %>
-    </ul>
+    <% if @legislations.any? %>
+      <ul class="content-list">
+        <% @legislations.uniq.each do |l| %>
+          <%= render 'cclow/geography/legislations/list_item', legislation: l %>
+        <% end %>
+      </ul>
+    <% else %>
+      <p>No data available for <%= @geography.name %>.</p>
+    <% end %>
   </div>
 </div>

--- a/app/views/cclow/geography/litigation_cases/index.html.erb
+++ b/app/views/cclow/geography/litigation_cases/index.html.erb
@@ -1,6 +1,7 @@
 <% content_for :page_title, "Climate Laws - #{@geography.name} - Litigation cases" %>
 <div class="container">
   <h3>Litigation cases</h3>
+
   <% if @litigations.any? %>
     <ul class="content-list">
       <% @litigations.each do |l| %>
@@ -9,14 +10,19 @@
     </ul>
   <% elsif @geography.iso == 'USA' %>
     <p>
-      The dataset does not include the United States – To access information
-      about climate change litigation in the US, please
+      For all US climate litigation cases, please
       <a href="http://climatecasechart.com/us-climate-change-litigation/" target="_blank" rel="noopener noreferrer">
-        click here to go to the Sabin Center / Arnold & Porter Kaye Scholer database</a>.
+        click here to go to the Sabin Center / Arnold & Porter Kaye Scholer database
+      </a>. This will take you to a different website and will open in a new window.
       <br />
-      This will take you to a different website and will open in a new window.
+      Summaries for a selection of US cases will be added here shortly.
     </p>
   <% else %>
-    <p>No litigation cases available for <%= @geography.name %>.</p>
+    <p>
+      Currently there are no litigation cases available for <%= @geography.name %>.
+      <br />
+      If you are aware of climate litigation cases and would like us to add them,
+      please <a href="mailto:gri.cgl@lse.ac.uk">contact us</a>.
+    </p>
   <% end %>
 </div>

--- a/app/views/cclow/geography/litigation_cases/index.html.erb
+++ b/app/views/cclow/geography/litigation_cases/index.html.erb
@@ -1,9 +1,22 @@
 <% content_for :page_title, "Climate Laws - #{@geography.name} - Litigation cases" %>
 <div class="container">
   <h3>Litigation cases</h3>
-  <ul class="content-list">
-    <% @litigations.each do   |l| %>
-      <%= render 'cclow/geography/litigation_cases/list_item', litigation: l %>
-    <% end %>
-  </ul>
+  <% if @litigations.any? %>
+    <ul class="content-list">
+      <% @litigations.each do |l| %>
+        <%= render 'cclow/geography/litigation_cases/list_item', litigation: l %>
+      <% end %>
+    </ul>
+  <% elsif @geography.iso == 'USA' %>
+    <p>
+      The dataset does not include the United States – To access information
+      about climate change litigation in the US, please
+      <a href="http://climatecasechart.com/us-climate-change-litigation/" target="_blank" rel="noopener noreferrer">
+        click here to go to the Sabin Center / Arnold & Porter Kaye Scholer database</a>.
+      <br />
+      This will take you to a different website and will open in a new window.
+    </p>
+  <% else %>
+    <p>No litigation cases available for <%= @geography.name %>.</p>
+  <% end %>
 </div>

--- a/app/views/layouts/cclow/geography.html.erb
+++ b/app/views/layouts/cclow/geography.html.erb
@@ -6,7 +6,7 @@
                     count: @geography_overview.number_of_litigation_cases},
                    {label: 'Climate targets',
                     path: cclow_geography_climate_targets_path(@geography),
-                    count: @geography_overview.number_of_targets}].select{|link| link[:count].positive?}
+                    count: @geography_overview.number_of_targets}]
 %>
 
 <% content_for :content do %>


### PR DESCRIPTION
Litigation cases from the USA are not managed in this database, so I've added a message to point the users to the right place.

I also removed the filter on links on the profile sidebar when there's
no data for a type of data, as I think this is more consistent and there
might be different reasons to not have data.
Maybe we could add a field to the countries to "Why no Litigation DAta"?
:D but I won't do it here now.