### PR TITLE
Improving laws search

### DIFF
--- a/app/assets/stylesheets/cclow/_laws-dropdown.scss
+++ b/app/assets/stylesheets/cclow/_laws-dropdown.scss
@@ -38,7 +38,7 @@ $icon-margin-right: 24px;
   @include desktop {
     padding: 20px 30px;
   }
-  
+
   &[placeholder] {
     text-overflow: ellipsis;
     width: calc(100% - #{$icon-size + $icon-margin-right});

--- a/app/assets/stylesheets/cclow/_laws-dropdown.scss
+++ b/app/assets/stylesheets/cclow/_laws-dropdown.scss
@@ -79,7 +79,9 @@ $icon-margin-right: 24px;
   border-top: none;
   padding-bottom: $space-between-categories;
 
-  &.searching {
+  &.loading {
+    overflow: hidden;
+
     &:before {
       content: '';
       position: absolute;

--- a/app/assets/stylesheets/cclow/_laws-dropdown.scss
+++ b/app/assets/stylesheets/cclow/_laws-dropdown.scss
@@ -78,6 +78,20 @@ $icon-margin-right: 24px;
   border: 1px solid $french-gray;
   border-top: none;
   padding-bottom: $space-between-categories;
+
+  &.searching {
+    &:before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      z-index: 100;
+      background: $white;
+      opacity: .7;
+    }
+  }
 }
 
 .laws-dropdown__category {

--- a/app/javascript/components/LawsDropdown.js
+++ b/app/javascript/components/LawsDropdown.js
@@ -51,7 +51,8 @@ const LawsDropdown = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [sValue, setSearchValue] = useState(null);
   const [searching, setSearching] = useState(false);
-  const searchValue = useDebounce(sValue, SEARCH_DEBOUNCE);
+  const [typing, setTyping] = useState(false);
+  const searchValue = useDebounce(sValue, SEARCH_DEBOUNCE, () => setTyping(false));
   const dropdownContainer = useRef(null);
 
   const lastSearch = localStorage.getItem('lastSearch');
@@ -78,6 +79,7 @@ const LawsDropdown = () => {
   const noMatches = allSearchResultsCount === 0;
 
   const handleInput = e => {
+    setTyping(true);
     setSearchValue(e.target.value);
   };
 
@@ -280,7 +282,7 @@ const LawsDropdown = () => {
         </a>
       </div>
       {isOpen && (
-        <div className={cx('laws-dropdown__content', { searching })}>
+        <div className={cx('laws-dropdown__content', { loading: searching || typing })}>
           {renderContent()}
         </div>
       )}

--- a/app/javascript/components/LawsDropdown.js
+++ b/app/javascript/components/LawsDropdown.js
@@ -108,7 +108,10 @@ const LawsDropdown = () => {
 
   // searching
   useEffect(() => {
-    if (!searchValue) return;
+    if (!searchValue) {
+      setResults({});
+      return;
+    }
 
     fetch(`/cclow/api/search?q=${encodeURIComponent(searchValue)}`)
       .then((r) => r.json())
@@ -180,7 +183,7 @@ const LawsDropdown = () => {
     };
   }, []);
 
-  const renderContent = () => {
+  const renderContent = useCallback(() => {
     if (!searchValue) return renderAllOptions();
     if (noMatches) {
       return (
@@ -255,7 +258,7 @@ const LawsDropdown = () => {
         )}
       </>
     );
-  };
+  }, [results]);
 
   return (
     <div ref={dropdownContainer} className="laws-dropdown__container container">

--- a/app/javascript/components/LawsDropdown.js
+++ b/app/javascript/components/LawsDropdown.js
@@ -13,7 +13,7 @@ import legalScale from 'images/icons/legal-scale.svg';
 import target from 'images/icons/target.svg';
 
 const ESCAPE_KEY = 27;
-const SEARCH_DEBOUNCE = 400;
+const SEARCH_DEBOUNCE = 500;
 
 const GEOGRAPHY_TYPES = {
   national: 'Country profile',

--- a/app/javascript/components/LawsDropdown.js
+++ b/app/javascript/components/LawsDropdown.js
@@ -2,6 +2,7 @@
 
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 
 import { useDebounce, useOutsideClick } from 'shared/hooks';
 
@@ -12,7 +13,7 @@ import legalScale from 'images/icons/legal-scale.svg';
 import target from 'images/icons/target.svg';
 
 const ESCAPE_KEY = 27;
-const SEARCH_DEBOUNCE = 500;
+const SEARCH_DEBOUNCE = 400;
 
 const GEOGRAPHY_TYPES = {
   national: 'Country profile',
@@ -49,6 +50,7 @@ LawsDropdownCategory.propTypes = {
 const LawsDropdown = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [sValue, setSearchValue] = useState(null);
+  const [searching, setSearching] = useState(false);
   const searchValue = useDebounce(sValue, SEARCH_DEBOUNCE);
   const dropdownContainer = useRef(null);
 
@@ -113,10 +115,13 @@ const LawsDropdown = () => {
       return;
     }
 
+    setSearching(true);
+
     fetch(`/cclow/api/search?q=${encodeURIComponent(searchValue)}`)
       .then((r) => r.json())
       .then((data) => {
         setResults(data);
+        setSearching(false);
       });
   }, [searchValue]);
 
@@ -258,7 +263,7 @@ const LawsDropdown = () => {
         )}
       </>
     );
-  }, [results]);
+  }, [results, counts, noMatches]);
 
   return (
     <div ref={dropdownContainer} className="laws-dropdown__container container">
@@ -275,7 +280,7 @@ const LawsDropdown = () => {
         </a>
       </div>
       {isOpen && (
-        <div className="laws-dropdown__content">
+        <div className={cx('laws-dropdown__content', { searching })}>
           {renderContent()}
         </div>
       )}

--- a/app/javascript/components/charts/cp-performance/CPPerformance.js
+++ b/app/javascript/components/charts/cp-performance/CPPerformance.js
@@ -9,30 +9,13 @@ import HighchartsReact from 'highcharts-react-official';
 
 import PlusIcon from 'images/icons/plus.svg';
 
+import { useOutsideClick } from 'shared/hooks';
 import { groupAllAreaSeries } from './helpers';
 import CompanySelector from './CompanySelector';
 import CompanyTag from './CompanyTag';
 import Tooltip from './Tooltip';
 
 const COLORS = ['#00C170', '#ED3D4A', '#FFDD49', '#440388', '#FF9600', '#B75038', '#00A8FF', '#F78FB3', '#191919', '#F602B4'];
-
-// TODO: move to common hooks
-const useCallbackOutsideClick = (element, action) => {
-  if (typeof action !== 'function') throw new Error('useCallbackOutsideClick expects action to be function');
-
-  const handleClickOutside = event => {
-    if (!element.current) return;
-    if (!element.current.contains(event.target)) action();
-  };
-
-  useEffect(() => {
-    document.addEventListener('mousedown', handleClickOutside);
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, []);
-};
 
 function getLegendItems(data) {
   return applyColorsToLegendItems(
@@ -62,7 +45,7 @@ function CPPerformance({ dataUrl, companySelector, unit }) {
         setLegendItems(getLegendItems(chartData));
       });
   }, []);
-  useCallbackOutsideClick(companySelectorWrapper, () => setCompanySelectorVisible(false));
+  useOutsideClick(companySelectorWrapper, () => setCompanySelectorVisible(false));
 
   const handleLegendItemRemove = (item) => {
     setLegendItems(

--- a/app/javascript/shared/hooks/index.js
+++ b/app/javascript/shared/hooks/index.js
@@ -1,0 +1,2 @@
+export { default as useDebounce } from './use-debounce';
+export { default as useOutsideClick } from './use-outside-click';

--- a/app/javascript/shared/hooks/use-debounce.js
+++ b/app/javascript/shared/hooks/use-debounce.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-export default function useDebounce(value, delay) {
+export default function useDebounce(value, delay, callback) {
   const [debouncedValue, setDebouncedValue] = useState(value);
 
   useEffect(
@@ -8,6 +8,7 @@ export default function useDebounce(value, delay) {
       // Set debouncedValue to value (passed in) after the specified delay
       const handler = setTimeout(() => {
         setDebouncedValue(value);
+        if (callback && typeof callback === 'function') callback();
       }, delay);
 
       return () => {

--- a/app/javascript/shared/hooks/use-debounce.js
+++ b/app/javascript/shared/hooks/use-debounce.js
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+export default function useDebounce(value, delay) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(
+    () => {
+      // Set debouncedValue to value (passed in) after the specified delay
+      const handler = setTimeout(() => {
+        setDebouncedValue(value);
+      }, delay);
+
+      return () => {
+        clearTimeout(handler);
+      };
+    },
+    [value]
+  );
+
+  return debouncedValue;
+}

--- a/app/javascript/shared/hooks/use-outside-click.js
+++ b/app/javascript/shared/hooks/use-outside-click.js
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+export default function useOutsideClick(element, action) {
+  if (typeof action !== 'function') throw new Error('useOutsideClick expects action to be function');
+
+  const handleClickOutside = event => {
+    if (!element.current) return;
+    if (!element.current.contains(event.target)) action();
+  };
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+}

--- a/app/models/geography.rb
+++ b/app/models/geography.rb
@@ -63,14 +63,15 @@ class Geography < ApplicationRecord
   enum geography_type: array_to_enum_hash(GEOGRAPHY_TYPES)
 
   pg_search_scope :full_text_search,
-                  associated_against: {tags: [:name]},
                   against: {
                     name: 'A',
-                    region: 'B',
-                    legislative_process: 'C'
+                    region: 'B'
                   },
                   using: {
-                    tsearch: {prefix: true}
+                    trigram: {
+                      word_similarity: true,
+                      threshold: 0.5
+                    }
                   }
 
   tag_with :political_groups

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -91,8 +91,12 @@ class Legislation < ApplicationRecord
                     description: 'B'
                   },
                   using: {
-                    tsearch: {prefix: true}
-                  }
+                    tsearch: {
+                      prefix: true,
+                      dictionary: 'english'
+                    }
+                  },
+                  ignoring: :accents
 
   with_options allow_destroy: true, reject_if: :all_blank do
     accepts_nested_attributes_for :documents

--- a/app/models/litigation.rb
+++ b/app/models/litigation.rb
@@ -107,7 +107,7 @@ class Litigation < ApplicationRecord
                     trigram: {
                       word_similarity: true,
                       only: [:title],
-                      threshold: 0.3
+                      threshold: 0.7
                     }
                   },
                   ignoring: :accents

--- a/app/models/litigation.rb
+++ b/app/models/litigation.rb
@@ -92,15 +92,25 @@ class Litigation < ApplicationRecord
 
   pg_search_scope :full_text_search,
                   associated_against: {
-                    tags: [:name]
+                    tags: [:name],
+                    litigation_sides: [:name]
                   },
                   against: {
                     title: 'A',
                     summary: 'B'
                   },
                   using: {
-                    tsearch: {prefix: true}
-                  }
+                    tsearch: {
+                      prefix: true,
+                      dictionary: 'english'
+                    },
+                    trigram: {
+                      word_similarity: true,
+                      only: [:title],
+                      threshold: 0.3
+                    }
+                  },
+                  ignoring: :accents
 
   tag_with :keywords
   tag_with :responses

--- a/app/models/litigation.rb
+++ b/app/models/litigation.rb
@@ -103,11 +103,6 @@ class Litigation < ApplicationRecord
                     tsearch: {
                       prefix: true,
                       dictionary: 'english'
-                    },
-                    trigram: {
-                      word_similarity: true,
-                      only: [:title],
-                      threshold: 0.7
                     }
                   },
                   ignoring: :accents

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -73,13 +73,14 @@ class Target < ApplicationRecord
                   associated_against: {
                     tags: [:name]
                   },
-                  against: {
-                    target_type: 'A',
-                    description: 'B'
-                  },
+                  against: [:description],
                   using: {
-                    tsearch: {prefix: true}
-                  }
+                    tsearch: {
+                      prefix: true,
+                      dictionary: 'english'
+                    }
+                  },
+                  ignoring: :accents
 
   accepts_nested_attributes_for :events, allow_destroy: true, reject_if: :all_blank
 

--- a/app/services/api/latest_additions.rb
+++ b/app/services/api/latest_additions.rb
@@ -15,6 +15,7 @@ module Api
     # rubocop:disable Metrics/AbcSize
     def litigations
       litigations = Litigation.published
+        .includes(:geography)
         .joins(:events)
         .order('events.date ASC, litigations.created_at ASC')
         .last(@count)
@@ -36,6 +37,7 @@ module Api
 
     def legislations
       legislation = Legislation.published
+        .includes(:geography)
         .joins(:events)
         .order('events.date ASC, legislations.created_at ASC')
         .last(@count)

--- a/db/migrate/20200216155620_enable_unaccent.rb
+++ b/db/migrate/20200216155620_enable_unaccent.rb
@@ -1,0 +1,5 @@
+class EnableUnaccent < ActiveRecord::Migration[6.0]
+  def change
+    enable_extension 'unaccent'
+  end
+end

--- a/db/migrate/20200216161342_enable_trigram.rb
+++ b/db/migrate/20200216161342_enable_trigram.rb
@@ -1,0 +1,5 @@
+class EnableTrigram < ActiveRecord::Migration[6.0]
+  def change
+    enable_extension 'pg_trgm'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_31_074036) do
+ActiveRecord::Schema.define(version: 2020_02_16_161342) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_trgm"
   enable_extension "plpgsql"
+  enable_extension "unaccent"
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string "namespace"

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -26,6 +26,25 @@ FactoryBot.define do
     }
   end
 
+  factory :scope do
+    type { 'Scope' }
+
+    sequence(:name) { |n|
+      [
+        'Energy Intensity',
+        'Energy Access',
+        'Transport: General',
+        'Energy Efficiency',
+        'Renewable Energy',
+        'Energy: General',
+        'Fuel Efficiency',
+        'Transportation Fuels',
+        'General',
+        'Afforestation'
+      ].sample << n.to_s
+    }
+  end
+
   factory :natural_hazard do
     type { 'NaturalHazard' }
     sequence(:name) { |n|

--- a/spec/models/geography_spec.rb
+++ b/spec/models/geography_spec.rb
@@ -58,4 +58,40 @@ RSpec.describe Geography, type: :model do
     geography.update!(name: 'New name')
     expect(geography.slug).to eq('new-name')
   end
+
+  context 'full_text_search' do
+    let!(:portugal) {
+      create(
+        :geography,
+        name: 'Portugal',
+        region: 'Europe & Central Asia'
+      )
+    }
+    let!(:argentina) {
+      create(
+        :geography,
+        name: 'Argentina',
+        region: 'Latin America & Caribbean'
+      )
+    }
+    let!(:austria) {
+      create(
+        :geography,
+        name: 'Austria',
+        region: 'Europe & Central Asia'
+      )
+    }
+
+    it 'uses name' do
+      expect(Geography.full_text_search('Argentina')).to contain_exactly(argentina)
+    end
+
+    it 'uses region' do
+      expect(Geography.full_text_search('europe')).to contain_exactly(austria, portugal)
+    end
+
+    it 'uses fuzzy searching' do
+      expect(Geography.full_text_search('portuagal')).to contain_exactly(portugal)
+    end
+  end
 end

--- a/spec/models/legislation_spec.rb
+++ b/spec/models/legislation_spec.rb
@@ -52,4 +52,51 @@ RSpec.describe Legislation, type: :model do
     legislation.update!(title: 'New title')
     expect(legislation.slug).to eq('new-title')
   end
+
+  context 'full_text_search' do
+    let!(:legislation_1) {
+      create(
+        :legislation,
+        title: 'Presidential decree declaring rational and efficient energy use a national priority',
+        description: 'This decree has far-reaching and ambitious goals to reduce energy consumption'
+      )
+    }
+    let!(:legislation_2) {
+      create(
+        :legislation,
+        title: 'Energy Policy of Poland until 2030',
+        description: 'Grzegorz Brzęczyszczykiewicz'
+      )
+    }
+    let!(:legislation_3) {
+      create(
+        :legislation,
+        title: 'The Mother Earth Law and Integral Development',
+        description: "The Mother Earth Law is a piece of legislation that epitomises Bolivia's dedication",
+        keywords: [
+          build(:keyword, name: 'Super keyword')
+        ]
+      )
+    }
+
+    it 'ignores accents' do
+      expect(Legislation.full_text_search('Brzeczyszczykiewicz')).to contain_exactly(legislation_2)
+    end
+
+    it 'uses stemming' do
+      expect(Legislation.full_text_search('reducing')).to contain_exactly(legislation_1)
+    end
+
+    it 'uses title' do
+      expect(Legislation.full_text_search('decree')).to contain_exactly(legislation_1)
+    end
+
+    it 'uses description' do
+      expect(Legislation.full_text_search('piece of legislation')).to contain_exactly(legislation_3)
+    end
+
+    it 'uses tags' do
+      expect(Legislation.full_text_search('keyword')).to contain_exactly(legislation_3)
+    end
+  end
 end

--- a/spec/models/litigation_spec.rb
+++ b/spec/models/litigation_spec.rb
@@ -85,10 +85,6 @@ RSpec.describe Litigation, type: :model do
       expect(Litigation.full_text_search('Pty')).to contain_exactly(litigation_1, litigation_2)
     end
 
-    it 'fuzzy search works' do
-      expect(Litigation.full_text_search('Lott Hodlings')).to contain_exactly(litigation_2)
-    end
-
     it 'uses summary' do
       expect(Litigation.full_text_search('Environment')).to contain_exactly(litigation_3)
     end

--- a/spec/models/litigation_spec.rb
+++ b/spec/models/litigation_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Litigation, type: :model do
         title: 'Able Lott Holdings Pty. Ltd. v. City of Fremantle',
         summary: 'This case concerned a development application',
         litigation_sides: [
-          build(:litigation_side, name: 'Not real side name, only testing')
+          build(:litigation_side, name: 'Not real side name, only test')
         ]
       )
     }
@@ -79,6 +79,10 @@ RSpec.describe Litigation, type: :model do
 
     it 'ignores accents' do
       expect(Litigation.full_text_search('Laka')).to contain_exactly(litigation_1)
+    end
+
+    it 'uses stemming' do
+      expect(Litigation.full_text_search('testing')).to contain_exactly(litigation_2)
     end
 
     it 'uses title' do

--- a/spec/models/target_spec.rb
+++ b/spec/models/target_spec.rb
@@ -41,4 +41,44 @@ RSpec.describe Target, type: :model do
     subject.visibility_status = nil
     expect(subject).to have(2).errors_on(:visibility_status)
   end
+
+  context 'full_text_search' do
+    let!(:target_1) {
+      create(
+        :target,
+        description: "30% obliged entity's energy efficiency requirements implemented by 2016"
+      )
+    }
+    let!(:target_2) {
+      create(
+        :target,
+        description: '35% cut in GHG emissions from biofuels and bioliquids compared to fossil fuels by 2017 Łąka'
+      )
+    }
+    let!(:target_3) {
+      create(
+        :target,
+        description: '63 aggregated energy efficiency ratio by 2020 against a 2000 baseline',
+        scopes: [
+          build(:scope, name: 'Transport')
+        ]
+      )
+    }
+
+    it 'ignores accents' do
+      expect(Target.full_text_search('Laka')).to contain_exactly(target_2)
+    end
+
+    it 'uses stemming' do
+      expect(Target.full_text_search('comparing')).to contain_exactly(target_2)
+    end
+
+    it 'uses description' do
+      expect(Target.full_text_search('energy')).to contain_exactly(target_1, target_3)
+    end
+
+    it 'uses tags' do
+      expect(Target.full_text_search('transport')).to contain_exactly(target_3)
+    end
+  end
 end


### PR DESCRIPTION
I was revising full text search options we are using for all models.

1. Geography
 - removed legislative process from full text search
 - fuzzy matching using trigram algorithm to better match typos

2. Litigations
 - adding side names for full text searching
 - use stemming with english dictionary help
 - ignore accents while searching

3. Legislations
 - use stemming with english dictionary help
 - ignore accents while searching

4. Target
 - removing target_type from search
 - use stemming with english dictionary help
 - ignore accents while searching

Here is also code refactor and UX improvements for search dropdown. I introduced states as `typing` and `searching`, of any of these is happening then search content is in state of `loading` (disabled with opacity). That is eliminating search results "bad states" and empty content while typing.

I also increased search debounce timeout to be 500ms. I think that is reasonable value especially as we have `loading` state now.

![new-search](https://user-images.githubusercontent.com/1286444/74734188-567a3e00-524e-11ea-9f12-a84aaad7c98f.gif)

This should be tested on staging first, as I think optimization is not needed yet but we better try if it is performant enough.