### PR TITLE
Add filtering by side a|b|c party type to litigations page

### DIFF
--- a/app/controllers/cclow/litigation_cases_controller.rb
+++ b/app/controllers/cclow/litigation_cases_controller.rb
@@ -22,6 +22,9 @@ module CCLOW
             litigation_side_c_names_options: litigation_side_c_names_options,
             litigation_party_types_options: litigation_party_types_options,
             litigation_jurisdictions_options: litigation_jurisdictions_options,
+            litigation_side_a_party_type_options: litigation_side_a_party_type_options,
+            litigation_side_b_party_type_options: litigation_side_b_party_type_options,
+            litigation_side_c_party_type_options: litigation_side_c_party_type_options,
             litigations: CCLOW::LitigationDecorator.decorate_collection(@litigations.first(10)),
             count: @litigations.count
           }, prerender: false

--- a/app/controllers/concerns/cclow/filter_controller.rb
+++ b/app/controllers/concerns/cclow/filter_controller.rb
@@ -28,6 +28,27 @@ module CCLOW
       [{field_name: 'type', options: types.sort_by { |h| h[:label] }}]
     end
 
+    def litigation_side_a_party_type_options
+      side_a_party_types = LitigationSide.where(side_type: 'a').pluck(:party_type).uniq.compact.map do |n|
+        {value: n, label: n.humanize}
+      end
+      [{field_name: 'a_party_type', options: side_a_party_types.sort_by { |h| h[:label] }}]
+    end
+
+    def litigation_side_b_party_type_options
+      side_b_party_types = LitigationSide.where(side_type: 'b').pluck(:party_type).uniq.compact.map do |n|
+        {value: n, label: n.humanize}
+      end
+      [{field_name: 'b_party_type', options: side_b_party_types.sort_by { |h| h[:label] }}]
+    end
+
+    def litigation_side_c_party_type_options
+      side_c_party_types = LitigationSide.where(side_type: 'c').pluck(:party_type).uniq.compact.map do |n|
+        {value: n, label: n.humanize}
+      end
+      [{field_name: 'c_party_type', options: side_c_party_types.sort_by { |h| h[:label] }}]
+    end
+
     def litigation_side_a_names_options
       side_a = LitigationSide.where(side_type: 'a').pluck(:name).uniq.map { |n| {value: n, label: n.humanize} }
       [{field_name: 'side_a', options: side_a.sort_by { |h| h[:label] }}]
@@ -57,7 +78,8 @@ module CCLOW
       params.permit(:q, :from_date,
                     :to_date, :recent, :ids, region: [], geography: [], jurisdiction: [],
                                              status: [], type: [], tags: [], party_type: [],
-                                             side_a: [], side_b: [], side_c: [])
+                                             side_a: [], side_b: [], side_c: [],
+                                             a_party_type: [], b_party_type: [], c_party_type: [])
     end
   end
 end

