### PR TITLE
Feature/country profile

### DIFF
--- a/app/admin/geographies.rb
+++ b/app/admin/geographies.rb
@@ -11,7 +11,8 @@ ActiveAdmin.register Geography do
 
   permit_params :name, :iso, :region, :federal, :federal_details,
                 :legislative_process, :geography_type,
-                :visibility_status,
+                :visibility_status, :percent_global_emissions,
+                :climate_risk_index, :wb_income_group,
                 :created_by_id, :updated_by_id,
                 political_group_ids: [],
                 events_attributes: permit_params_for(:events)
@@ -41,6 +42,9 @@ ActiveAdmin.register Geography do
           row :indc_link
           row :legislative_process
           row :political_groups
+          row 'Percentage of Global Emissions', &:percent_global_emissions
+          row 'Climate Risk Index', &:climate_risk_index
+          row 'World Bank Income Group', &:wb_income_group
           row :updated_at
           row :updated_by
           row :created_at
@@ -74,6 +78,9 @@ ActiveAdmin.register Geography do
     column :federal
     column :federal_details
     column :political_groups, &:political_groups_string
+    column :percent_global_emissions
+    column :climate_risk_index
+    column :wb_income_group
     column :visibility_status
   end
 

--- a/app/decorators/geography_decorator.rb
+++ b/app/decorators/geography_decorator.rb
@@ -34,4 +34,8 @@ class GeographyDecorator < Draper::Decorator
 
     h.link_to 'INDC Link', indc_url, target: '_blank'
   end
+
+  def percent_global_emissions
+    "#{model.percent_global_emissions} %"
+  end
 end

--- a/app/decorators/geography_decorator.rb
+++ b/app/decorators/geography_decorator.rb
@@ -36,6 +36,6 @@ class GeographyDecorator < Draper::Decorator
   end
 
   def percent_global_emissions
-    "#{model.percent_global_emissions} %"
+    model.percent_global_emissions ? "#{model.percent_global_emissions} %" : '-'
   end
 end

--- a/app/models/cp/unit.rb
+++ b/app/models/cp/unit.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: cp_units
+#
+#  id          :bigint           not null, primary key
+#  sector_id   :bigint
+#  valid_since :date
+#  unit        :text             not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 class CP::Unit < ApplicationRecord
   belongs_to :sector, class_name: 'TPISector', foreign_key: 'sector_id'
 

--- a/app/models/geography.rb
+++ b/app/models/geography.rb
@@ -2,21 +2,24 @@
 #
 # Table name: geographies
 #
-#  id                  :bigint           not null, primary key
-#  geography_type      :string           not null
-#  iso                 :string           not null
-#  name                :string           not null
-#  slug                :string           not null
-#  region              :string           not null
-#  federal             :boolean          default(FALSE), not null
-#  federal_details     :text
-#  legislative_process :text
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
-#  visibility_status   :string           default("draft")
-#  created_by_id       :bigint
-#  updated_by_id       :bigint
-#  discarded_at        :datetime
+#  id                       :bigint           not null, primary key
+#  geography_type           :string           not null
+#  iso                      :string           not null
+#  name                     :string           not null
+#  slug                     :string           not null
+#  region                   :string           not null
+#  federal                  :boolean          default(FALSE), not null
+#  federal_details          :text
+#  legislative_process      :text
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  visibility_status        :string           default("draft")
+#  created_by_id            :bigint
+#  updated_by_id            :bigint
+#  discarded_at             :datetime
+#  percent_global_emissions :string
+#  climate_risk_index       :string
+#  wb_income_group          :string
 #
 
 class Geography < ApplicationRecord

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -6,6 +6,8 @@
 #  link       :string
 #  content_id :bigint           not null
 #  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 
 class Image < ApplicationRecord

--- a/app/models/tpi_sector.rb
+++ b/app/models/tpi_sector.rb
@@ -7,7 +7,7 @@
 #  slug       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  cp_unit    :text
+#  cluster_id :bigint
 #
 
 class TPISector < ApplicationRecord

