### PR TITLE
Fix display of fixed-navbar on mobile screens

### DIFF
--- a/app/assets/stylesheets/tpi/_navbar.scss
+++ b/app/assets/stylesheets/tpi/_navbar.scss
@@ -2,6 +2,14 @@
 @import "colors";
 @import "variables";
 
+.tpi__navbar-margin {
+  margin-top: var(--fixed-navbar-height);
+
+  @include desktop {
+    margin-top: 0;
+  }
+}
+
 .tpi__navbar {
   // EDGE workaround: Fix the hovering navbar dropdowns issue: https://github.com/jgthms/bulma/issues/2503
   // maybe it's best to use from($desktop) since we use widescreen

--- a/app/views/layouts/tpi.html.erb
+++ b/app/views/layouts/tpi.html.erb
@@ -37,7 +37,7 @@
       <%= render "layouts/tpi/banner" %>
     </section>
 
-    <section class="tpi__navbar">
+    <section class="tpi__navbar <%= 'tpi__navbar-margin' if @current_user.present? %>">
       <%= render "layouts/tpi/header" %>
     </section>
 


### PR DESCRIPTION
On TPI, on mobile screens, the fixed-navbar was overlapping the menu. This PR fixes that issue.

![image](https://user-images.githubusercontent.com/6136899/73673931-6bc86780-46a7-11ea-8f57-94574f4a5341.png)
