### PR TITLE
[CCLOW] Style static pages according to UI kit

### DIFF
--- a/app/assets/stylesheets/cclow/_pages.scss
+++ b/app/assets/stylesheets/cclow/_pages.scss
@@ -2,6 +2,9 @@
 @import "colors";
 @import "bulma/sass/utilities/all";
 
+$text-indent: 25px;
+$text-indent-numbers: 18px;
+
 .pages__title {
   margin-top: 40px;
   margin-bottom: 40px;
@@ -17,19 +20,25 @@
   * > {
     ul {
       margin-top: 20px;
+      margin-left: $text-indent;
 
       li {
         list-style-type: disc;
+        list-style-position: inside;
         line-height: 32px;
+        text-indent: calc(-1 * #{$text-indent});
       }
     }
 
     ol {
       margin-top: 20px;
+      margin-left: $text-indent-numbers;
 
       li {
         list-style-type: decimal;
+        list-style-position: inside;
         line-height: 32px;
+        text-indent: calc(-1 * #{$text-indent-numbers});
       }
     }
 

--- a/app/assets/stylesheets/cclow/_pages.scss
+++ b/app/assets/stylesheets/cclow/_pages.scss
@@ -7,11 +7,42 @@
   margin-bottom: 40px;
   color: $blue-dark;
   font-family: $family-sans-serif-bold;
+  font-weight: normal;
   font-size: 28px;
 }
 
 .pages__content {
   margin: 0 150px;
+
+  * > {
+    ul {
+      margin-top: 20px;
+
+      li {
+        list-style-type: disc;
+        line-height: 32px;
+      }
+    }
+
+    ol {
+      margin-top: 20px;
+
+      li {
+        list-style-type: decimal;
+        line-height: 32px;
+      }
+    }
+
+    strong {
+      font-weight: normal;
+      font-family: $family-sans-serif-bold;
+    }
+
+    h4 {
+      font-family: $family-sans-serif-bold;
+      font-size: 20px !important;
+    }
+  }
 }
 
 .pages__description {
@@ -22,7 +53,7 @@
 
   h1, h2, h3, h4, h5 {
     margin-top: 40px;
-    margin-bottom: 15px;
+    margin-bottom: 20px;
   }
 
   img {
@@ -32,6 +63,18 @@
 
   a {
     color: $red;
+    font-family: $family-sans-serif-bold;
+
+    &:hover {
+      color: $red-medium;
+      text-decoration: underline;
+    }
+
+    &:focus {
+      color: $white;
+      background-color: $red-medium;
+      text-decoration: underline;
+    }
   }
 }
 
@@ -41,6 +84,7 @@
   grid-column-gap: 50px;
   grid-template-columns: repeat(3, 1fr);
   align-items: center;
+  text-align: center;
 }
 
 .latest_additions__container {


### PR DESCRIPTION
[CCLOW] This PR adds more accurate styling to static pages according to UI kit:
- bullet lists;
- numbered lists;
- headings;
- bold;
- links