--- a/app/models/tpi_sector_cluster.rb
+++ b/app/models/tpi_sector_cluster.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: tpi_sector_clusters
+#
+#  id         :bigint           not null, primary key
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 class TPISectorCluster < ApplicationRecord
   has_many :sectors, class_name: 'TPISector', foreign_key: :cluster_id, inverse_of: :cluster
 

--- a/app/services/csv_import/geographies.rb
+++ b/app/services/csv_import/geographies.rb
@@ -39,6 +39,9 @@ module CSVImport
         federal_details: row[:federal_details],
         legislative_process: row[:legislative_process],
         geography_type: row[:geography_type].downcase,
+        percent_global_emissions: row[:percent_global_emissions],
+        climate_risk_index: row[:climate_risk_index],
+        wb_income_group: row[:wb_income_group],
         visibility_status: row[:visibility_status]
       }
     end

--- a/app/services/migration/geographies.rb
+++ b/app/services/migration/geographies.rb
@@ -1,0 +1,27 @@
+require 'uri'
+module Migration
+  class Geographies
+    class << self
+      def migrate_metadata_file(source)
+        file = File.read(source).force_encoding('UTF-8')
+        csv = CSV.parse(
+          file,
+          headers: true,
+          skip_blanks: true
+        ).delete_if { |row| row.to_hash.values.all?(&:blank?) }
+        csv.each do |row|
+          puts row['iso']
+          g = ::Geography.where(iso: row['iso']).first
+          unless g
+            puts "Can't find geography with this iso: #{row['iso']}"
+            next
+          end
+          g.percent_global_emissions = row['percent_global_emissions'].to_f.round(2).to_s
+          g.climate_risk_index = row['climate_risk_index']
+          g.wb_income_group = row['wb_income_group']
+          g.save
+        end
+      end
+    end
+  end
+end

--- a/app/services/seed/cclow_data.rb
+++ b/app/services/seed/cclow_data.rb
@@ -9,6 +9,7 @@ module Seed
       delegate :call_sources_import, to: :instance
       delegate :import_litigation_sides, to: :instance
       delegate :call_litigation_sources_import, to: :instance
+      delegate :import_geographies_metadata, to: :instance
     end
 
     def call_sources_import
@@ -62,6 +63,12 @@ module Seed
     def import_litigation_sides
       TimedLogger.log('Import Litigations Sides') do
         CSVImport::LitigationSides.new(seed_file('litigations-sides.csv')).call
+      end
+    end
+
+    def import_geographies_metadata
+      TimedLogger.log('Import Geographies Metadata') do
+        Migration::Geographies.migrate_metadata_file(seed_file('geographies_metadata.csv'))
       end
     end
 

--- a/app/views/admin/geographies/_form.html.erb
+++ b/app/views/admin/geographies/_form.html.erb
@@ -20,6 +20,9 @@
           <%= f.input :federal_details, wrapper_html: {data: {controller: 'dependent-input', depends_on: 'federal'}} %>
           <%= f.input :legislative_process, as: :trix %>
           <%= f.input :political_group_ids, label: 'Political Groups', as: :tags, collection: PoliticalGroup.all %>
+          <%= f.input :percent_global_emissions, label: 'Percentage of Global Emissions' %>
+          <%= f.input :climate_risk_index %>
+          <%= f.input :wb_income_group, label: 'World Bank Income Group' %>
           <%= f.input :visibility_status, as: :select %>
         <% end %>
       </div>

--- a/app/views/cclow/geographies/_overview.html.erb
+++ b/app/views/cclow/geographies/_overview.html.erb
@@ -3,9 +3,9 @@
            {caption: 'Litigation cases', count: geography_overview.number_of_litigation_cases, img: 'scale', link: cclow_geography_litigation_cases_path(geography)},
            {caption: 'Climate targets', count: geography_overview.number_of_targets, img: 'target', link: cclow_geography_climate_targets_path(geography)}] %>
 <% properties = [{caption: 'Region', value: geography.region, question: false},
-                 {caption: 'Rank as emitter', question: false},
-                 {caption: 'Paris Agreement ratification status', question: false},
-                 {caption: 'Income group (World Bank)', question: false},
+                 {caption: '% Global Emissions', value: geography.percent_global_emissions, question: false},
+                 {caption: 'Global Climate Risk Index', value: geography.climate_risk_index, question: false},
+                 {caption: 'Income group (World Bank)', value: geography.wb_income_group, question: false},
                  {caption: 'Main political groups', value: geography.political_groups.map(&:name).join('; '), question: false},
                  {caption: 'Federative/Unitary',
                   value: geography.federal ? "Federative #{geography.federal_details}" : 'Unitary', question: false}] %>

