### PR TITLE
Avoid crashing tracking activities index page

### DIFF
--- a/app/decorators/public_activity/activity_decorator.rb
+++ b/app/decorators/public_activity/activity_decorator.rb
@@ -38,7 +38,9 @@ class PublicActivity::ActivityDecorator < Draper::Decorator
   end
 
   def find_discarded_trackable
-    trackable_type.constantize.all_discarded.find(trackable_id)
+    return nil unless trackable_type.constantize.respond_to?(:all_discarded)
+
+    trackable_type.constantize.all_discarded.where(id: trackable_id).first
   end
 
   def trackable_display_name(trackable_object)


### PR DESCRIPTION
There was a bug getting to the public activities page when you did the following workflow:

- Edit NewsArticle;
- Delete NewsArticle;

We are not treating it as a discardable entity, so when it's gone it's gone, but their activities are still preserved. Maybe we should just cascade delete those activities? But in this PR I'm handling those errors.

Similar for when other entities that are discardable are gone (which might not happen on Prod, but happened locally to me).

If removing the activities is the best way forward, I can add dependent destroy.

Cheers!
Simão