### PR TITLE
use different cut off date then default one when parsing two digit year

### DIFF
--- a/app/services/csv_import/date_utils.rb
+++ b/app/services/csv_import/date_utils.rb
@@ -1,14 +1,23 @@
 module CSVImport
   class DateUtils
     class << self
+      TWO_DIGIT_YEAR_CUTOFF = 2040
+
       def safe_parse(date, expected_date_formats)
         expected_date_formats.map { |format| parse_date(date, format) }.compact.first
       end
 
-      def parse_date(date, format)
-        Date.strptime(date, format)
+      def parse_date(date_text, format)
+        date = Date.strptime(date_text, format)
+        return date.prev_year(100) if two_digit_year?(format) && date.year > TWO_DIGIT_YEAR_CUTOFF
+
+        date
       rescue ArgumentError
         nil
+      end
+
+      def two_digit_year?(format)
+        format.include?('%y')
       end
     end
   end


### PR DESCRIPTION
I hope that format with the two-digit year is not used by the client anymore :) and it was only for first import (maybe we should actually forbid it at some point)

Although, to make our development data sane and fix it I introduced a different cut off date for a two-digit year format than the default one.