### PR TITLE
Avoid showing the future

### DIFF
--- a/app/services/queries/tpi/news_publications_query.rb
+++ b/app/services/queries/tpi/news_publications_query.rb
@@ -24,6 +24,8 @@ module Queries
         scope
           .merge(filter_by_tags(scope))
           .merge(filter_by_sectors(scope))
+          .where('publication_date <= NOW()')
+          .includes([:keywords, :tpi_sectors, :image_attachment])
           .order(publication_date: :desc)
       end
 


### PR DESCRIPTION
Don't show future publications and articles on the public interface.
Also adds includes clauses to remove N+1 queries.