--- a/db/migrate/20200227100810_add_percent_global_emissions_and_climate_risk_index_and_wb_income_group_to_geographies.rb
+++ b/db/migrate/20200227100810_add_percent_global_emissions_and_climate_risk_index_and_wb_income_group_to_geographies.rb
@@ -1,0 +1,7 @@
+class AddPercentGlobalEmissionsAndClimateRiskIndexAndWbIncomeGroupToGeographies < ActiveRecord::Migration[6.0]
+  def change
+    add_column :geographies, :percent_global_emissions, :string
+    add_column :geographies, :climate_risk_index, :string
+    add_column :geographies, :wb_income_group, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_16_161342) do
+ActiveRecord::Schema.define(version: 2020_02_27_100810) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -234,6 +234,9 @@ ActiveRecord::Schema.define(version: 2020_02_16_161342) do
     t.bigint "created_by_id"
     t.bigint "updated_by_id"
     t.datetime "discarded_at"
+    t.string "percent_global_emissions"
+    t.string "climate_risk_index"
+    t.string "wb_income_group"
     t.index ["created_by_id"], name: "index_geographies_on_created_by_id"
     t.index ["discarded_at"], name: "index_geographies_on_discarded_at"
     t.index ["iso"], name: "index_geographies_on_iso", unique: true

