### PR TITLE
Allow a display name different from the resource

### DIFF
--- a/app/admin/legislations.rb
+++ b/app/admin/legislations.rb
@@ -48,7 +48,7 @@ ActiveAdmin.register Legislation do
 
   publishable_resource_sidebar
 
-  data_export_sidebar 'Laws', documents: true, events: true
+  data_export_sidebar 'Legislations', display_name: 'Laws', documents: true, events: true
 
   show do
     tabs do

--- a/lib/extensions/active_admin/active_admin_csv_download.rb
+++ b/lib/extensions/active_admin/active_admin_csv_download.rb
@@ -10,11 +10,12 @@ module ActiveAdminCsvDownload
   def data_export_sidebar(resource_name, options = {}, &block)
     export_link_for_documents = options.fetch(:documents) { false }
     export_link_for_events = options.fetch(:events) { false }
+    display_name = options.fetch(:display_name) { resource_name }
 
     sidebar 'Export / Import', if: -> { collection.any? }, only: :index do
       ul do
         li do
-          link_to "Download #{resource_name} CSV",
+          link_to "Download #{display_name} CSV",
                   params: request.query_parameters.except(:commit, :format),
                   format: 'csv'
         end
@@ -46,7 +47,7 @@ module ActiveAdminCsvDownload
         instance_eval(&block) if block_given?
 
         li do
-          upload_label = "<strong>Upload</strong> #{resource_name}".html_safe
+          upload_label = "<strong>Upload</strong> #{display_name}".html_safe
           upload_path = new_admin_data_upload_path(data_upload: {uploader: resource_name})
 
           link_to upload_label, upload_path


### PR DESCRIPTION
We are using a different display name for laws from its model name, so we need to allow passing on a label, otherwise it can't find an eventable type of name Law.