### PR TITLE
Adds validation for geography_id in litigations

### DIFF
--- a/app/models/litigation.rb
+++ b/app/models/litigation.rb
@@ -119,7 +119,7 @@ class Litigation < ApplicationRecord
     accepts_nested_attributes_for :events
   end
 
-  validates_presence_of :title, :slug, :document_type
+  validates_presence_of :title, :slug, :document_type, :geography
 
   def should_generate_new_friendly_id?
     title_changed? || super

--- a/app/models/litigation.rb
+++ b/app/models/litigation.rb
@@ -105,7 +105,7 @@ class Litigation < ApplicationRecord
   tag_with :keywords
   tag_with :responses
 
-  belongs_to :geography, optional: true
+  belongs_to :geography
   has_and_belongs_to_many :laws_sectors
   has_many :litigation_sides, -> { order(:side_type) }, inverse_of: :litigation
   has_many :documents, as: :documentable, dependent: :destroy
@@ -119,7 +119,7 @@ class Litigation < ApplicationRecord
     accepts_nested_attributes_for :events
   end
 
-  validates_presence_of :title, :slug, :document_type, :geography
+  validates_presence_of :title, :slug, :document_type
 
   def should_generate_new_friendly_id?
     title_changed? || super


### PR DESCRIPTION
Small PR to add validation for litigations' geography ID.
I'm not making bigger changes yet, because they still have some records without geography, they'll have to fix that first.