--- a/db/seeds/laws_migration/geographies_metadata.csv
+++ b/db/seeds/laws_migration/geographies_metadata.csv
@@ -1,0 +1,190 @@
+iso,percent_global_emissions,climate_risk_index,wb_income_group
+AFG,0.203271024,41.83,Low income
+AGO,0.379057634,97,Lower middle income
+ALB,0.019340105,114.17,Upper middle income
+AND,0.000210447,,High income
+ARE,0.545521429,158.33,High income
+ARG,1.014524229,79.5,Upper middle income
+ARM,0.019908312,145.17,Upper middle income
+ATG,0.002904172,58,High income
+AUS,1.092410766,50.17,High income
+AUT,0.151206368,55.67,High income
+AZE,0.155688895,133.67,Upper middle income
+BDI,0.016288619,73.67,Low income
+BEL,0.225915151,63.83,High income
+BEN,0.055831662,141,Low income
+BFA,0.081295783,99.33,Low income
+BGD,0.441055402,30,Lower middle income
+BGR,0.092744115,70.83,Upper middle income
+BHR,0.099057533,171.83,High income
+BHS,0.008354757,39.67,High income
+BIH,0.057346883,70.17,Upper middle income
+BLR,0.169830952,142,Upper middle income
+BLZ,0.010227738,48.5,Upper middle income
+BOL,0.317649119,45.33,Lower middle income
+BRA,2.902867639,83.17,Upper middle income
+BRB,0.009154457,141.67,High income
+BRN,0.035355142,169.17,High income
+BTN,-0.00383014,97,Lower middle income
+BWA,0.147292049,132.33,Upper middle income
+CAF,0.159371722,149.33,Low income
+CAN,1.639952489,88.17,High income
+CHE,0.098320967,52.33,High income
+CHL,0.007870728,87.83,High income
+CHN,24.36320759,55.5,Upper middle income
+CIV,0.065596416,142.67,Lower middle income
+CMR,0.438530034,133.83,Lower middle income
+COD,0.473169656,125.83,Low income
+COG,0.104739609,151.5,Lower middle income
+COK,0.000231492,,
+COL,0.488237681,55.67,Upper middle income
+COM,0.001262684,122.67,Lower middle income
+CPV,0.00195716,143.5,Lower middle income
+CRI,0.009743709,88.17,Upper middle income
+CUB,0.057325838,,Upper middle income
+CYP,0.017382945,129.67,High income
+CZE,0.235216921,79.67,High income
+DEU,1.701950257,38.67,High income
+DJI,0.004377303,69.5,Lower middle income
+DMA,0.0007997,32.33,Upper middle income
+DNK,0.098194699,112.83,High income
+DOM,0.060819263,58.5,Upper middle income
+DZA,0.442128683,92.5,Upper middle income
+ECU,0.20747997,92.83,Upper middle income
+EGY,0.653270435,143.67,Lower middle income
+ERI,0.016751603,109.17,Low income
+ESP,0.59724937,47.33,High income
+EST,0.042889155,148.83,High income
+ETH,0.397029831,64.67,Low income
+FIN,0.1329185,155.67,High income
+FJI,0.002020294,37.17,Upper middle income
+FRA,0.693634222,38,High income
+GAB,-0.178796006,167.33,Upper middle income
+GBR,0.971298359,65,High income
+GEO,0.036260066,94.17,Upper middle income
+GHA,0.10741229,102.5,Lower middle income
+GIN,0.095963958,161.33,Low income
+GMB,0.005050735,81,Low income
+GNB,0.00885983,111.33,Low income
+GNQ,0.048865858,,Upper middle income
+GRC,0.181742268,78.83,High income
+GRD,0.004882377,39.83,Upper middle income
+GTM,0.092154862,38.33,Upper middle income
+GUY,0.078749371,107.17,Upper middle income
+HND,0.108338258,55,Lower middle income
+HRV,0.039858714,48.33,High income
+HTI,0.021128907,13.83,Low income
+HUN,0.128962091,69,High income
+IDN,4.690869787,76.83,Lower middle income
+IND,6.809358338,38.67,Lower middle income
+IRL,0.138011324,119.17,High income
+IRN,1.826598179,79,Upper middle income
+IRQ,0.402817131,141.33,Upper middle income
+ISL,0.006713268,170.33,High income
+ISR,0.189570906,120.5,High income
+ITA,0.777876267,43.67,High income
+JAM,0.020202939,64.83,Upper middle income
+JOR,0.075171767,116,Upper middle income
+JPN,2.65977999,69.33,High income
+KAZ,0.608234718,142.83,Upper middle income
+KEN,0.100530664,53.67,Lower middle income
+KGZ,0.033671564,109.33,Lower middle income
+KHM,0.137695653,35.33,Lower middle income
+KIR,0.000168358,116.17,Lower middle income
+KNA,0.000778655,113.5,High income
+KOR,1.383480394,82.83,High income
+KWT,0.235679905,152,High income
+LAO,0.099499472,76.33,Lower middle income
+LBN,0.0660594,120,Upper middle income
+LBR,0.022181143,155.33,Low income
+LBY,0.184036143,158.83,Upper middle income
+LCA,0.001704623,59.33,Upper middle income
+LIE,8.41789E-05,,High income
+LKA,0.078538923,40.17,Upper middle income
+LSO,0.007723415,106.5,Lower middle income
+LTU,0.037270213,100.5,High income
+LUX,0.020560699,97.17,High income
+LVA,-0.004903422,83.83,High income
+MAR,0.185298827,100,Lower middle income
+MDA,0.024916958,86.17,Lower middle income
+MDG,0.123848222,32.83,Low income
+MDV,0.004251035,169.17,Upper middle income
+MEX,1.44867696,61.83,Upper middle income
+MHL,8.41789E-05,165,Upper middle income
+MKD,0.021865472,100,Upper middle income
+MLI,0.099899322,116.67,Low income
+MLT,0.004040588,152.83,High income
+MMR,0.461994905,10.33,Lower middle income
+MNE,0.007197297,,Upper middle income
+MNG,0.142262359,61.67,Lower middle income
+MOZ,0.160192467,37.5,Low income
+MRT,0.023990989,78.5,Lower middle income
+MUS,0.013636983,104.67,Upper middle income
+MWI,0.044614823,77.83,Low income
+MYS,0.338904294,103.33,Upper middle income
+NAM,0.042952289,66.67,Upper middle income
+NER,0.089882032,74,Low income
+NGA,1.012293488,104.83,Lower middle income
+NIC,0.043436318,53.83,Lower middle income
+NIU,0.000126268,,
+NLD,0.393494317,71.83,High income
+NOR,0.050107496,138.83,High income
+NPL,0.128898957,31.5,Low income
+NRU,0.000168358,,Upper middle income
+NZL,0.132855365,84.17,High income
+OMN,0.15989784,41.17,High income
+PAK,0.84951252,28.83,Lower middle income
+PAN,0.056694496,106.5,High income
+PER,0.355340226,58,Upper middle income
+PHL,0.314429275,17.67,Lower middle income
+PLW,6.31342E-05,,High income
+PNG,0.134370586,91.33,Lower middle income
+POL,0.736060393,77.17,High income
+PRK,0.13794819,,Low income
+PRT,0.146029365,38.83,High income
+PRY,0.409509355,73.5,Upper middle income
+QAT,0.194158657,173.67,High income
+ROU,-0.123385238,53.17,Upper middle income
+RUS,5.032594074,47.67,Upper middle income
+RWA,0.015972948,102,Low income
+SAU,1.396486036,102.17,High income
+SDN,0.319206429,93,Lower middle income
+SEN,0.073635502,129.5,Lower middle income
+SGP,0.133107902,172.17,High income
+SLB,0.005745211,70,Lower middle income
+SLE,0.028599785,85.67,Low income
+SLV,0.028368293,42.5,Lower middle income
+SOM,0.084705029,,Low income
+SRB,0.132287158,,Upper middle income
+STP,0.000420895,,Lower middle income
+SUR,0.01544683,166,Upper middle income
+SVK,0.070562972,108,High income
+SVN,0.023128156,54.33,High income
+SWE,0.097289776,129.5,High income
+SYC,0.002735815,159.5,High income
+SYR,0.095500974,,Low income
+TCD,0.214593088,100.83,Low income
+TGO,0.032345746,149.67,Low income
+THA,0.878070215,31,Upper middle income
+TJK,0.028031577,58.17,Low income
+TKM,0.265521328,,Upper middle income
+TON,0.000610297,75.67,Upper middle income
+TTO,0.054568979,150.17,High income
+TUN,0.082937272,114.33,Lower middle income
+TUR,0.83326599,115.17,Upper middle income
+TUV,2.10447E-05,113.67,Upper middle income
+TZA,0.672294869,114.33,Low income
+UGA,0.170609607,69.33,Low income
+UKR,0.597081012,88,Lower middle income
+URY,0.055936886,88.33,High income
+USA,12.27642081,44.17,High income
+UZB,0.409677713,162,Lower middle income
+VCT,0.000694476,59.83,Upper middle income
+VEN,0.736818004,66,Upper middle income
+VNM,0.661372655,29.83,Lower middle income
+VUT,0.001746712,53.83,Lower middle income
+WSM,0.001473131,73.67,Upper middle income
+YEM,0.049602423,74.67,Low income
+ZAF,1.046743707,77.33,Upper middle income
+ZMB,1.0395885,119.67,Lower middle income
+ZWE,0.138853113,53.33,Lower middle income

