### PR TITLE
Fix line clamp

### DIFF
--- a/app/assets/stylesheets/cclow/_geography-page.scss
+++ b/app/assets/stylesheets/cclow/_geography-page.scss
@@ -69,6 +69,11 @@ $count-description-lines: 2;
       margin-top: 2.85rem;
 
       .description {
+        display: -webkit-box;
+        overflow: hidden;
+        -webkit-line-clamp: $count-description-lines;
+        -webkit-box-orient: vertical;
+
         a {
           color: $red;
         }

--- a/app/assets/stylesheets/cclow/_geography-page.scss
+++ b/app/assets/stylesheets/cclow/_geography-page.scss
@@ -69,11 +69,6 @@ $count-description-lines: 2;
       margin-top: 2.85rem;
 
       .description {
-        display: -webkit-box;
-        overflow: hidden;
-        -webkit-line-clamp: $count-description-lines;
-        -webkit-box-orient: vertical;
-
         a {
           color: $red;
         }

--- a/app/decorators/cclow/legislation_decorator.rb
+++ b/app/decorators/cclow/legislation_decorator.rb
@@ -17,7 +17,7 @@ module CCLOW
     def short_description
       h.truncate(
         h.strip_tags(description),
-        length: 500
+        length: 300
       )
     end
 

--- a/app/decorators/cclow/legislation_decorator.rb
+++ b/app/decorators/cclow/legislation_decorator.rb
@@ -14,9 +14,17 @@ module CCLOW
       h.cclow_geography_path(geography)
     end
 
+    def short_description
+      h.truncate(
+        h.strip_tags(description),
+        length: 500
+      )
+    end
+
     def as_json(*)
       super.tap do |hash|
         hash['link'] = link
+        hash['short_description'] = short_description
         hash['geography'] = model.geography
         hash['date_passed'] = model.first_event&.date&.strftime('%Y')
         hash['last_change'] = model.last_event&.date&.strftime('%B, %Y')

--- a/app/decorators/cclow/litigation_decorator.rb
+++ b/app/decorators/cclow/litigation_decorator.rb
@@ -10,6 +10,13 @@ module CCLOW
       end
     end
 
+    def short_summary
+      h.truncate(
+        h.strip_tags(summary),
+        length: 500
+      )
+    end
+
     def geography_path
       return nil if geography.nil?
 
@@ -19,6 +26,7 @@ module CCLOW
     def as_json(*)
       super.tap do |hash|
         hash['link'] = link
+        hash['short_summary'] = short_summary
         hash['geography'] = model.geography
         hash['opened_in'] = model.started_event&.date&.year
         hash['last_development_in'] = model.last_non_starting_event&.date&.strftime('%B, %Y')

--- a/app/decorators/cclow/litigation_decorator.rb
+++ b/app/decorators/cclow/litigation_decorator.rb
@@ -13,7 +13,7 @@ module CCLOW
     def short_summary
       h.truncate(
         h.strip_tags(summary),
-        length: 500
+        length: 300
       )
     end
 

--- a/app/javascript/components/pages/cclow/LegislationAndPolicies.js
+++ b/app/javascript/components/pages/cclow/LegislationAndPolicies.js
@@ -360,9 +360,7 @@ class LegislationAndPolicies extends Component {
                         {legislation.date_passed && <div>{legislation.date_passed}</div>}
                         {legislation.last_change && <div>Last change in {legislation.last_change}</div>}
                       </div>
-                      <div className="description">
-                        {legislation.short_description}
-                      </div>
+                      <div className="description" dangerouslySetInnerHTML={{__html: legislation.short_description}} />
                     </li>
                   </Fragment>
                 ))}

--- a/app/javascript/components/pages/cclow/LegislationAndPolicies.js
+++ b/app/javascript/components/pages/cclow/LegislationAndPolicies.js
@@ -360,7 +360,9 @@ class LegislationAndPolicies extends Component {
                         {legislation.date_passed && <div>{legislation.date_passed}</div>}
                         {legislation.last_change && <div>Last change in {legislation.last_change}</div>}
                       </div>
-                      <div className="description" dangerouslySetInnerHTML={{__html: legislation.description}} />
+                      <div className="description">
+                        {legislation.short_description}
+                      </div>
                     </li>
                   </Fragment>
                 ))}

--- a/app/javascript/components/pages/cclow/LitigationCases.js
+++ b/app/javascript/components/pages/cclow/LitigationCases.js
@@ -407,9 +407,7 @@ class LitigationCases extends Component {
                           {litigation.opened_in && <div>Opened in {litigation.opened_in}</div>}
                           {litigation.last_development_in && <div>Last development in {litigation.last_development_in}</div>}
                         </div>
-                        <div className="description">
-                          {litigation.short_summary}
-                        </div>
+                        <div className="description" dangerouslySetInnerHTML={{__html: litigation.short_summary}} />
                       </li>
                     </Fragment>
                   ))}

--- a/app/javascript/components/pages/cclow/LitigationCases.js
+++ b/app/javascript/components/pages/cclow/LitigationCases.js
@@ -407,7 +407,9 @@ class LitigationCases extends Component {
                           {litigation.opened_in && <div>Opened in {litigation.opened_in}</div>}
                           {litigation.last_development_in && <div>Last development in {litigation.last_development_in}</div>}
                         </div>
-                        <div className="description" dangerouslySetInnerHTML={{__html: litigation.summary}} />
+                        <div className="description">
+                          {litigation.short_summary}
+                        </div>
                       </li>
                     </Fragment>
                   ))}

--- a/app/views/cclow/geography/legislations/_list_item.html.erb
+++ b/app/views/cclow/geography/legislations/_list_item.html.erb
@@ -13,6 +13,6 @@
     <% end %>
   </div>
   <div class="description">
-    <%= legislation.description&.html_safe %>
+    <%= legislation.short_description %>
   </div>
 </li>

--- a/app/views/cclow/geography/litigation_cases/_list_item.html.erb
+++ b/app/views/cclow/geography/litigation_cases/_list_item.html.erb
@@ -9,6 +9,6 @@
     <% end %>
   </p>
   <div class="description">
-    <%= litigation.summary&.html_safe %>
+    <%= litigation.short_summary %>
   </div>
 </li>


### PR DESCRIPTION
Fix issue with line clamp. I think that inner html was causing troubles so I'm removing that and also truncating at the backend to 300 characters just to be sure. I left line-clamp css property because it's not to show the whole 2 lines, and not truncate in the middle.

![image](https://user-images.githubusercontent.com/1286444/75347887-10eaf000-58a2-11ea-9ab8-c7f7cb7eb2c9.png)
