### PR TITLE
Fix framework sectoral laws determination

### DIFF
--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -108,13 +108,13 @@ class Target < ApplicationRecord
       single_year: single_year,
       base_year_period: base_year_period,
       year: year,
-      sources: legislations.map do |l|
+      sources: legislations.published.map do |l|
         {
           id: l.id,
           title: l.title,
           type: l.law? ? 'law' : 'policy',
-          framework: l.frameworks.any?,
-          sectoral: l.frameworks.none?,
+          framework: l.framework?,
+          sectoral: l.sectoral?,
           link: l.url
         }
       end


### PR DESCRIPTION
As per description

```
Framework laws are overarching in how they tackle climate change (through one or multiple of the following: mitigation/adaptation/loss&damage/DRM). Example: UK's Climate Change Act. There are generally just a handful of these per country. NB: we're still in the process of reviewing the methodology for this classification.

Framework laws are generally classified as "economy-wide" or "DRM" in sector. So all laws have a sector attached even if it's "economy-wide". Non-framework laws can be "economy-wide" as well (so not strictly-speaking "sectoral").
```