--- a/lib/tasks/reimport.rake
+++ b/lib/tasks/reimport.rake
@@ -64,4 +64,9 @@ namespace :reimport do
 
     Seed::CCLOWData.import_litigation_sides
   end
+
+  desc 'Reimport Geographies Metadata'
+  task geographies_metadata: :environment do
+    Seed::CCLOWData.import_geographies_metadata
+  end
 end

--- a/spec/factories/geographies.rb
+++ b/spec/factories/geographies.rb
@@ -2,21 +2,24 @@
 #
 # Table name: geographies
 #
-#  id                  :bigint           not null, primary key
-#  geography_type      :string           not null
-#  iso                 :string           not null
-#  name                :string           not null
-#  slug                :string           not null
-#  region              :string           not null
-#  federal             :boolean          default(FALSE), not null
-#  federal_details     :text
-#  legislative_process :text
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
-#  visibility_status   :string           default("draft")
-#  created_by_id       :bigint
-#  updated_by_id       :bigint
-#  discarded_at        :datetime
+#  id                       :bigint           not null, primary key
+#  geography_type           :string           not null
+#  iso                      :string           not null
+#  name                     :string           not null
+#  slug                     :string           not null
+#  region                   :string           not null
+#  federal                  :boolean          default(FALSE), not null
+#  federal_details          :text
+#  legislative_process      :text
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  visibility_status        :string           default("draft")
+#  created_by_id            :bigint
+#  updated_by_id            :bigint
+#  discarded_at             :datetime
+#  percent_global_emissions :string
+#  climate_risk_index       :string
+#  wb_income_group          :string
 #
 
 FactoryBot.define do
