### PR TITLE
updates litigation-sources file and upload script

### DIFF
--- a/app/services/migration/litigation.rb
+++ b/app/services/migration/litigation.rb
@@ -39,7 +39,7 @@ module Migration
           #   doc.type = 'external'
           #   doc.external_url = row['url']
           # end
-          l.documents << doc
+          l.documents << doc if for_real
         end
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/app/services/migration/litigation.rb
+++ b/app/services/migration/litigation.rb
@@ -4,7 +4,7 @@ module Migration
     class << self
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def migrate_source_files(source)
-        for_real = Rails.env.production?
+        for_real = Rails.env.staging?
         file = File.read(source).force_encoding('UTF-8')
         csv = CSV.parse(
           file,
@@ -23,22 +23,22 @@ module Migration
           doc = Document.new(name: row['title'],
                              last_verified_on: row['date'],
                              language: row['language'])
-          if row['url'].include?('http://www.lse.ac.uk/GranthamInstitute/wp-content/uploads')
-            doc.type = 'uploaded'
-            if for_real
-              begin
-                filename = File.basename(URI.parse(source).path)
-                file = URI.open(source)
-              rescue URI::InvalidURIError, OpenURI::HTTPError, OpenSSL::SSL::SSLError
-                puts "File for #{row['law_id']} and #{row['url']} not working"
-                next
-              end
-              doc.file.attach(io: file, filename: filename.last)
+          # if row['url'].include?('http://www.lse.ac.uk/GranthamInstitute/wp-content/uploads')
+          doc.type = 'uploaded'
+          if for_real
+            begin
+              filename = File.basename(URI.parse(source).path)
+              file = URI.open(source)
+            rescue URI::InvalidURIError, OpenURI::HTTPError, OpenSSL::SSL::SSLError
+              puts "File for #{row['law_id']} and #{row['url']} not working"
+              next
             end
-          else
-            doc.type = 'external'
-            doc.external_url = row['url']
+            doc.file.attach(io: file, filename: filename.last)
           end
+          # else
+          #   doc.type = 'external'
+          #   doc.external_url = row['url']
+          # end
           l.documents << doc
         end
       end

--- a/app/services/seed/cclow_data.rb
+++ b/app/services/seed/cclow_data.rb
@@ -20,6 +20,12 @@ module Seed
       end
     end
 
+    def call_litigation_sources_import
+      TimedLogger.log('Migrate litigations source files') do
+        Migration::Litigation.migrate_source_files(seed_file('litigation-sources.csv'))
+      end
+    end
+
     def call
       ### import Laws ###
       TimedLogger.log('Import legislation') do

--- a/app/services/seed/cclow_data.rb
+++ b/app/services/seed/cclow_data.rb
@@ -8,6 +8,7 @@ module Seed
       delegate :call, to: :instance
       delegate :call_sources_import, to: :instance
       delegate :import_litigation_sides, to: :instance
+      delegate :call_litigation_sources_import, to: :instance
     end
 
     def call_sources_import

--- a/db/seeds/laws_migration/litigation-sources.csv
+++ b/db/seeds/laws_migration/litigation-sources.csv
@@ -1,272 +1,256 @@
 case_id,title,url,date,language
-7362,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20191023_NA_na-1.pdf,27/11/2019,en
-7361,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190710_2019-EWHC-1738-Admin_judgment-1.pdf,27/11/2019,en
-7350,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181031_NA_complaint.pdf,16/11/2019,en
-7349,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181206_2018-ECWA-Crim-2739_opinion.pdf,27-oct-19,en
-7348,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2016/20160224_Not-available_na-1.pdf,27-oct-19,en
-7347,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20191015_Not-available_na.pdf,27-oct-19,en
-7346,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180104_R-42-2017_judgment.pdf,27-oct-19,en
-7345,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181108_R-77-2018_petition.pdf,"27-oct-19,Case document",en
-7342,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190916_Not-available-_judgment-1.pdf,"30-sep-19,Case document",en
-7341,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190923_Not-available_petition.pdf,"30-sep-19,Case document",en
-7340,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2015/20151216_I.C.J.-Reports-2011-2018_judgment.pdf,"19-sep-19,Case document",en
-7339,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190830_W.P.-No.-1920692018_judgment-1.pdf,19-sep-19,en
-7338,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190306_2019-EWHC-519-Admin_judgment.pdf,19-sep-19,en
-7337,Case document,"http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180309_C-68217_application-1.pdf,Case document",http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190620_C-68217_judgment-1.pdf,en
-7336,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190214_No.-8960-of-2019_application.pdf,"3-7-19,Case document",en
-7335,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190503_2019-SKCA-40_judgment.pdf,3-7-19,en
-7334,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2011/20110325_Court-No.-VLC-S-S-111913_complaint-1.pdf,"3-7-19,Case document",en
-7333,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2011/20111222_2011-NSWCA-424-2010-NSWLEC-34-Australia_decision.pdf,3-7-19,en
-7332,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190626_Tribunal-Appeal-No.-Net-196-of-2016_decision.pdf,3-7-19,en
-7331,Case document,http://curia.europa.eu/juris/fiche.jsf?id=C%3B580%3B14%3BRP%3B1%3BP%3B1%3BC2014%2F0580%2FO&oqp=&for=&mat=or&lgrec=en&jge=&td=%3BALL&jur=C%2CT%2CF&num=C-580%252F14&dates=&pcs=Oor&lg=&pro=&nat=or&cit=none%252CC%252CCJ%252CR%252C2008E%252C%252C%252C%252C%252C%252C%252C%252C%252C%252Ctrue%252Cfalse%252Cfalse&language=en&avg=&cid=216704,"30/11/2018,",en
-7330,Case document,http://curia.europa.eu/juris/document/document.jsf?text=&docid=183125&pageIndex=0&doclang=en&mode=lst&dir=&occ=first&part=1&cid=668786,3/12/18,en
-7329,Case document,https://eur-lex.europa.eu/legal-content/EN/TXT/?qid=1544612541801&uri=CELEX:62015CJ0158,"12-12-2018,",en
-7328,Case document,http://curia.europa.eu/juris/liste.jsf?language=en&td=ALL&num=C-460/15,"12-12-18,",en
-7327,Case document,http://curia.europa.eu/juris/document/document.jsf?text=&docid=188666&pageIndex=0&doclang=EN&mode=lst&dir=&occ=first&part=1&cid=1945642,12-14-18,en
-7326,Case document,http://curia.europa.eu/juris/document/document.jsf?text=climate&docid=200968&pageIndex=0&doclang=EN&mode=req&dir=&occ=first&part=1&cid=10351367#ctx1,5/2/2019,en
-7355,Case document,http://curia.europa.eu/juris/document/document.jsf?text=climate&docid=198528&pageIndex=0&doclang=EN&mode=req&dir=&occ=first&part=1&cid=10351367#ctx1,5/2/2019,en
-7352,Case document,http://curia.europa.eu/juris/document/document.jsf?text=climate&docid=199770&pageIndex=0&doclang=EN&mode=req&dir=&occ=first&part=1&cid=10369188#ctx1,5/2/2019,en
-7344,Case document,http://curia.europa.eu/juris/document/document.jsf?text=climate&docid=203224&pageIndex=0&doclang=EN&mode=req&dir=&occ=first&part=1&cid=10369188#ctx1,5/2/19,en
-7325,Case document,http://curia.europa.eu/juris/document/document.jsf?text=climate&docid=199567&pageIndex=0&doclang=EN&mode=req&dir=&occ=first&part=1&cid=10369188#ctx1,5/219,en
-7324,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190405_8918_summons.pdf,24/4/2019,en
-7323,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190513_Not-Available_press-release-1.pdf,17-jun-2019,en
-7322,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180920_Not-Available_na.pdf,"26-6-2019,Case document",en
-7321,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190123_Not-Yet-Available_press-release-1.pdf,"24/4/2019,Case document",en
-7320,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190919_2017-No.-793-JR_judgment.pdf,"30-sep-19,",en
-7319,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181126_500-06_application.pdf,"2-oct-19,Case document",en
-7318,Case document,http://climatecasechart.com/non-us-case/hj-banks-co-v-secretary-of-state-for-housing-communities-and-local-government/,27-mar-2019,en
-7317,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181126_Not-Available_press-release.pdf,24-apr-2019,en
-7316,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181217_NA_na.pdf,"26-apr-2019,Case document",en
-7315,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181025_0027117-R-SP_complaint.pdf,24-apr-2019,en
-7314,Case document,http://climatecasechart.com/non-us-case/gloucester-resources-limited-v-minister-for-planning/?cn-reloaded=1,27-mar-2019,en
-7313,Case document,http://climatecasechart.com/non-us-case/eu-biomass-plaintiffs-v-european-union/?cn-reloaded=1&cn-reloaded=1,"27-mar-2019,",en
-7312,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180913_C65807_points-of-claim-1.pdf,"17-jun-2019,Case document",en
-7311,Case document,http://climatecasechart.com/non-us-case/greenpeace-canada-v-minister-of-the-environment-conservation-and-parks-lieutenant-governor-in-council/,11-oct-18,en
-7310,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180806_2019-EWHC-1070-Admin_complaint-1.pdf,"2-oct-19,Case document",en
-7309,Case document,http://climatecasechart.com/non-us-case/mcveigh-v-retail-employees-superannuation-trust/?cn-reloaded=1,7-sep-18,en
-7308,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20170704_WAI-2607_application-1.pdf,25-jul-18,en
-7307,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20170325_Original-Application-No.-___-of-2017_petition-1.pdf,25-jul-18,en
-7306,Case document,http://climatecasechart.com/non-us-case/greenpeace-indonesia-and-others-v-bali-provincial-governor/,24-jul-18,en
-7304,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180129_11001-22-03-000-2018-00319-00_complaint-1.pdf,"20-may-19,Case document",en
-7360,Case document,http://www.lse.ac.uk/GranthamInstitute/wp-content/uploads/2018/05/20180524_Case-no.-T-18_application-1.pdf,"31-may-18,Case document",en
-7305,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/non-us-case/request-advisory-opinion-inter-american-court-human-rights-concerning-interpretation-article-11-41-51-american-convention-human-rights/?preview_id=6520&preview_nonce=2a35f83a1a&preview=true,27-feb-18,en
-7303,Case document,http://climatecasechart.com/non-us-case/plan-b-earth-others-v-secretary-state-business-energy-industrial-strategy/,"6-feb-18,Case document",en
-7302,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20171121_2017-No.344-JR_judgment.pdf,30-Nov-2017,en
-7301,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2015/20150828_Civil-Suit-No.-283-of-2012_complaint.pdf,18/10/2017,en
-7300,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20170830_2017-CSOH-113_decision-1.pdf,16/10/2017,en
-7299,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20170905_Case-no.-5408717_petition.pdf,,en
-7298,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20170905_Case-no.-6156117_petition.pdf,,en
-7297,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2017/20170807_No.-VID-__-of-2017_complaint.pdf,25/08/2017,en
-7296,Case document,http://www.austlii.edu.au/au/cases/qld/QLRT/2007/33.html,,en
-7295,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2001/922.html,,en
-7294,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2007/2454.html,,en
-7293,Case document,http://www.austlii.edu.au/au/cases/vic/VCAT/2014/360.html,,en
-7292,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2009/1324.html,,en
-7291,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2010/1348.html,,en
-7290,Case document,https://www.caselaw.nsw.gov.au/decision/5897f721e4b0e71e17f56b92,,en
-7289,Case document,"http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2009/1946.html,Case document",http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2010/522.html,en
-7288,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2011/1230.html,,en
-7287,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2010/1549.html,,en
-7286,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/nsw/NSWLEC/2016/1527.html,,en
-7285,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2010/1320.html,,en
-7284,Case document,http://www.austlii.edu.au/au/cases/vic/VCAT/2010/634.html,,en
-7283,Case document,http://www.judgments.fedcourt.gov.au/judgments/Judgments/fca/single/2016/2016fca1042,,en
-7282,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2016/20160927_2016-QCA-242_decision-1.pdf,,en
-7281,Case document,http://earthjustice.org/sites/default/files/AAC_PETITION_13-04-23a.pdf,23/08/2017,en
-7273,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20170202_W109-2000179-1291E_decision-1.pdf,"2-oct-19,Case document",en
-7253,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20171130_Case-No.-2-O-28515-Essen-Regional-Court_press-release.pdf,1-dec-2017,en
-7251,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2016/20161018_16-166674TVI-OTIR06_petition-1.pdf,"16-aug-18,Case document",en
-7227,Case document,http://www.lse.ac.uk/GranthamInstitute/wp-content/uploads/2018/03/au_cases_cth_FCA_2016_1042.pdf,"5-mar-18,Case document",en
-7225,Case document,https://www.tib.eu/en/search/id/BLSE%3ARN110952491/Wigan-Metropolitan-Borough-Council-v-Secretary/?tx_tibsearch_search%5Bsearchspace%5D=tn,11/4/2016,en
-7224,Case document,http://www.dnsrsearch.com/index.php?origURL=Case document,http%3A//www.pcs.planningportal.gov.uk/pcsportal/fscdav/READONLY%3FOBJ%3DCOO.2036.300.12.3856248%26NAME%3D/Decision%2520Letter.pdf&r=&bc=,en
-7223,Case document,http://www.scotcourts.gov.uk/search-judgments/judgment?id=61f6daa6-8980-69d2-b500-ff0000d74aa7,11/4/2016,en
-7222,Case document,http://www.bailii.org/ew/cases/EWHC/Admin/2007/2288.html,11/4/2016,en
-7221,Case document,http://www.scotcourts.gov.uk/search-judgments/judgment?id=608b8aa6-8980-69d2-b500-ff0000d74aa7,11/4/2016,en
-7220,Case document,http://www.bailii.org/ew/cases/EWHC/Admin/2014/3677.html,11/4/2016,en
-7218,Case document,http://leo.informea.org/court-decision/ardagh-glass-ltd-v-chester-city-council-anor,11/4/2016,en
-7217,Case document,https://www.unece.org/fileadmin/DAM/env/pp/a.to.j/Jurisprudence_prj/UNITED_KINGDOM/Littlewood/LittlewoodJudgment.pdf,11/.04/2016,en
-7216,Case document,http://g8fip1kplyr33r3krz5b97d1.wpengine.netdna-cdn.com/wp-content/uploads/2016/12/Judgement_ETS_Swiss.pdf,18/02/2017,en
-7215,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2009/20091020_2009-EWHC-3020_judgment.pdf,23/08/2017,en
-7214,Case document,http://www.bailii.org/ew/cases/EWHC/Admin/2017/121.html,28/08/2017,en
-7212,Case document,http://www.bailii.org/ew/cases/EWHC/Admin/2013/3958.html,11/4/2016,en
-7211,Case document,http://www.bailii.org/ew/cases/EWHC/Admin/2015/3.html,11/4/2016,en
-7210,Case document,http://www.bailii.org/ew/cases/EWHC/Admin/2015/292.html,11/4/2016,en
-7209,Case document,http://www.newark-sherwooddc.gov.uk/media/newarkandsherwood/imagesandfiles/planningpolicy/pdfs/allocationsdevelopmentmanagmentoptionsreport/allocationsanddmdpo-examination/Appeal%20Decision%20North%20Gate.pdf,11/4/2016,en
-7206,Case document,http://www.bailii.org/ew/cases/EWHC/Admin/2014/2006.html,11/4/2016,en
-7205,*,,,en
-7204,*,,,en
-7203,Case document,http://www.bailii.org/ew/cases/EWHC/Admin/2012/3642.html,11/4/2016,en
-7202,Case document,http://www.courtsni.gov.uk/en-GB/Judicial%20Decisions/PublishedByYear/Documents/2013/[2013]%20NIQB%2024/j_j_TRE8779Final.htm,11/4/2016,en
-7201,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2007/20070806_2007-EWHC-1957_judgment-1.pdf,23/08/2017,en
-7200,Case document,http://www.bailii.org/ew/cases/EWCA/Civ/2012/1473.html,"11/4/2016,Case document",en
-7199,Case document,http://www.bailii.org/ew/cases/EWHC/Admin/2007/311.html,11/4/2016,en
-7198,Case document,http://www.bailii.org/cgi-bin/markup.cgi?doc=/uk/cases/UKEAT/2009/0219_09_0311.html&query=title+(+grainger++and+employment&method=boolean,11/4/2016,en
-7197,Case document,http://high-court-justice.vlex.co.uk/vid/-52634946,11/4/2016,en
-7195,Case document,http://www.bailii.org/ew/cases/EWHC/Comm/2012/1201.html,11/4/2016,en
-7194,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/1994/19941206_1995-10-P.A.D.-243_decision-1.pdf,23/08/2017,en
-7193,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/1994/19941201_1995-10-P.A.D.-255_decision.pdf,23/08/2017,en
-7192,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/1994/19941206_1995-10-P.A.D.-267_decision.pdf,23/08/2017,en
-7190,Case document,http://www.bailii.org/ew/cases/EWHC/Ch/2014/3049.html,11/1/2016,en
-7188,Case document,http://www.bailii.org/ew/cases/EWHC/Admin/2013/3293.html,11/4/2016,en
-7187,*,,,en
-7186,*,,,en
-7184,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2009/20090313_2009-EWHC-463_judgment.pdf,23/08/2017,en
-7185,Case document,http://www.bailii.org/ew/cases/EWHC/Admin/2009/308.html,11/4/2016,en
-7183,Case document,http://www.bailii.org/ew/cases/EWHC/Ch/2012/10.html,11/1/2016,en
-7181,*,,,en
-7180,*,,,en
-7179,Case document,http://epl.org.ua/en/law-posts/natsionalne-agentstvo-ekologichnyh-investytsij-dostup-do-informatsiyi-v-natsionalnomu-elektronnomu-reyestri-antropogennyh-vykydiv-2/,27-feb-18,en
-7178,*,,,en
-7177,Case document,http://uitspraken.rechtspraak.nl/inziendocument?id=ECLI:NL:RBDHA:2015:7196,"2-oct-19,Case document",en
-7176,Case document,http://climatecasechart.com/non-us-case/union-of-swiss-senior-women-for-climate-protection-v-swiss-federal-parliament/,5-aug-19,en
-7175,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2010/20100304_Appeal-No.-212007_judgment.pdf,23/08/2017,en
-7174,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2009/20090706_Appeal-No.-982005_judgment.pdf,23/08/2017,en
-7173,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2008/20081203_Appeal-No.-3222005_judgment.pdf,23/08/2017,en
-7172,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2008/20081202_Appeal-No.-2592005_judgment.pdf,23/08/2017,en
-7171,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2008/20081119_Appeal-No.-3182005_judgment.pdf,23/08/2017,en
-7169,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2009/20090717_Appeal-No.-1032005_judgment.pdf,23/08/2017,en
-7168,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2009/20090715_Appeal-No.-1192004_judgment.pdf,23/08/2017,en
-7167,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2009/20090529_Appeal-No.-3032005_judgment.pdf,23/08/2017,en
-7166,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2008/20081203_Appeal-No.-3152005_judgment.pdf,23/08/2017,en
-7165,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2008/20081118_Appeal-No.-3322006_judgment-1.pdf,23/08/2017,en
-7164,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2008/20081006_Appeal-No.-1002005_judgment-1.pdf,23/08/2017,en
-7163,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2008/20080930_Appeal-No.-1192004_judgment.pdf,23/08/2017,en
-7162,Case document,http://www.greenpeace.org/seasia/ph/PageFiles/105904/Climate-Change-and-Human-Rights-Complaint.pdf,11/4/2016,en
-7161,Case document,http://edigest.elaw.org/sites/default/files/pk.leghari.090415.pdf,"11/4/2016,Case document",en
-7160,Case document,https://web.law.columbia.edu/sites/default/files/microsites/climate-change/files/Resources/Non-US-Climate-Change-Litigation-Chart/pakistanyouthclimatepetition.pdf,11/1/2016,en
-7158,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2005/20051130_FHCBCS5305_judgment-1.pdf,23/08/2017,en
-7157,Case document,http://www.courtsofnz.govt.nz/cases/west-coast-ent-inc-v-buller-coal-ltd,11/4/2016,en
-7156,Case document,http://files.ecan.govt.nz/public/lwrp/hearing-evidence/doc/UnisonNetworksLtdvHastingsDistrictCouncilHCWellingtonCIV-2007-485-89611Dec072011NZRMA394.pdf,11/4/2016,en
-7155,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2015/20151110_CIV-2015-___complaint.pdf,11/4/2016,en
-7154,Case document,http://www.nzlii.org/cgi-bin/sinodisp/nz/cases/NZHC/2012/2156.html?query=royal%20Forest%20and%20Bird%20Protection%20Society%20of%20New%20Zealand%20Incorporated%20near%20Buller%20Coal%20Limited,11/4/2016,en
-7153,Case document,http://www.nzlii.org/cgi-bin/sinodisp/nz/cases/NZEnvC/2007/87.html?query=title(%222007%20NZEnvC%2087%22,11/4/2016,en
-7151,Case document,http://www.nzlii.org/cgi-bin/download.cgi/cgi-bin/download.cgi/download/nz/cases/NZHC/2012/2297.pdf,11/4/2016,en
-7150,Case document,http://www.pncc.govt.nz/content/48565/Motorimu%20EC%20Decisiona.pdf,11/4/2016,en
-7149,Case document,http://www.nzlii.org/nz/cases/NZEnvC/2007/128.html,11/4/2016,en
-7148,Case document,https://forms.justice.govt.nz/search/IPT/Documents/Deportation/pdf/rem_20140604_501370.pdf,11/4/2016,en
-7147,Case document,http://www.nzlii.org/cgi-bin/sinodisp/nz/cases/NZHC/2011/1702.html?query=Imported%20Motor%20Vehicle%20Industry%20Association%20Incorporated%20v%20Minister%20of%20Transport,11/4/2016,en
-7146,Case document,http://www.nzlii.org/nz/cases/NZHC/2006/1212.pdf,11/4/2016,en
-7145,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2002/20020521_2002-11-NZRMA-492_judgment-1.pdf,11/4/2016,en
-7144,Case document,http://www.nzlii.org/cgi-bin/sinodisp/nz/cases/NZEnvC/2009/293.html?query=title(%222009%20NZEnvC%20293%22,11/4/2016,en
-7143,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2015/20150720_2015-NZSC-107_judgment-1.pdf,23/08/2017,en
-7142,Case document,http://www.courtsofnz.govt.nz/cases/greenpeace-new-zealand-inc-v-genesis-power-ltd,11/1/2016,en
-7141,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2005/20050907_2005-NRRMA-541_judgment-1.pdf,23/08/2017,en
-7140,Case document,http://www.courts.ie/Judgments.nsf/0/59901538DB4C321780257EE700362A4C,11/4/2016,en
-7139,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2016/20160509_Application-No.-237-THC2013-CWPIL-No.-15-of-2010-_decision.pdf,,en
-7137,Case document,http://www.presse.sachsen-anhalt.de/index.php?cmd=get&id=874572&identifier=019e081b540341619084276e8ee58e00,11/4/2016,en
-7135,*,,,en
-7134,Case document,https://www.global-regulation.com/translation/france/1874531/decision-no.-2010-622-december-28%252c-2010-dc.html,11/4/2016,en
-7132,Case document,http://curia.europa.eu/juris/document/document.jsf,,en
-7132,jsessionid=9ea7d0f130d5c86283c9d5d5497b8877a8f3debe0aee.e34KaxiLc3eQc40LaxqMbN4OahuOe0?text=&docid=142213&pageIndex=0&doclang=en&mode=lst&dir=&occ=first&part=1&cid=385786,11/4/2016,,en
-7131,Case document,http://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A62007CJ0127,11/4/2016,en
-7130,Case document,http://curia.europa.eu/juris/document/document.jsf?text=&docid=162532&pageIndex=0&doclang=EN&mode=req&dir=&occ=first&part=1&cid=586939,11/4/2016,en
-7129,Case document,"http://curia.europa.eu/juris/liste.jsf?language=en&jur=C,T,F&num=T-370/11&td=ALL",11/4/2016,en
-7128,Case document,http://curia.europa.eu/juris/liste.jsf?language=en&num=T-183/07,11/4/2016,en
-7127,Case document,http://curia.europa.eu/juris/liste.jsf?language=en&num=T-263/07,11/4/2016,en
+7360,Application,http://www.lse.ac.uk/GranthamInstitute/wp-content/uploads/2018/05/20180524_Case-no.-T-18_application-1.pdf,31-may-18,en
+7360,Reply,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181210_Case-no.-T-33018_reply.pdf,10-12-18,en
+7360,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190515_Case-no.-T-33018_judgment.pdf,2-oct-19,en
+7360,Appeal,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190711_Case-no.-T-33018_appeal.pdf,22-oct-19,en
+7352,Judgment,http://curia.europa.eu/juris/document/document.jsf?text=climate&docid=199770&pageIndex=0&doclang=EN&mode=req&dir=&occ=first&part=1&cid=10369188#ctx1,5/2/2019,en
+7349,Opinion,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181206_2018-ECWA-Crim-2739_opinion.pdf,27-oct-19,en
+7348,Sentencing remarks,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2016/20160224_Not-available_na-1.pdf,27-oct-19,en
+7347,Memorandum (in French),http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20191015_Not-available_na.pdf,27-oct-19,en
+7346,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180104_R-42-2017_judgment.pdf,27-oct-19,en
+7345,Petition,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181108_R-77-2018_petition.pdf,27-oct-19,en
+7345,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190820_R-77-2018_judgment.pdf,27-oct-19,en
+7345,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190820_R-77-2018_judgment-4.pdf,27-oct-19,en
+7345,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190820_R-77-2018_judgment-1.pdf,27-oct-19,en
+7345,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190820_R-77-2018_judgment-2.pdf,27-oct-19,en
+7342,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190916_Not-available-_judgment-1.pdf,30-sep-19,en
+7342,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190916_Not-available-_judgment-2.pdf,30-sep-19,en
+7341,Petition,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190923_Not-available_petition.pdf,30-sep-19,en
+7341,Appendix to petition 1,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190923_Not-available_na-2.pdf,30-sep-19,en
+7341,Appendix to petition 2,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190923_Not-available_na.pdf,30-sep-19,en
+7340,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2015/20151216_I.C.J.-Reports-2011-2018_judgment.pdf,19-sep-19,en
+7340,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180202_I.C.J.-Reports-2011-2018_judgment.pdf,19-sep-19,en
+7339,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190830_W.P.-No.-1920692018_judgment-1.pdf,19-sep-19,en
+7338,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190306_2019-EWHC-519-Admin_judgment.pdf,19-sep-19,en
+7337,Application,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180309_C-68217_application-1.pdf,,en
+7337,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190620_C-68217_judgment-1.pdf,,en
+7336,Application,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190214_No.-8960-of-2019_application.pdf,3-7-19,en
+7336,Order,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190215_No.-8960-of-2019_order.pdf,3-7-19,en
+7335,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190503_2019-SKCA-40_judgment.pdf,3-7-19,en
+7334,Complaint,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2011/20110325_Court-No.-VLC-S-S-111913_complaint-1.pdf,3-7-19,en
+7334,Press release,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190607_Court-No.-VLC-S-S-111913_press-release-1.png,3-7-19,en
+7333,Decision,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2011/20111222_2011-NSWCA-424-2010-NSWLEC-34-Australia_decision.pdf,3-7-19,en
+7332,Decision,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190626_Tribunal-Appeal-No.-Net-196-of-2016_decision.pdf,3-7-19,en
+7331,Order,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2015/20150917_Directive-200387EC_order-1.pdf,30/11/2018,en
+7330,Judgment,http://curia.europa.eu/juris/document/document.jsf?text=&docid=183125&pageIndex=0&doclang=en&mode=lst&dir=&occ=first&part=1&cid=668786,3/12/18,en
+7327,Judgment,http://curia.europa.eu/juris/document/document.jsf?text=&docid=188666&pageIndex=0&doclang=EN&mode=lst&dir=&occ=first&part=1&cid=1945642,12-14-18,en
+7326,Judgment,http://curia.europa.eu/juris/document/document.jsf?text=climate&docid=200968&pageIndex=0&doclang=EN&mode=req&dir=&occ=first&part=1&cid=10351367#ctx1,5/2/2019,en
+7324,Summons,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190405_8918_summons.pdf,24/4/2019,en
+7323,Press release,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190513_Not-Available_press-release-1.pdf,17-jun-2019,en
+7322,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180920_Not-Available_na.pdf,26-6-2019,en
+7322,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190801_Not-Available_judgment-1.pdf,5-8-2019,en
+7322,Press release,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190801_Not-Available_press-release-1.pdf,5-8-2019,en
+7321,Press release,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190123_Not-Yet-Available_press-release-1.pdf,24/4/2019,en
+7321,Press release,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190123_Not-Yet-Available_press-release-2.pdf,24/4/2019,en
+7319,Application,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181126_500-06_application.pdf,2-oct-19,en
+7319,Application,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181126_500-06_application-2.pdf,2-oct-19,en
+7319,Decision,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190711_500-06_decision.pdf,2-oct-19,en
+7319,Decision,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190711_500-06_decision-2.pdf,2-oct-19,en
+7318,Decision,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181123_CO17312018_decision-1.pdf/,27-mar-2019,en
+7317,Press release,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181126_Not-Available_press-release.pdf,24-apr-2019,en
+7316,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181217_NA_na.pdf,26-apr-2019,en
+7316,Complaint,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190314_NA_complaint-1.pdf,26-apr-2019,en
+7314,Decision,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190208_2019-NSWLEC-7_decision-1.pdf,27-mar-2019,en
+7313,Press release,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190304_8766_press-release.pdf,27-mar-2019,en
+7312,Points of claim,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180913_C65807_points-of-claim-1.pdf,17-jun-2019,en
+7312,Complaint,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181130_C65807_complaint.pdf,17-jun-2019,en
+7312,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190503_2019-SKCA-40_judgment-1.pdf,17-jun-2019,en
+7311,Application,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180911_Case-no.-57518_application-1.pdf,11-oct-18,en
+7310,Complaint,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180806_2019-EWHC-1070-Admin_complaint-1.pdf,2-oct-19,en
+7310,Complaint,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181104_2019-EWHC-1070-Admin_complaint-1.pdf,2-oct-19,en
+7310,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190501_2019-EWHC-1070-Admin_judgment-1.pdf,2-oct-19,en
+7310,Order,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190722_2019-EWHC-1070-Admin_order.pdf,2-oct-19,en
+7309,Complaint,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180723_NSD13332018_complaint-1.pdf,23-jul-18,en
+7309,Amended complaint,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180921_NSD13332018_complaint-1.pdf,21-sep-18,en
+7309,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190117_NSD13332018_judgment-1.pdf,17-jan-19,en
+7308,Application,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20170704_WAI-2607_application-1.pdf,25-jul-18,en
+7307,Petition,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20170325_Original-Application-No.-___-of-2017_petition-1.pdf,25-jul-18,en
+7306,Complaint (indonesian),http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180124_2-G-LH-2018-PTUN.DPS_complaint.pdf,24-jul-18,en
+7306,Complaint (unofficial translation),http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180124_2-G-LH-2018-PTUN.DPS_complaint-1.pdf,24-jul-18,en
+7306,Complaint (amicus briefed in English),http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180626_2-G-LH-2018-PTUN.DPS_complaint-1.pdf,26-jun-18,en
+7304,Complaint,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180129_11001-22-03-000-2018-00319-00_complaint-1.pdf,20-may-19,en
+7304,Decision,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180212_11001-22-03-000-2018-00319-00_decision-1.pdf,20-may-19,en
+7304,Opinion,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180212_11001-22-03-000-2018-00319-00_opinion-1.pdf,20-may-19,en
+7304,Appeal,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180216_11001-22-03-000-2018-00319-00_appeal-1.pdf,20-may-19,en
+7304,Case document,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180316_11001-22-03-000-2018-00319-00_na.pdf,20-may-19,en
+7304,Decision,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180405_11001-22-03-000-2018-00319-00_decision.pdf,20-may-19,en
+7304,Decision,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180405_11001-22-03-000-2018-00319-00_decision-1.pdf,20-may-19,en
+7302,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20171121_2017-No.344-JR_judgment.pdf,30-Nov-2017,en
+7301,Complaint,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2015/20150828_Civil-Suit-No.-283-of-2012_complaint.pdf,18/10/2017,en
+7300,Decision,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20170830_2017-CSOH-113_decision-1.pdf,16/10/2017,en
+7299,Petition,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20170905_Case-no.-5408717_petition.pdf,,en
+7298,Petition,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20170905_Case-no.-6156117_petition.pdf,,en
+7297,Complaint,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2017/20170807_No.-VID-__-of-2017_complaint.pdf,25/08/2017,en
+7294,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2007/2454.html,30-Nov-2017,en
+7293,Decision,http://www.austlii.edu.au/au/cases/vic/VCAT/2014/360.html,30-Nov-2017,en
+7292,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2009/1324.html,30-Nov-2017,en
+7291,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2010/1348.html,30-Nov-2017,en
+7290,Judgment,https://www.caselaw.nsw.gov.au/decision/5897f721e4b0e71e17f56b92,30-Nov-2017,en
+7289,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2009/1946.html,,en
+7289,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2010/522.html,30-Nov-2017,en
+7288,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2011/1230.html,30-Nov-2017,en
+7287,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2010/1549.html,30-Nov-2017,en
+7286,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/nsw/NSWLEC/2016/1527.html,30-Nov-2017,en
+7285,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2010/1320.html,30-Nov-2017,en
+7284,Decision,http://www.austlii.edu.au/au/cases/vic/VCAT/2010/634.html,30-Nov-2017,en
+7283,Judgment,http://www.judgments.fedcourt.gov.au/judgments/Judgments/fca/single/2016/2016fca1042,30-Nov-2017,en
+7273,Decision,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20170202_W109-2000179-1291E_decision-1.pdf,2-oct-19,en
+7273,Decision,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20170202_W109-2000179-1291E_decision-2.pdf,2-oct-19,en
+7273,Decision,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20170629_W109-2000179-1291E_decision.pdf,2-oct-19,en
+7273,Decision,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20170601_W109-2000179-1291E_decision.pdf,2-oct-19,en
+7253,press release,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20171130_Case-No.-2-O-28515-Essen-Regional-Court_press-release.pdf,1-dec-2017,en
+7251,petition,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2016/20161018_16-166674TVI-OTIR06_petition-1.pdf,16-aug-18,en
+7251,judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180104_16-166674TVI-OTIR06_judgment-1.pdf,16-aug-18,en
+7251,judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180104_16-166674TVI-OTIR06_judgment-2.pdf,16-aug-18,en
+7251,press release,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20180205_16-166674TVI-OTIR06_press-release.pdf,16-aug-18,en
+7227,Decision,http://www.lse.ac.uk/GranthamInstitute/wp-content/uploads/2018/03/au_cases_cth_FCA_2016_1042.pdf,5-mar-18,en
+7227,Judgment,http://www7.austlii.edu.au/cgi-bin/sign.cgi/au/cases/cth/FCA/2016/1042,5-mar-18,en
+7225,Journal article,https://www.tib.eu/en/search/id/BLSE%3ARN110952491/Wigan-Metropolitan-Borough-Council-v-Secretary/?tx_tibsearch_search%5Bsearchspace%5D=tn,11/4/2016,en
+7223,Opinion,http://www.scotcourts.gov.uk/search-judgments/judgment?id=61f6daa6-8980-69d2-b500-ff0000d74aa7,11/4/2016,en
+7222,Judgment,http://www.bailii.org/ew/cases/EWHC/Admin/2007/2288.html,11/4/2016,en
+7221,Opinion,http://www.scotcourts.gov.uk/search-judgments/judgment?id=608b8aa6-8980-69d2-b500-ff0000d74aa7,11/4/2016,en
+7220,Judgment,http://www.bailii.org/ew/cases/EWHC/Admin/2014/3677.html,11/4/2016,en
+7218,Decision,http://leo.informea.org/court-decision/ardagh-glass-ltd-v-chester-city-council-anor,11/4/2016,en
+7217,Judgment,https://www.unece.org/fileadmin/DAM/env/pp/a.to.j/Jurisprudence_prj/UNITED_KINGDOM/Littlewood/LittlewoodJudgment.pdf,11/.04/2016,en
+7216,Judgment,http://g8fip1kplyr33r3krz5b97d1.wpengine.netdna-cdn.com/wp-content/uploads/2016/12/Judgement_ETS_Swiss.pdf,18/02/2017,en
+7215,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2009/20091020_2009-EWHC-3020_judgment.pdf,23/08/2017,en
+7214,Judgment,http://www.bailii.org/ew/cases/EWHC/Admin/2017/121.html,28/08/2017,en
+7212,Decision,http://www.bailii.org/ew/cases/EWHC/Admin/2013/3958.html,11/4/2016,en
+7211,Decision,http://www.bailii.org/ew/cases/EWHC/Admin/2015/3.html,11/4/2016,en
+7210,Decision,http://www.bailii.org/ew/cases/EWHC/Admin/2015/292.html,11/4/2016,en
+7209,Appeal decision,http://www.newark-sherwooddc.gov.uk/media/newarkandsherwood/imagesandfiles/planningpolicy/pdfs/allocationsdevelopmentmanagmentoptionsreport/allocationsanddmdpo-examination/Appeal%20Decision%20North%20Gate.pdf,11/4/2016,en
+7206,Decision,http://www.bailii.org/ew/cases/EWHC/Admin/2014/2006.html,11/4/2016,en
+7203,Decision,http://www.bailii.org/ew/cases/EWHC/Admin/2012/3642.html,11/4/2016,en
+7202,Decision,http://www.courtsni.gov.uk/en-GB/Judicial%20Decisions/PublishedByYear/Documents/2013/[2013]%20NIQB%2024/j_j_TRE8779Final.htm,11/4/2016,en
+7201,Judgment,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2007/20070806_2007-EWHC-1957_judgment-1.pdf,23/08/2017,en
+7200,Decision,http://www.bailii.org/ew/cases/EWCA/Civ/2012/1473.html,11/4/2016,en
+7200,Decision,http://www.bailii.org/ew/cases/EWCA/Civ/2012/1473.html,28/08/2017,en
+7199,Decision,http://www.bailii.org/ew/cases/EWHC/Admin/2007/311.html,11/4/2016,en
+7198,Decision,http://www.bailii.org/cgi-bin/markup.cgi?doc=/uk/cases/UKEAT/2009/0219_09_0311.html&query=title+(+grainger++and+employment&method=boolean,11/4/2016,en
+7195,Judgment,http://www.bailii.org/ew/cases/EWHC/Comm/2012/1201.html,11/4/2016,en
+7190,Decision,http://www.bailii.org/ew/cases/EWHC/Ch/2014/3049.html,11/1/2016,en
+7188,Decision,http://www.bailii.org/ew/cases/EWHC/Admin/2013/3293.html,11/4/2016,en
+7185,Decision,http://www.bailii.org/ew/cases/EWHC/Admin/2009/308.html,11/4/2016,en
+7183,Decision,http://www.bailii.org/ew/cases/EWHC/Ch/2012/10.html,11/1/2016,en
+7176,Full petition (German),http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2016/20161025_No.-A-29922017_petition-2.pdf,25-oct-16,en
+7176,Petition summary (English),http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2016/20161025_No.-A-29922017_petition.pdf,25-oct-16,en
+7176,Order (unofficial translation),http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20170426_No.-A-29922017_order.pdf,26-apr-17,en
+7176,Appeal (German),http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2017/20170526_No.-A-29922017_appeal.pdf,26-may-17,en
+7176,Decision (German),http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181127_No.-A-29922017_decision-1.pdf,27-nov-18,en
+7176,Press release (English),http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181207_No.-A-29922017_press-release.pdf,12-dec-18,en
+7176,Decision(unofficial translation),http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2018/20181127_No.-A-29922017_decision.pdf,27-nov-18,en
+7176,Appeal (German),http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190121_No.-A-29922017_appeal.pdf,21-jan-19,en
+7176,Appeal (unofficial translation),http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2019/20190121_No.-A-29922017_appeal-1.pdf,21-jan-19,en
+7160,Petition,https://web.law.columbia.edu/sites/default/files/microsites/climate-change/files/Resources/Non-US-Climate-Change-Litigation-Chart/pakistanyouthclimatepetition.pdf,11/1/2016,en
+7157,Decision,http://www.courtsofnz.govt.nz/cases/west-coast-ent-inc-v-buller-coal-ltd,11/4/2016,en
+7155,Complaint,http://blogs2.law.columbia.edu/climate-change-litigation/wp-content/uploads/sites/16/non-us-case-documents/2015/20151110_CIV-2015-___complaint.pdf,11/4/2016,en
+7154,Judgment,http://www.nzlii.org/cgi-bin/sinodisp/nz/cases/NZHC/2012/2156.html?query=royal%20Forest%20and%20Bird%20Protection%20Society%20of%20New%20Zealand%20Incorporated%20near%20Buller%20Coal%20Limited,11/4/2016,en
+7153,Judgment,http://www.nzlii.org/cgi-bin/sinodisp/nz/cases/NZEnvC/2007/87.html?query=title(%222007%20NZEnvC%2087%22,11/4/2016,en
+7151,Judgment,http://www.nzlii.org/cgi-bin/download.cgi/cgi-bin/download.cgi/download/nz/cases/NZHC/2012/2297.pdf,11/4/2016,en
+7149,Judgment,http://www.nzlii.org/nz/cases/NZEnvC/2007/128.html,11/4/2016,en
+7147,Judgment,http://www.nzlii.org/cgi-bin/sinodisp/nz/cases/NZHC/2011/1702.html?query=Imported%20Motor%20Vehicle%20Industry%20Association%20Incorporated%20v%20Minister%20of%20Transport,11/4/2016,en
+7146,Judgment,http://www.nzlii.org/nz/cases/NZHC/2006/1212.pdf,11/4/2016,en
+7144,Judgment,http://www.nzlii.org/cgi-bin/sinodisp/nz/cases/NZEnvC/2009/293.html?query=title(%222009%20NZEnvC%20293%22,11/4/2016,en
+7142,Decision,http://www.courtsofnz.govt.nz/cases/greenpeace-new-zealand-inc-v-genesis-power-ltd,11/1/2016,en
+7140,Judgment,http://www.courts.ie/Judgments.nsf/0/59901538DB4C321780257EE700362A4C,11/4/2016,en
+7137,Decision,http://www.presse.sachsen-anhalt.de/index.php?cmd=get&id=874572&identifier=019e081b540341619084276e8ee58e00,11/4/2016,en
+7134,Decision (unofficial translation),https://www.global-regulation.com/translation/france/1874531/decision-no.-2010-622-december-28%252c-2010-dc.html,11/4/2016,en
+7132,Judgment,http://curia.europa.eu/juris/document/document.jsf;jsessionid=9ea7d0f130d5c86283c9d5d5497b8877a8f3debe0aee.e34KaxiLc3eQc40LaxqMbN4OahuOe0?text=&docid=142213&pageIndex=0&doclang=en&mode=lst&dir=&occ=first&part=1&cid=385786,11/4/2016,en
+7131,Judgment,http://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A62007CJ0127,11/4/2016,en
+7130,Judgment,http://curia.europa.eu/juris/document/document.jsf?text=&docid=162532&pageIndex=0&doclang=EN&mode=req&dir=&occ=first&part=1&cid=586939,11/4/2016,en
+7129,Judgment,http://curia.europa.eu/juris/liste.jsf?language=en&jur=C,,en
+7129,T,,,en
+7129,F&num=T-370/11&td=ALL,11/4/2016,,en
+7128,Judgment,http://curia.europa.eu/juris/liste.jsf?language=en&num=T-183/07,11/4/2016,en
+7127,Judgment,http://curia.europa.eu/juris/liste.jsf?language=en&num=T-263/07,11/4/2016,en
 7126,Case document,http://ec.europa.eu/dgs/legal_service/arrets/04c217_en.pdf,11/4/2016,en
-7125,Case document,http://curia.europa.eu/juris/document/document.jsf?text=&docid=152657&pageIndex=0&doclang=en&mode=req&dir=&occ=first&part=1&cid=415398,11/4/2016,en
-7124,Case document,http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=CELEX:62007B0195:EN:HTML,11/4/2016,en
-7123,Case document,http://curia.europa.eu/juris/document/document.jsf,,en
-7123,jsessionid=9ea7d2dc30dbb1ea5de0e8f84afa8e84a9b818538d7c.e34KaxiLc3qMb40Rch0SaxuMahv0?text=&docid=143190&pageIndex=0&doclang=EN&mode=lst&dir=&occ=first&part=1&cid=780724,11/4/2016,,en
-7122,Case document,http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=CELEX:62007B0197:EN:HTML,11/4/2016,en
-7121,Case document,http://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:62013CJ0066&from=EN,11/4/2016,en
-7120,Case document,http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=CELEX:62007B0193:EN:HTML,11/4/2016,en
-7119,Case document,http://curia.europa.eu/juris/document/document.jsf?text=&docid=119426&pageIndex=0&doclang=en&mode=lst&dir=&occ=first&part=1&cid=1013205,11/4/2016,en
-7118,Case document,http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=OJ:C:2007:283:0027:0027:EN:PDF,11/4/2016,en
-7116,Case document,http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=CELEX:62011CJ0267:EN:HTML,11/4/2016,en
-7115,Case document,http://curia.europa.eu/juris/document/document.jsf?docid=157525&mode=req&pageIndex=1&dir=&occ=first&part=1&text=&doclang=EN&cid=249534,"11/4/2016,Case document",en
-7113,Case document,http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=CELEX:62007B0196:EN:HTML,11/4/2016,en
-7112,Case document,http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=CELEX:62006B0130:EN:HTML,11/4/2016,en
-7111,Case document,http://curia.europa.eu/juris/liste.jsf?language=en&num=C-122/05,11/4/2016,en
-7108,Case document,http://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A62007TB0198,11/1/2016,en
-7109,Case document,http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=CELEX:62007B0203:EN:HTML,11/1/2016,en
-7107,Case document,http://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:62007TO0199,11/1/2016,en
-7106,Case document,http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=CELEX:62007B0241:EN:HTML,11/1/2016,en
-7105,Case document,http://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A62014CJ0148,11/4/2016,en
-7104,Case document,http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=CELEX:62007B0208:EN:HTML,11/1/2016,en
-7103,Case document,http://web.law.columbia.edu/sites/default/files/microsites/climate-change/files/Resources/Non-US-Climate-Change-Litigation-Chart/borealis_polyolefine_gmbh_2d_chamber_2016-04-28.pdf,11/1/2016,en
-7102,Case document,http://curia.europa.eu/juris/document/document.jsf,,en
-7102,jsessionid=9ea7d0f130d5a6b7aa204b8f48a8a6a8ac56502feb0e.e34KaxiLc3eQc40LaxqMbN4Oax0Se0?text=&docid=143186&pageIndex=0&doclang=en&mode=lst&dir=&occ=first&part=1&cid=179274,11/1/2016,,en
-7101,Case document,http://curia.europa.eu/juris/liste.jsf?language=en&num=C-2/10,11/4/2016,en
-7100,Case document,http://curia.europa.eu/juris/liste.jsf?language=en&num=T-16/04,11/1/2016,en
-7099,Case document,http://curia.europa.eu/juris/document/document_print.jsf?doclang=EN&text=&pageIndex=0&part=1&mode=lst&docid=154403&occ=first&dir=&cid=67445,11/4/2016,en
-7098,Case document,"http://curia.europa.eu/juris/liste.jsf?language=en&jur=C,T,F&num=366/10&td=ALL","11/4/2016,Case document",en
-7097,Case document,http://www.bailii.org/eu/cases/EUECJ/2013/C54511.html,11/4/2016,en
-7096,Case document,http://curia.europa.eu/juris/document/document.jsf?text=&docid=83134&pageIndex=0&doclang=EN&mode=lst&dir=&occ=first&part=1&cid=355098,,en
-7095,Case document,http://curia.europa.eu/juris/liste.jsf?language=en&num=T-27/07,"11/4/2016,Case document",en
-7093,Case document,http://curia.europa.eu/juris/document/document.jsf,,en
-7093,jsessionid=9ea7d2dc30d6197e3aab43b54df480cb9e81dc78e07e.e34KaxiLc3qMb40Rch0SaxyMb3r0?text=&docid=83446&pageIndex=0&doclang=EN&mode=lst&dir=&occ=first&part=1&cid=354606,,,en
-7092,Case document,http://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:62013CC0425,11/1/2016,en
-7091,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2009/20091203_2686_petition.pdf,11/4/2016,en
-7090,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2016/20160208_3588_decision-1.pdf,11/29/2016,en
-7089,Case document,http://www.courts.gov.bc.ca/jdb-txt/SC/15/01/2015BCSC0165.htm,11/4/2016,en
-7088,Case document,http://www.canlii.org/en/ca/fct/doc/2012/2012fc893/2012fc893.pdf,11/4/2016,en
-7087,Case document,http://decisions.fca-caf.gc.ca/fca-caf/decisions/en/144495/1/document.do,11/4/2016,en
-7086,Case document,http://www.bcuc.com/Documents/Proceedings/2011/DOC_29396_12-19-2011-RiverDistrictEnergy-CPCN-Decision-WEB.pdf,11/4/2016,en
-7085,Case document,http://www.bcuc.com/Documents/Proceedings/2012/DOC_30355_04-12-2012-FEU-2012-13RR-Decision-WEB.pdf,11/4/2016,en
-7084,Case document,http://decisions.fct-cf.gc.ca/fc-cf/decisions/en/item/55045/index.do,11/4/2016,en
-7082,Case document,http://www.bcuc.com/Documents/Proceedings/2012/DOC_30355_04-12-2012-FEU-2012-13RR-Decision-WEB.pdf,11/4/2016,en
-7081,Case document,http://decisions.fca-caf.gc.ca/fca-caf/decisions/en/item/36582/index.do,"11/4/2016,Case document",en
-7078,Case document,http://www.canlii.org/en/ca/tmob/doc/2014/2014tmob78/2014tmob78.html,11/4/2016,en
-7077,Case document,http://climatecasechart.com/non-us-case/vzw-klimaatzaak-v-kingdom-of-belgium-et-al/,24-4-19,en
-7076,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2010/20100120_2010-VCAT-60_decision.pdf,23/08/2017,en
-7073,Case document,http://archive.sclqld.org.au/qjudgment/2012/QLC12-067.pdf,11/4/2016,en
-7072,Case document,http://www.ecolex.org/details/court-decision/wildlife-preservation-society-of-queensland-proserpinewhitsunday-branch-inc-v-minister-for-the-environment-and-heritage-and-bowen-central-coal-management-pty-ltd-and-qcoal-pty-ltd-b6863ce4-8e1c-4b4e-b805-bd49291b53a6/,11/4/2016,en
-7071,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2010/1334.html,11/4/2016,en
-7070,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2009/2177.html,11/4/2016,en
-7069,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2009/2072.html,11/4/2016,en
-7068,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2006/20060606_2006-151-LGERA-1_decision.pdf,23/08/2017,en
-7067,Case document,http://www.terminalspl.com.au/community/geelong/gceg/reports/2011/Terminals_Avgas_VCAT_decision_2011.pdf,11/4/2016,en
-7066,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2009/2231.html,11/4/2016,en
-7065,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2007/20070201_2007-161-LGERA-1_decision.pdf,23/08/2017,en
-7064,Case document,http://www.ecolex.org/details/court-decision/l-taip-v-east-gippsland-shire-council-94c766fe-ef37-46cb-ac3e-6c3473729fd4/,11/4/2016,en
-7063,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2010/1272.html,11/4/2016,en
-7062,Case document,http://www.austlii.edu.au/au/cases/nsw/NSWLEC/2013/1145.html,11/4/2016,en
-7059,Case document,https://www.informea.org/sites/default/files/court-decisions/COU-156705.pdf,11/4/2016,en
-7058,Case document,https://www.caselaw.nsw.gov.au/decision/549f8bd03004262463adabf8,11/4/2016,en
-7056,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2004/20041029_2004-140-LGERA-100_decision-1.pdf,23/08/2017,en
-7055,Case document,http://www.austlii.edu.au/au/cases/qld/QPEC/2013/26.pdf,11/4/2016,en
-7054,Case document,http://archive.sclqld.org.au/qjudgment/2007/QCA07-338.pdf,11/4/2016,en
-7052,Case document,http://earthjustice.org/sites/default/files/library/legal_docs/petition-to-the-inter-american-commission-on-human-rights-on-behalf-of-the-inuit-circumpolar-conference.pdf,23/08/2017,en
-7049,Case document,http://www.austlii.edu.au/au/cases/vic/VCAT/2010/1755.html,11/4/2016,en
-7048,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2010/20100323_2009-VCAT-1946-25-September-2009-2010-VCAT-522-23-March-2010_decision.pdf,23/08/2017,en
-7047,Case document,http://archive.sclqld.org.au/qjudgment/2013/QLC13-019.pdf,11/4/2016,en
-7046,Case document,http://www.austlii.edu.au/au/cases/sa/SASC/2008/57.html,11/4/2016,en
-7045,Case document,https://www.caselaw.nsw.gov.au/decision/54a63c1a3004de94513db721,11/4/2016,en
-7044,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2009/20091119_2009-VCAT-1022-2009-VCAT-2414-Australia_decision.pdf,23/08/2017,en
-7042,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2008/20080924_2008-161-LGERA-423-2008-NSWCA-334_decision.pdf,23/08/2017,en
-7041,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2007/363.html,11/4/2016,en
-7040,Case document,https://www.caselaw.nsw.gov.au/decision/54a6364d3004de94513d90f9,11/4/2016,en
-7039,Case document,http://www.austlii.edu.au/au/cases/nsw/NSWLEC/2010/129.html,11/4/2016,en
-7038,Case document,http://www.austlii.edu.au/au/cases/vic/VCAT/2011/513.html,"11/4/2016,Case document",en
-7037,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/nsw/NSWLEC/2012/1167.html,11/4/2016,en
-7036,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/nsw/NSWLEC/2011/195.html,11/4/2016,en
-7035,Case document,http://www.caselaw.nsw.gov.au/action/PJUDG?jgmtid=160375,11/4/2016,en
-7034,Case document,http://www.caselaw.nsw.gov.au/action/PJUDG?jgmtid=155760,11/4/2016,en
-7032,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/1994/19941110_1994-86-LGERA-143-Australia_decision.pdf,23/08/2017,en
-7031,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2006/20061127_2006-152-LGERA-258-Australia_decision-1.pdf,23/08/2017,en
-7030,Case document,http://www.austlii.edu.au/au/cases/vic/VCAT/2008/1545.html,11/4/2016,en
-7029,Case document,http://www.austlii.edu.au/au/cases/vic/VCAT/2013/39.html,11/4/2016,en
-7028,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2010/1183.html,11/4/2016,en
-7027,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2012/308.html,11/4/2016,en
-7026,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2007/20070813_2007-158-LGERA-349-Australia_decision.pdf,23/08/2017,en
-7024,Case document,https://www.caselaw.nsw.gov.au/decision/549f94443004262463afb52a,12/2/2016,en
-7023,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/qld/QPEC/2012/39.html,11/4/2016,en
-7022,Case document,http://www.judgments.fedcourt.gov.au/judgments/Judgments/fca/single/2013/2013fca0205,11/4/2016,en
-7021,Case document,http://www.austlii.edu.au/au/cases/vic/VCAT/2011/76.html,11/1/2016,en
-7018,Case document,http://www.austlii.edu.au/au/cases/nsw/NSWLEC/2009/88.html,11/1/2016,en
-7020,Case document,http://www.austlii.edu.au/au/cases/vic/VCAT/2010/1457.html,11/1/2016,en
-7017,Case document,https://www.caselaw.nsw.gov.au/decision/54a639943004de94513da836,11/1/2016,en
-7016,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2010/1334.html,11/1/2016,en
-7014,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2009/1453.html,11/1/2016,en
-7012,Case document,https://www.accc.gov.au/media-release/accc-institutes-proceedings-against-prime-carbon-pty-ltd,12/2/2016,en
-7013,Case document,http://www.accc.gov.au/media-release/v8-supercars-corrects-carbon-emissions-claims,11/1/2016,en
-7011,Case document,https://www.accc.gov.au/media-release/goodyear-tyres-apologises-offers-compensation-for-unsubstantiated-environmental-claims,12/2/2016,en
-7009,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2010/20100929_2010-FCA-1057_opinion-1.pdf,23/08/2017,en
-7008,Case document,https://www.accc.gov.au/media-release/de-longhi-alters-environmentally-friendly-claims,12/2/2016,en
-7006,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2009/20090219_-2009-NCWELC-17-Australia_decision.pdf,23/08/2017,en
-7005,Case document,http://www.austlii.edu.au/au/cases/wa/WASAT/2010/117.html,11/1/2016,en
-7003,Case document,https://www.caselaw.nsw.gov.au/decision/549f91ea3004262463af254e,11/4/2016,en
-7002,Case document,http://eresources.hcourt.gov.au/downloadPdf/2010/HCA/28,"11/4/2016,Case document",en
-7001,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2007/20070615_2007-QCA-200-Australia_decision.pdf,23/08/2017,en
-7000,Case document,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/nsw/NSWLEC/2011/221.html?stem=0&synonyms=0&query=Hunter%20Environment%20Lobby%20Inc,"11/4/2016,Case document",en
+7125,Judgment,http://curia.europa.eu/juris/document/document.jsf?text=&docid=152657&pageIndex=0&doclang=en&mode=req&dir=&occ=first&part=1&cid=415398,11/4/2016,en
+7124,Judgment,http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=CELEX:62007B0195:EN:HTML,11/4/2016,en
+7123,Judgment,http://curia.europa.eu/juris/document/document.jsf;jsessionid=9ea7d2dc30dbb1ea5de0e8f84afa8e84a9b818538d7c.e34KaxiLc3qMb40Rch0SaxuMahv0?text=&docid=143190&pageIndex=0&doclang=EN&mode=lst&dir=&occ=first&part=1&cid=780724,11/4/2016,en
+7121,Judgment,http://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:62013CJ0066&from=EN,11/4/2016,en
+7119,Judgment,http://curia.europa.eu/juris/document/document.jsf?text=&docid=119426&pageIndex=0&doclang=en&mode=lst&dir=&occ=first&part=1&cid=1013205,11/4/2016,en
+7118,Judgment,http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=OJ:C:2007:283:0027:0027:EN:PDF,11/4/2016,en
+7116,Judgment,http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=CELEX:62011CJ0267:EN:HTML,11/4/2016,en
+7115,Judgment,http://curia.europa.eu/juris/document/document.jsf?docid=157525&mode=req&pageIndex=1&dir=&occ=first&part=1&text=&doclang=EN&cid=249534,11/4/2016,en
+7115,Case document,http://wordpress2.ei.columbia.edu/climate-change-litigation/files/non-us-case-documents/2016/20161025_3585_petition.pdf,,en
+7113,Judgment,http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=CELEX:62007B0196:EN:HTML,11/4/2016,en
+7112,Judgment,http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=CELEX:62006B0130:EN:HTML,11/4/2016,en
+7111,Judgment,http://curia.europa.eu/juris/liste.jsf?language=en&num=C-122/05,11/4/2016,en
+7109,Judgment,http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=CELEX:62007B0203:EN:HTML,11/1/2016,en
+7108,Judgment,http://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A62007TB0198,11/1/2016,en
+7107,Judgment,http://eur-lex.europa.eu/legal-content/EN/ALL/?uri=CELEX:62007TO0199,11/1/2016,en
+7106,Judgment,http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=CELEX:62007B0241:EN:HTML,11/1/2016,en
+7105,Judgment,http://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A62014CJ0148,11/4/2016,en
+7104,Judgment,http://eur-lex.europa.eu/LexUriServ/LexUriServ.do?uri=CELEX:62007B0208:EN:HTML,11/1/2016,en
+7103,Judgment,http://web.law.columbia.edu/sites/default/files/microsites/climate-change/files/Resources/Non-US-Climate-Change-Litigation-Chart/borealis_polyolefine_gmbh_2d_chamber_2016-04-28.pdf,11/1/2016,en
+7102,Judgment,http://curia.europa.eu/juris/document/document.jsf;jsessionid=9ea7d0f130d5a6b7aa204b8f48a8a6a8ac56502feb0e.e34KaxiLc3eQc40LaxqMbN4Oax0Se0?text=&docid=143186&pageIndex=0&doclang=en&mode=lst&dir=&occ=first&part=1&cid=179274,11/1/2016,en
+7101,Judgment,http://curia.europa.eu/juris/liste.jsf?language=en&num=C-2/10,11/4/2016,en
+7100,Judgment,http://curia.europa.eu/juris/liste.jsf?language=en&num=T-16/04,11/1/2016,en
+7099,Judgment,http://curia.europa.eu/juris/document/document_print.jsf?doclang=EN&text=&pageIndex=0&part=1&mode=lst&docid=154403&occ=first&dir=&cid=67445,11/4/2016,en
+7098,Judgment,http://curia.europa.eu/juris/liste.jsf?language=en&jur=C,,en
+7098,T,,,en
+7098,F&num=366/10&td=ALL,11/4/2016,,en
+7098,Case document,http://cases.iclr.co.uk/Subscr/search.aspx?path=WLR%20Dailies/WLRD%202011/wlrd2011-386,04/11/2016,en
+7097,Decision,http://www.bailii.org/eu/cases/EUECJ/2013/C54511.html,11/4/2016,en
+7096,Judgment,http://curia.europa.eu/juris/document/document.jsf?text=&docid=83134&pageIndex=0&doclang=EN&mode=lst&dir=&occ=first&part=1&cid=355098,,en
+7095,Judgment,http://curia.europa.eu/juris/liste.jsf?language=en&num=T-27/07,11/4/2016,en
+7095,Judgment,http://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A62004TO0489,04/11/2016,en
+7093,Judgment,http://curia.europa.eu/juris/document/document.jsf;jsessionid=9ea7d2dc30d6197e3aab43b54df480cb9e81dc78e07e.e34KaxiLc3qMb40Rch0SaxyMb3r0?text=&docid=83446&pageIndex=0&doclang=EN&mode=lst&dir=&occ=first&part=1&cid=354606,,en
+7092,Judgment,http://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:62013CC0425,11/1/2016,en
+7089,Judgment,http://www.courts.gov.bc.ca/jdb-txt/SC/15/01/2015BCSC0165.htm,11/4/2016,en
+7088,Judgment,http://www.canlii.org/en/ca/fct/doc/2012/2012fc893/2012fc893.pdf,11/4/2016,en
+7087,Judgment,http://decisions.fca-caf.gc.ca/fca-caf/decisions/en/144495/1/document.do,11/4/2016,en
+7086,Decision,http://www.bcuc.com/Documents/Proceedings/2011/DOC_29396_12-19-2011-RiverDistrictEnergy-CPCN-Decision-WEB.pdf,11/4/2016,en
+7085,Decision,http://www.bcuc.com/Documents/Proceedings/2012/DOC_30355_04-12-2012-FEU-2012-13RR-Decision-WEB.pdf,11/4/2016,en
+7084,Judgment,http://decisions.fct-cf.gc.ca/fc-cf/decisions/en/item/55045/index.do,11/4/2016,en
+7082,Judgment,http://www.bcuc.com/Documents/Proceedings/2012/DOC_30355_04-12-2012-FEU-2012-13RR-Decision-WEB.pdf,11/4/2016,en
+7081,Judgment,http://decisions.fca-caf.gc.ca/fca-caf/decisions/en/item/36582/index.do,11/4/2016,en
+7081,Decision and arguments,http://www.canlii.org/en/ca/fct/doc/2008/2008fc1183/2008fc1183.pdf,04/11/2016,en
+7078,Decision,http://www.canlii.org/en/ca/tmob/doc/2014/2014tmob78/2014tmob78.html,11/4/2016,en
+7073,Decision,http://archive.sclqld.org.au/qjudgment/2012/QLC12-067.pdf,11/4/2016,en
+7071,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2010/1334.html,11/4/2016,en
+7070,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2009/2177.html,11/4/2016,en
+7069,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2009/2072.html,11/4/2016,en
+7066,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2009/2231.html,11/4/2016,en
+7063,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2010/1272.html,11/4/2016,en
+7062,Decision,http://www.austlii.edu.au/au/cases/nsw/NSWLEC/2013/1145.html,11/4/2016,en
+7059,Decision,https://www.informea.org/sites/default/files/court-decisions/COU-156705.pdf,11/4/2016,en
+7058,Decision,https://www.caselaw.nsw.gov.au/decision/549f8bd03004262463adabf8,11/4/2016,en
+7055,Decision,http://www.austlii.edu.au/au/cases/qld/QPEC/2013/26.pdf,11/4/2016,en
+7054,Appeal decision,http://archive.sclqld.org.au/qjudgment/2007/QCA07-338.pdf,11/4/2016,en
+7052,Petition,http://earthjustice.org/sites/default/files/library/legal_docs/petition-to-the-inter-american-commission-on-human-rights-on-behalf-of-the-inuit-circumpolar-conference.pdf,23/08/2017,en
+7049,Decision,http://www.austlii.edu.au/au/cases/vic/VCAT/2010/1755.html,11/4/2016,en
+7047,Decision (appeal dismissal ),http://archive.sclqld.org.au/qjudgment/2013/QLC13-019.pdf,11/4/2016,en
+7046,Decision,http://www.austlii.edu.au/au/cases/sa/SASC/2008/57.html,11/4/2016,en
+7045,Decision,https://www.caselaw.nsw.gov.au/decision/54a63c1a3004de94513db721,11/4/2016,en
+7041,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2007/363.html,11/4/2016,en
+7040,Decision,https://www.caselaw.nsw.gov.au/decision/54a6364d3004de94513d90f9,11/4/2016,en
+7039,Decision,http://www.austlii.edu.au/au/cases/nsw/NSWLEC/2010/129.html,11/4/2016,en
+7038,Decision,http://www.austlii.edu.au/au/cases/vic/VCAT/2011/513.html,11/4/2016,en
+7038,Decision,http://www.austlii.edu.au/au/cases/vic/VCAT/2010/2106.html,04/11/2016,en
+7037,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/nsw/NSWLEC/2012/1167.html,11/4/2016,en
+7036,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/nsw/NSWLEC/2011/195.html,11/4/2016,en
+7035,Decision,http://www.caselaw.nsw.gov.au/action/PJUDG?jgmtid=160375,11/4/2016,en
+7034,Decision,http://www.caselaw.nsw.gov.au/action/PJUDG?jgmtid=155760,11/4/2016,en
+7030,Decision,http://www.austlii.edu.au/au/cases/vic/VCAT/2008/1545.html,11/4/2016,en
+7029,Decision,http://www.austlii.edu.au/au/cases/vic/VCAT/2013/39.html,11/4/2016,en
+7028,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2010/1183.html,11/4/2016,en
+7027,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2012/308.html,11/4/2016,en
+7024,Judgment,http://www.caselaw.nsw.gov.au/decision/549f94443004262463afb52a,12/2/2016,en
+7023,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/qld/QPEC/2012/39.html,11/4/2016,en
+7022,Judgment,http://www.judgments.fedcourt.gov.au/judgments/Judgments/fca/single/2013/2013fca0205,11/4/2016,en
+7021,Decision,http://www.austlii.edu.au/au/cases/vic/VCAT/2011/76.html,11/1/2016,en
+7020,Decision,http://www.austlii.edu.au/au/cases/vic/VCAT/2010/1457.html,11/1/2016,en
+7018,Decision,http://www.austlii.edu.au/au/cases/nsw/NSWLEC/2009/88.html,11/1/2016,en
+7017,Judgment,http://www.caselaw.nsw.gov.au/decision/54a639943004de94513da836,11/1/2016,en
+7016,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2010/1334.html,11/1/2016,en
+7014,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/vic/VCAT/2009/1453.html,11/1/2016,en
+7013,Press release,http://www.accc.gov.au/media-release/v8-supercars-corrects-carbon-emissions-claims,11/1/2016,en
+7012,Press release,https://www.accc.gov.au/media-release/accc-institutes-proceedings-against-prime-carbon-pty-ltd,12/2/2016,en
+7011,Press release,https://www.accc.gov.au/media-release/goodyear-tyres-apologises-offers-compensation-for-unsubstantiated-environmental-claims,12/2/2016,en
+7008,Press release,https://www.accc.gov.au/media-release/de-longhi-alters-environmentally-friendly-claims,12/2/2016,en
+7005,Decision,http://www.austlii.edu.au/au/cases/wa/WASAT/2010/117.html,11/1/2016,en
+7003,Judgment,http://www.caselaw.nsw.gov.au/decision/549f91ea3004262463af254e,11/4/2016,en
+7000,Decision,http://www.austlii.edu.au/cgi-bin/sinodisp/au/cases/nsw/NSWLEC/2011/221.html?stem=0&synonyms=0&query=Hunter%20Environment%20Lobby%20Inc,11/4/2016,en
+7000,Judgment,http://www.caselaw.nsw.gov.au/decision/54a636e33004de94513d95ce,04/11/2016,en
+7000,Case document,http://www.law.columbia.edu/null/download?&exclusive=filemgr.download&file_id=6061,,en

--- a/lib/tasks/reimport.rake
+++ b/lib/tasks/reimport.rake
@@ -1,6 +1,8 @@
 namespace :reimport do
   desc 'Reimport TPI data - USE WITH CAUTION'
   task tpi: :environment do
+    next if Rails.env.production?
+
     Company.delete_all
     CP::Assessment.delete_all
     MQ::Assessment.delete_all
@@ -10,6 +12,8 @@ namespace :reimport do
   end
 
   task tpi_sector_clusters: :environment do
+    next if Rails.env.production?
+
     Seed::TPIData.import_sector_clusters
 
     puts 'TPI Sector Clusters reimported'
@@ -17,6 +21,8 @@ namespace :reimport do
 
   desc 'Reimport CCLOW data - USE WITH CAUTION'
   task cclow: :environment do
+    next if Rails.env.production?
+
     Legislation.delete_all
     Keyword.delete_all
     Framework.delete_all
@@ -33,13 +39,17 @@ namespace :reimport do
 
   desc 'Reimport CCLOW files data - USE WITH CAUTION'
   task cclow_sources: :environment do
+    next if Rails.env.production?
+
     Document.delete_all
 
     Seed::CCLOWData.call_sources_import
   end
 
   desc 'Reimport CCLOW litigation files data only - USE WITH CAUTION'
-  task cclow_sources: :environment do
+  task cclow_litigation_sources: :environment do
+    next if Rails.env.production?
+
     # let's start by appending
     # Document.delete_all
 
@@ -48,6 +58,8 @@ namespace :reimport do
 
   desc 'Reimport CCLOW LitigationSides'
   task cclow_litigation_sides: :environment do
+    next if Rails.env.production?
+
     LitigationSide.delete_all
 
     Seed::CCLOWData.import_litigation_sides

--- a/lib/tasks/reimport.rake
+++ b/lib/tasks/reimport.rake
@@ -38,6 +38,14 @@ namespace :reimport do
     Seed::CCLOWData.call_sources_import
   end
 
+  desc 'Reimport CCLOW litigation files data only - USE WITH CAUTION'
+  task cclow_sources: :environment do
+    # let's start by appending
+    # Document.delete_all
+
+    Seed::CCLOWData.call_litigation_sources_import
+  end
+
   desc 'Reimport CCLOW LitigationSides'
   task cclow_litigation_sides: :environment do
     LitigationSide.delete_all


### PR DESCRIPTION
- Adds a new file for litigation sources upload;
- Adds a new task focused on this upload only;
- Constrains it to just be used on staging before they can validate the data;
- Doesn't delete existing documents to avoid deleting valid documents [will need to double check how to review it afterwards, but I'll ask them];

New task is: `bundle exec rails reimport:cclow_litigation_sources` 