--- a/app/javascript/components/pages/cclow/LitigationCases.js
+++ b/app/javascript/components/pages/cclow/LitigationCases.js
@@ -251,19 +251,19 @@ class LitigationCases extends Component {
           <>
             <SearchFilter
               ref={this.sideAFilter}
-              filterName="Side A"
+              filterName="Side A name"
               params={litigationSideAOptions}
               onChange={(event) => this.filterList('activeSideAFilter', event)}
             />
             <SearchFilter
               ref={this.sideBFilter}
-              filterName="Side B"
+              filterName="Side B name"
               params={litigationSideBOptions}
               onChange={(event) => this.filterList('activeSideBFilter', event)}
             />
             <SearchFilter
               ref={this.sideCFilter}
-              filterName="Side C"
+              filterName="Side C name"
               params={litigationSideCOptions}
               onChange={(event) => this.filterList('activeSideCFilter', event)}
             />

--- a/app/javascript/components/pages/cclow/LitigationCases.js
+++ b/app/javascript/components/pages/cclow/LitigationCases.js
@@ -250,34 +250,16 @@ class LitigationCases extends Component {
         {isMoreSearchOptionsVisible && (
           <>
             <SearchFilter
-              ref={this.sideAFilter}
-              filterName="Side A name"
-              params={litigationSideAOptions}
-              onChange={(event) => this.filterList('activeSideAFilter', event)}
-            />
-            <SearchFilter
-              ref={this.sideBFilter}
-              filterName="Side B name"
-              params={litigationSideBOptions}
-              onChange={(event) => this.filterList('activeSideBFilter', event)}
-            />
-            <SearchFilter
-              ref={this.sideCFilter}
-              filterName="Side C name"
-              params={litigationSideCOptions}
-              onChange={(event) => this.filterList('activeSideCFilter', event)}
+              ref={this.jurisdictionFilter}
+              filterName="Jurisdiction"
+              params={litigationJurisdictionsOptions}
+              onChange={(event) => this.filterList('activeJurisdictionsFilter', event)}
             />
             <SearchFilter
               ref={this.partyTypeFilter}
               filterName="Party types"
               params={litigationPartyTypesOptions}
               onChange={(event) => this.filterList('activePartyTypesFilter', event)}
-            />
-            <SearchFilter
-              ref={this.jurisdictionFilter}
-              filterName="Jurisdiction"
-              params={litigationJurisdictionsOptions}
-              onChange={(event) => this.filterList('activeJurisdictionsFilter', event)}
             />
             <SearchFilter
               ref={this.sideAPartyTypeFilter}
@@ -296,6 +278,24 @@ class LitigationCases extends Component {
               filterName="Side C Type"
               params={litigationSideCPartyTypeOptions}
               onChange={(event) => this.filterList('activeSideCPartyTypesFilter', event)}
+            />
+            <SearchFilter
+              ref={this.sideAFilter}
+              filterName="Side A name"
+              params={litigationSideAOptions}
+              onChange={(event) => this.filterList('activeSideAFilter', event)}
+            />
+            <SearchFilter
+              ref={this.sideBFilter}
+              filterName="Side B name"
+              params={litigationSideBOptions}
+              onChange={(event) => this.filterList('activeSideBFilter', event)}
+            />
+            <SearchFilter
+              ref={this.sideCFilter}
+              filterName="Side C name"
+              params={litigationSideCOptions}
+              onChange={(event) => this.filterList('activeSideCFilter', event)}
             />
             <button
               type="button"

--- a/app/javascript/components/pages/cclow/LitigationCases.js
+++ b/app/javascript/components/pages/cclow/LitigationCases.js
@@ -29,6 +29,9 @@ class LitigationCases extends Component {
       activeSideBFilter: {},
       activeSideCFilter: {},
       activePartyTypesFilter: {},
+      activeSideAPartyTypesFilter: {},
+      activeSideBPartyTypesFilter: {},
+      activeSideCPartyTypesFilter: {},
       activeJurisdictionsFilter: {}
     };
 
@@ -41,6 +44,9 @@ class LitigationCases extends Component {
     this.sideCFilter = React.createRef();
     this.partyTypeFilter = React.createRef();
     this.jurisdictionFilter = React.createRef();
+    this.sideAPartyTypeFilter = React.createRef();
+    this.sideBPartyTypeFilter = React.createRef();
+    this.sideCPartyTypeFilter = React.createRef();
   }
 
   getQueryString(extraParams = {}) {
@@ -53,7 +59,10 @@ class LitigationCases extends Component {
       activeSideAFilter,
       activeSideBFilter,
       activeSideCFilter,
-      activeJurisdictionsFilter
+      activeJurisdictionsFilter,
+      activeSideAPartyTypesFilter,
+      activeSideBPartyTypesFilter,
+      activeSideCPartyTypesFilter
     } = this.state;
     const params = {
       ...getQueryFilters(),
@@ -66,6 +75,9 @@ class LitigationCases extends Component {
       ...activeSideCFilter,
       ...activePartyTypesFilter,
       ...activeJurisdictionsFilter,
+      ...activeSideAPartyTypesFilter,
+      ...activeSideBPartyTypesFilter,
+      ...activeSideCPartyTypesFilter,
       ...extraParams
     };
 
@@ -110,7 +122,10 @@ class LitigationCases extends Component {
       activeSideBFilter,
       activeSideCFilter,
       activePartyTypesFilter,
-      activeJurisdictionsFilter
+      activeJurisdictionsFilter,
+      activeSideAPartyTypesFilter,
+      activeSideBPartyTypesFilter,
+      activeSideCPartyTypesFilter
     } = this.state;
     const {
       geo_filter_options: geoFilterOptions,
@@ -120,7 +135,10 @@ class LitigationCases extends Component {
       litigation_side_b_names_options: litigationSideBOptions,
       litigation_side_c_names_options: litigationSideCOptions,
       litigation_party_types_options: litigationPartyTypesOptions,
-      litigation_jurisdictions_options: litigationJurisdictionsOptions
+      litigation_jurisdictions_options: litigationJurisdictionsOptions,
+      litigation_side_a_party_type_options: litigationSideAPartyTypeOptions,
+      litigation_side_b_party_type_options: litigationSideBPartyTypeOptions,
+      litigation_side_c_party_type_options: litigationSideCPartyTypeOptions
     } = this.props;
     if (!Object.keys(activeGeoFilter).length
       && !Object.keys(activeTagFilter).length
@@ -129,6 +147,9 @@ class LitigationCases extends Component {
       && !Object.keys(activeSideAFilter).length
       && !Object.keys(activeSideBFilter).length
       && !Object.keys(activeSideCFilter).length
+      && !Object.keys(activeSideAPartyTypesFilter).length
+      && !Object.keys(activeSideBPartyTypesFilter).length
+      && !Object.keys(activeSideCPartyTypesFilter).length
       && !Object.keys(activePartyTypesFilter).length) return null;
     return (
       <div className="filter-tags">
@@ -140,6 +161,9 @@ class LitigationCases extends Component {
         {this.renderTagsGroup(activeSideCFilter, litigationSideCOptions, 'sideCFilter')}
         {this.renderTagsGroup(activePartyTypesFilter, litigationPartyTypesOptions, 'partyTypeFilter')}
         {this.renderTagsGroup(activeJurisdictionsFilter, litigationJurisdictionsOptions, 'jurisdictionFilter')}
+        {this.renderTagsGroup(activeSideAPartyTypesFilter, litigationSideAPartyTypeOptions, 'sideAPartyTypeFilter')}
+        {this.renderTagsGroup(activeSideBPartyTypesFilter, litigationSideBPartyTypeOptions, 'sideBPartyTypeFilter')}
+        {this.renderTagsGroup(activeSideCPartyTypesFilter, litigationSideCPartyTypeOptions, 'sideCPartyTypeFilter')}
         {this.renderTimeRangeTags(activeTimeRangeFilter)}
       </div>
     );
@@ -206,7 +230,10 @@ class LitigationCases extends Component {
       litigation_jurisdictions_options: litigationJurisdictionsOptions,
       litigation_side_a_names_options: litigationSideAOptions,
       litigation_side_b_names_options: litigationSideBOptions,
-      litigation_side_c_names_options: litigationSideCOptions
+      litigation_side_c_names_options: litigationSideCOptions,
+      litigation_side_a_party_type_options: litigationSideAPartyTypeOptions,
+      litigation_side_b_party_type_options: litigationSideBPartyTypeOptions,
+      litigation_side_c_party_type_options: litigationSideCPartyTypeOptions
     } = this.props;
 
     return (
@@ -251,6 +278,24 @@ class LitigationCases extends Component {
               filterName="Jurisdiction"
               params={litigationJurisdictionsOptions}
               onChange={(event) => this.filterList('activeJurisdictionsFilter', event)}
+            />
+            <SearchFilter
+              ref={this.sideAPartyTypeFilter}
+              filterName="Side A Type"
+              params={litigationSideAPartyTypeOptions}
+              onChange={(event) => this.filterList('activeSideAPartyTypesFilter', event)}
+            />
+            <SearchFilter
+              ref={this.sideBPartyTypeFilter}
+              filterName="Side B Type"
+              params={litigationSideBPartyTypeOptions}
+              onChange={(event) => this.filterList('activeSideBPartyTypesFilter', event)}
+            />
+            <SearchFilter
+              ref={this.sideCPartyTypeFilter}
+              filterName="Side C Type"
+              params={litigationSideCPartyTypeOptions}
+              onChange={(event) => this.filterList('activeSideCPartyTypesFilter', event)}
             />
             <button
               type="button"
@@ -363,6 +408,9 @@ LitigationCases.defaultProps = {
   litigation_side_b_names_options: [],
   litigation_side_c_names_options: [],
   litigation_party_types_options: [],
+  litigation_side_a_party_type_options: [],
+  litigation_side_b_party_type_options: [],
+  litigation_side_c_party_type_options: [],
   litigation_jurisdictions_options: []
 };
 
@@ -376,6 +424,9 @@ LitigationCases.propTypes = {
   litigation_side_a_names_options: PropTypes.array,
   litigation_side_b_names_options: PropTypes.array,
   litigation_side_c_names_options: PropTypes.array,
+  litigation_side_a_party_type_options: PropTypes.array,
+  litigation_side_b_party_type_options: PropTypes.array,
+  litigation_side_c_party_type_options: PropTypes.array,
   litigation_jurisdictions_options: PropTypes.array
 };
 


### PR DESCRIPTION
This PR adds 3 new filters to the Litigations index page:
* By side A party type
* By side B party type
* By side C party type

Also renames Side A|B|C filter labels to -> Side A|B|C name

[PT](https://www.pivotaltracker.com/story/show/170945441)

<img width="1143" alt="filteringLitigations" src="https://user-images.githubusercontent.com/6136899/73378848-2bd53f00-42b9-11ea-867c-ca1178f374bf.png">

The filters are starting to look a bit cluttery so we might need to review the designs 🤔 cc @faustoperez 