@@ -29,6 +32,9 @@ FactoryBot.define do
     geography_type { 'national' }
     region { Geography::REGIONS.sample }
     federal { false }
+    percent_global_emissions { '10.0' }
+    climate_risk_index { '0.5' }
+    wb_income_group { 'Rich' }
 
     association :created_by, factory: :admin_user
     association :updated_by, factory: :admin_user

--- a/spec/factories/tpi_sectors.rb
+++ b/spec/factories/tpi_sectors.rb
@@ -7,7 +7,7 @@
 #  slug       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  cp_unit    :text
+#  cluster_id :bigint
 #
 
 FactoryBot.define do

--- a/spec/models/cclow_page_spec.rb
+++ b/spec/models/cclow_page_spec.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: pages
+#
+#  id          :bigint           not null, primary key
+#  title       :string
+#  description :text
+#  slug        :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  menu        :string
+#  type        :string
+#
+
 require 'rails_helper'
 
 RSpec.describe CCLOWPage, type: :model do

--- a/spec/models/geography_spec.rb
+++ b/spec/models/geography_spec.rb
@@ -2,21 +2,24 @@
 #
 # Table name: geographies
 #
-#  id                  :bigint           not null, primary key
-#  geography_type      :string           not null
-#  iso                 :string           not null
-#  name                :string           not null
-#  slug                :string           not null
-#  region              :string           not null
-#  federal             :boolean          default(FALSE), not null
-#  federal_details     :text
-#  legislative_process :text
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
-#  visibility_status   :string           default("draft")
-#  created_by_id       :bigint
-#  updated_by_id       :bigint
-#  discarded_at        :datetime
+#  id                       :bigint           not null, primary key
+#  geography_type           :string           not null
+#  iso                      :string           not null
+#  name                     :string           not null
+#  slug                     :string           not null
+#  region                   :string           not null
+#  federal                  :boolean          default(FALSE), not null
+#  federal_details          :text
+#  legislative_process      :text
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  visibility_status        :string           default("draft")
+#  created_by_id            :bigint
+#  updated_by_id            :bigint
+#  discarded_at             :datetime
+#  percent_global_emissions :string
+#  climate_risk_index       :string
+#  wb_income_group          :string
 #
 
 require 'rails_helper'

--- a/spec/models/tpi_page_spec.rb
+++ b/spec/models/tpi_page_spec.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: pages
+#
+#  id          :bigint           not null, primary key
+#  title       :string
+#  description :text
+#  slug        :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  menu        :string
+#  type        :string
+#
+
 require 'rails_helper'
 
 RSpec.describe TPIPage, type: :model do

--- a/spec/models/tpi_sector_spec.rb
+++ b/spec/models/tpi_sector_spec.rb
@@ -7,7 +7,7 @@
 #  slug       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  cp_unit    :text
+#  cluster_id :bigint
 #
 
 require 'rails_helper'


### PR DESCRIPTION
This PR adds three new fields for Geographies metadata, the data file to be used and an import script to import the data. It also enables editing on the backend.

You'll need to migrate the database: `bundle exec rails db:migrate`
And then you can import the data with: `bundle exec rails reimport:geographies_metadata`