### PR TITLE
Updates the available event types for legislation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -84,3 +84,16 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: true
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Style/ExponentialNotation:
+  Enabled: true
+

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -33,31 +33,10 @@ class Legislation < ApplicationRecord
   LEGISLATION_TYPES = %w[executive legislative].freeze
   EVENT_TYPES = %w[
     amended
-    approved
-    deadline_for_regulation
-    decree_passed
-    document_amended
-    document_passed
-    document_approved
-    endorsement
-    entry_into_force
-    executive_decree_issued
-    federal_decree_issued
-    first_phase_approved
-    last_amended
-    last_amendment
-    law_amended
-    law_passed
-    law_published
-    law_adopted
-    ordinance_issued
-    plan_adopted
-    policy_revised
-    regulation_issued
-    repealed_and_replaced
-    replaced
-    start_of_reporting_period
-    wholly_amended
+    entered_into_force
+    implementation_details
+    passed/approved
+    repealed/replaced
   ].freeze
 
   tag_with :frameworks
@@ -79,7 +58,7 @@ class Legislation < ApplicationRecord
 
   scope :laws, -> { legislative }
   scope :policies, -> { executive }
-  scope :passed, -> { joins(:events).where(events: {event_type: 'law_passed'}) }
+  scope :passed, -> { joins(:events).where(events: {event_type: 'passed/approved'}) }
   scope :recent, ->(date = 1.month.ago) { passed.where('events.date > ?', date) }
 
   pg_search_scope :full_text_search,
@@ -130,7 +109,7 @@ class Legislation < ApplicationRecord
   end
 
   def date_passed
-    events.where(event_type: 'law_passed').first&.date
+    events.where(event_type: 'passed/approved').first&.date
   end
 
   def first_event

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -109,7 +109,7 @@ class Legislation < ApplicationRecord
   end
 
   def date_passed
-    events.where(event_type: 'passed/approved').first&.date
+    events.passed.first&.date
   end
 
   def first_event

--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -109,7 +109,7 @@ class Legislation < ApplicationRecord
   end
 
   def date_passed
-    events.passed.first&.date
+    events.find_by(event_type: 'passed/approved')&.date
   end
 
   def first_event

--- a/spec/commands/csv_data_upload_spec.rb
+++ b/spec/commands/csv_data_upload_spec.rb
@@ -195,7 +195,7 @@ describe 'CSVDataUpload (integration)' do
     csv_content = <<-CSV
       Id,Eventable type,Eventable,Event type,Title,Description,Date,Url
       #{litigation_event.id},Litigation,#{litigation_event.eventable_id},case_decided,Changed title,Changed description,2020-12-30,https://example.com
-      ,Legislation,#{legislation.id},approved,title,description,2019-02-20,
+      ,Legislation,#{legislation.id},passed/approved,title,description,2019-02-20,
     CSV
     events_csv = fixture_file('events.csv', content: csv_content)
 
@@ -221,7 +221,7 @@ describe 'CSVDataUpload (integration)' do
       url: 'https://example.com'
     )
     expect(created_event).to have_attributes(
-      event_type: 'approved',
+      event_type: 'passed/approved',
       title: 'title',
       description: 'description',
       date: Date.parse('2019-02-20'),

--- a/spec/controllers/admin/legislations_controller_spec.rb
+++ b/spec/controllers/admin/legislations_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Admin::LegislationsController, type: :controller do
             },
             {
               date: 3.days.ago,
-              event_type: 'approved',
+              event_type: 'passed/approved',
               title: 'Event 2',
               description: 'Description 2',
               url: 'https://validurl2.com'
@@ -90,7 +90,7 @@ RSpec.describe Admin::LegislationsController, type: :controller do
 
         expected_events_attrs = [
           ['Event 1', 'amended', 'Description 1', 'https://validurl1.com'],
-          ['Event 2', 'approved', 'Description 2', 'https://validurl2.com']
+          ['Event 2', 'passed/approved', 'Description 2', 'https://validurl2.com']
         ]
 
         last_legislation_created.tap do |l|

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
     factory :legislation_event do
       title { 'Some law was approved' }
       description { 'Description of approved law' }
-      event_type { 'approved' }
+      event_type { 'passed/approved' }
       eventable { |e| e.association(:legislation) }
     end
 

--- a/spec/services/queries/cclow/legislation_query_spec.rb
+++ b/spec/services/queries/cclow/legislation_query_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Queries::CCLOW::LegislationQuery do
       responses: [@adaptation],
       instruments: [@instrument1, @instrument3],
       events: [
-        build(:event, event_type: 'law_passed', date: '2009-01-01'),
+        build(:event, event_type: 'passed/approved', date: '2009-01-01'),
         build(:event, event_type: 'amended', date: '2013-03-01')
       ]
     )
@@ -46,7 +46,7 @@ RSpec.describe Queries::CCLOW::LegislationQuery do
       title: 'Act No. 7 of 1994 on protection against natural damage',
       keywords: [@business_risk, @cap_and_trade],
       events: [
-        build(:event, event_type: 'law_passed', date: '2014-12-02')
+        build(:event, event_type: 'passed/approved', date: '2014-12-02')
       ]
     )
 
@@ -59,7 +59,7 @@ RSpec.describe Queries::CCLOW::LegislationQuery do
       laws_sectors: [@sector3],
       title: 'Zimbabwe: National contingency plan 2012-2013',
       events: [
-        build(:event, event_type: 'law_passed', date: '2016-12-02'),
+        build(:event, event_type: 'passed/approved', date: '2016-12-02'),
         build(:event, event_type: 'amended', date: '2019-03-01')
       ]
     )
@@ -73,7 +73,7 @@ RSpec.describe Queries::CCLOW::LegislationQuery do
       title: 'Some natural law',
       responses: [@adaptation],
       events: [
-        build(:event, event_type: 'law_passed', date: '2010-12-02'),
+        build(:event, event_type: 'passed/approved', date: '2010-12-02'),
         build(:event, event_type: 'amended', date: '2018-03-01')
       ]
     )


### PR DESCRIPTION
This PR updates the list of event_types for legislation, based on the updated data provided by the client.

The migration files will not fit with this data, but I won't worry too much about it now, as we could always download the updated dataset from prod if needed in the future.