### PR TITLE
Updates format to match the right format

### DIFF
--- a/app/controllers/cclow/api/targets_controller.rb
+++ b/app/controllers/cclow/api/targets_controller.rb
@@ -13,24 +13,22 @@ module CCLOW
       private
 
       def targets_as_json(geography)
-        geography.targets.order(:year).map do |t|
+        result = {}
+        result[:targets] = geography.targets.order(:year).map(&:to_api_format)
+        result[:sectors] = LawsSector.order(:name).map do |s|
           {
-            id: t.id,
-            iso_code3: geography.iso,
-            doc_type: t.source&.humanize,
-            type: t.target_type&.humanize,
-            scope: t.scopes&.map(&:name)&.join(', '),
-            sector: t.sector&.name,
-            description: t.description,
-            sources: t.legislations.map do |l|
-              {
-                id: l.id,
-                title: l.title,
-                link: legislation_route(geography, l)
-              }
-            end
+            key: s.name.parameterize,
+            title: s.name
           }
         end
+
+        result[:country_meta] = {
+          'BRA': {
+            country_profile: cclow_geography_url(geography),
+            lnp_count: geography.legislations.count
+          }
+        }
+        result
       end
 
       def legislation_route(geography, legislation)

--- a/app/controllers/cclow/api/targets_controller.rb
+++ b/app/controllers/cclow/api/targets_controller.rb
@@ -30,11 +30,6 @@ module CCLOW
         }
         result
       end
-
-      def legislation_route(geography, legislation)
-        send("cclow_geography_#{legislation.law? ? 'law' : 'policy'}_url",
-             geography, legislation)
-      end
     end
   end
 end

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -135,4 +135,10 @@ class Legislation < ApplicationRecord
   def last_event
     events.order(:date).offset(1).last
   end
+
+  def route(geography)
+    Rails.application.routes.url_helpers.send("cclow_geography_#{law? ? 'law' : 'policy'}_url",
+                                              geography, self,
+                                              host: 'climate-laws.org')
+  end
 end

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -107,7 +107,7 @@ class Target < ApplicationRecord
         {
           id: l.id,
           title: l.title,
-          link: legislation_route(geography, l)
+          link: l.route(geography)
         }
       end
     }

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -92,4 +92,24 @@ class Target < ApplicationRecord
     parts = [geography.name, target_type&.humanize, year]
     parts.compact.join(' - ')
   end
+
+  def to_api_format
+    {
+      id: id,
+      iso_code3: geography.iso,
+      country: geography.name,
+      doc_type: source&.downcase,
+      type: target_type&.humanize,
+      scope: scopes&.map(&:name)&.join(', '),
+      sector: sector&.name&.parameterize,
+      description: description,
+      sources: legislations.map do |l|
+        {
+          id: l.id,
+          title: l.title,
+          link: legislation_route(geography, l)
+        }
+      end
+    }
+  end
 end

--- a/spec/controllers/cclow/api/targets_controller_spec.rb
+++ b/spec/controllers/cclow/api/targets_controller_spec.rb
@@ -4,9 +4,12 @@ RSpec.describe CCLOW::Api::TargetsController, type: :controller do
   let!(:geography) { create(:geography, iso: 'ABC') }
   let!(:geography2) { create(:geography, iso: 'DEF') }
   let!(:geography3) { create(:geography, iso: 'GHI') }
-  let!(:target1) { create(:target, year: 2025, geography_id: geography.id) }
-  let!(:target2) { create(:target, year: 2020, geography_id: geography.id) }
-  let!(:target3) { create(:target, geography_id: geography2.id) }
+  let!(:sector1) { create(:laws_sector) }
+  let!(:sector2) { create(:laws_sector) }
+  let!(:sector3) { create(:laws_sector) }
+  let!(:target1) { create(:target, year: 2025, geography_id: geography.id, sector: sector1) }
+  let!(:target2) { create(:target, year: 2020, geography_id: geography.id, sector: sector1) }
+  let!(:target3) { create(:target, geography_id: geography2.id, sector: sector2) }
 
   describe 'Get index with geography iso as param' do
     subject { get :index, params: {iso: geography.iso} }
@@ -16,9 +19,10 @@ RSpec.describe CCLOW::Api::TargetsController, type: :controller do
     it('should return all targets for that country') do
       subject
       result = JSON.parse(response.body)
-      expect(result.size).to eq(2)
-      expect(result.first['iso_code3']).to eq(geography.iso)
-      expect(result.first['sector']).to eq(target2.sector.name)
+      expect(result['targets'].size).to eq(2)
+      expect(result['targets'].first['iso_code3']).to eq(geography.iso)
+      expect(result['targets'].first['sector']).to eq(target2.sector.name.downcase)
+      expect(result['sectors'].size).to eq(3)
     end
   end
 
@@ -30,7 +34,8 @@ RSpec.describe CCLOW::Api::TargetsController, type: :controller do
     it('should return no targets') do
       subject
       result = JSON.parse(response.body)
-      expect(result.size).to eq(0)
+      expect(result['targets'].size).to eq(0)
+      expect(result['sectors'].size).to eq(3)
     end
   end
 

--- a/spec/controllers/cclow/api/targets_controller_spec.rb
+++ b/spec/controllers/cclow/api/targets_controller_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe CCLOW::Api::TargetsController, type: :controller do
   let!(:sector1) { create(:laws_sector) }
   let!(:sector2) { create(:laws_sector) }
   let!(:sector3) { create(:laws_sector) }
+  let!(:legislation) { create(:legislation, laws_sectors: []) }
   let!(:target1) { create(:target, year: 2025, geography_id: geography.id, sector: sector1) }
   let!(:target2) { create(:target, year: 2020, geography_id: geography.id, sector: sector1) }
-  let!(:target3) { create(:target, geography_id: geography2.id, sector: sector2) }
+  let!(:target3) { create(:target, geography_id: geography2.id, sector: sector2, legislations: [legislation]) }
 
   describe 'Get index with geography iso as param' do
     subject { get :index, params: {iso: geography.iso} }


### PR DESCRIPTION
We were not using the right output format for the Climate Targets API endpoint used by Climate Watch, this updates it. We are aiming to match this: http://www.lse.ac.uk/GranthamInstitute/wp-json/wri/v1/targets/BRA