### PR TITLE
base importer: add rollback_on_error option, default to false

### DIFF
--- a/app/commands/command/csv_data_upload.rb
+++ b/app/commands/command/csv_data_upload.rb
@@ -54,7 +54,7 @@ module Command
     end
 
     def import_service
-      @import_service ||= CSVImport.const_get(importer_name).new(uploaded_csv_file)
+      @import_service ||= CSVImport.const_get(importer_name).new(uploaded_csv_file, rollback_on_error: true)
     rescue NameError
       raise "Can't find 'CSVImport::#{importer_name}' importer service class!"
     end

--- a/spec/commands/csv_data_upload_spec.rb
+++ b/spec/commands/csv_data_upload_spec.rb
@@ -77,12 +77,12 @@ describe 'CSVDataUpload (integration)' do
         # Editor should't publish resources
         let(:current_user_role) { 'editor_laws' }
 
-        it 'does not import one row from CSV files with Legislation data' do
+        it 'does not at all if one row is not valid' do
           # 2nd record (ID=20) should fail with auth error
           command = expect_data_upload_results(
             Legislation,
             fixture_file('legislations.csv', content: csv_content),
-            {new_records: 1, not_changed_records: 0, rows: 3, updated_records: 1},
+            {new_records: 0, not_changed_records: 0, rows: 3, updated_records: 0},
             false
           )
 


### PR DESCRIPTION
Fixing CSV upload bug. When there is any validation error for csv file then nothing should be updated, changes should be rolled back. 