### PR TITLE
feat: Banking CP controller actions for react components

### DIFF
--- a/app/controllers/tpi/banks_controller.rb
+++ b/app/controllers/tpi/banks_controller.rb
@@ -1,6 +1,6 @@
 module TPI
   class BanksController < TPIController
-    before_action :fetch_bank, only: [:show, :assessment, :emissions_chart_data]
+    before_action :fetch_bank, only: [:show, :assessment, :emissions_chart_data, :cp_matrix_data]
     before_action :fetch_banks, only: [:index, :show]
     before_action :redirect_if_numeric_or_historic_slug, only: [:show]
     before_action :fetch_assessment, only: [:show, :assessment]
@@ -61,6 +61,16 @@ module TPI
     # On pages: :show
     def emissions_chart_data
       data = ::Api::Charts::CPAssessment.new(@cp_assessment, 'regional').emissions_data
+
+      render json: data.chart_json
+    end
+
+    # Data:     Bank CP Alignments
+    # Section:  CP
+    # Type:     table
+    # On pages: :show
+    def cp_matrix_data
+      data = ::Api::Charts::CPMatrix.new(@bank).matrix_data
 
       render json: data.chart_json
     end

--- a/app/controllers/tpi/banks_controller.rb
+++ b/app/controllers/tpi/banks_controller.rb
@@ -1,9 +1,10 @@
 module TPI
   class BanksController < TPIController
-    before_action :fetch_bank, only: [:show, :assessment]
+    before_action :fetch_bank, only: [:show, :assessment, :emissions_chart_data]
     before_action :fetch_banks, only: [:index, :show]
     before_action :redirect_if_numeric_or_historic_slug, only: [:show]
     before_action :fetch_assessment, only: [:show, :assessment]
+    before_action :fetch_cp_assessment, only: [:show, :emissions_chart_data]
     before_action :fetch_results, only: [:index, :index_assessment]
 
     helper_method :child_indicators
@@ -54,6 +55,16 @@ module TPI
       }, filename: "TPI banking data - #{timestamp}"
     end
 
+    # Data:     Bank emissions
+    # Section:  CP
+    # Type:     line chart
+    # On pages: :show
+    def emissions_chart_data
+      data = ::Api::Charts::CPAssessment.new(@cp_assessment, 'regional').emissions_data
+
+      render json: data.chart_json
+    end
+
     private
 
     def fetch_bank
@@ -95,6 +106,15 @@ module TPI
                       @bank.latest_assessment
                     end
       @assessment_presenter = BankAssessmentPresenter.new(@assessment)
+    end
+
+    def fetch_cp_assessment
+      @cp_assessment = if params[:cp_assessment_id].present?
+                         @bank.cp_assessments.find(params[:cp_assessment_id])
+                       else
+                         @bank.cp_assessments.where(sector_id: params[:sector_id]).currently_published
+                           .order(assessment_date: :desc).first
+                       end
     end
 
     def redirect_if_numeric_or_historic_slug

--- a/app/models/bank.rb
+++ b/app/models/bank.rb
@@ -39,6 +39,8 @@ class Bank < ApplicationRecord
   validates_presence_of :name, :slug, :isin, :market_cap_group
   validates_uniqueness_of :slug, :name
 
+  scope :published, -> { all }
+
   def should_generate_new_friendly_id?
     name_changed? || super
   end

--- a/app/models/cp/assessment.rb
+++ b/app/models/cp/assessment.rb
@@ -46,7 +46,7 @@ module CP
     scope :published_on_or_before, lambda { |publication_date|
       order(:publication_date).where('publication_date <= ?', publication_date)
     }
-    scope :currently_published, -> { where('publication_date <= ?', DateTime.now) }
+    scope :currently_published, -> { where('cp_assessments.publication_date <= ?', DateTime.now) }
     scope :regional, -> { where.not(region: [nil, '']) }
     scope :companies, -> { where(cp_assessmentable_type: 'Company') }
     scope :banks, -> { where(cp_assessmentable_type: 'Bank') }

--- a/app/models/tpi_sector.rb
+++ b/app/models/tpi_sector.rb
@@ -38,8 +38,9 @@ class TPISector < ApplicationRecord
   validates :categories, array_inclusion: {in: CATEGORIES}
 
   scope :tpi_tool, -> { where(show_in_tpi_tool: true) }
-  scope :companies, -> { where('categories && ARRAY[?]::varchar[]', 'Company') }
-  scope :banks, -> { where('categories && ARRAY[?]::varchar[]', 'Bank') }
+  scope :for_category, ->(klass) { where('categories && ARRAY[?]::varchar[]', klass.to_s) }
+  scope :companies, -> { for_category Company }
+  scope :banks, -> { for_category Bank }
   scope :with_companies, -> { joins(:companies).where(companies: Company.published).distinct }
 
   def should_generate_new_friendly_id?

--- a/app/services/api/charts/cp_assessment.rb
+++ b/app/services/api/charts/cp_assessment.rb
@@ -5,17 +5,18 @@ module Api
 
       attr_reader :assessment
 
-      delegate :company, to: :assessment
+      delegate :sector, to: :assessment
 
       def initialize(assessment, view)
         @assessment = assessment
+        @category = assessment&.cp_assessmentable_type
         @view = view
       end
 
       # Returns array of following series:
-      # - company emissions
-      # - company's sector average emissions
-      # - company's sector CP benchmarks (scenarios)
+      # - assessment emissions
+      # - assessment's sector average emissions
+      # - assessment's sector CP benchmarks (scenarios)
       #
       # @return [Array]
       # @example
@@ -33,7 +34,7 @@ module Api
 
         [
           emissions_data_from_sector_benchmarks,
-          emissions_data_from_company,
+          emissions_data_from_assessment,
           emissions_data_from_sector,
           years_with_targets
         ].compact.flatten
@@ -59,14 +60,14 @@ module Api
       #     }
       #   }
       # ]
-      def emissions_data_from_company
+      def emissions_data_from_assessment
         data = if assessment&.emissions&.size == 1
                  data_with_marker_settings
                else
                  assessment&.emissions&.transform_keys(&:to_i)
                end
         {
-          name: company.name,
+          name: assessment.cp_assessmentable.name,
           data: data,
           zoneAxis: 'x',
           zones: [{
@@ -118,10 +119,10 @@ module Api
       end
 
       def emissions_data_from_sector
-        name = if regional_view?
-                 "#{region} #{company.sector.name} sector mean"
+        name = if regional_view? && @category != 'Bank'
+                 "#{region} #{sector.name} sector mean"
                else
-                 "#{company.sector.name} sector mean"
+                 "#{sector.name} sector mean"
                end
         {
           name: name,
@@ -131,9 +132,8 @@ module Api
 
       def emissions_data_from_sector_benchmarks
         region = regional_view? ? assessment.region : nil
-        company
-          .sector
-          .latest_benchmarks_for_date(assessment.publication_date, category: Company, region: region)
+        sector
+          .latest_benchmarks_for_date(assessment.publication_date, category: @category, region: region)
           .sort_by(&:average_emission)
           .map.with_index do |benchmark, index|
             {
@@ -158,15 +158,15 @@ module Api
           .to_h
       end
 
-      # @return [Float] average emission from all Companies from single year
+      # @return [Float] average emission from all entities from single year
       def sector_average_emission_for_year(year)
-        company_emissions = sector_all_emissions
+        emissions_for_year = sector_all_emissions
           .map { |emissions| emissions[year] }
           .compact
 
-        return nil if company_emissions.empty?
+        return nil if emissions_for_year.empty?
 
-        (company_emissions.sum / company_emissions.count).round(2)
+        (emissions_for_year.sum / emissions_for_year.count).round(2)
       end
 
       # @return [Array] of years for which emissions was reported
@@ -184,19 +184,19 @@ module Api
           .uniq
       end
 
-      # @return [Array<Hash>] list of { year => value } pairs from all Companies from current TPISector
+      # @return [Array<Hash>] list of { year => value } pairs from all Companies or Banks from current TPISector
       def sector_all_emissions
-        @sector_all_emissions ||= company.sector
-          .companies
-          .published
-          .includes(:cp_assessments)
-          .flat_map do |c|
-            c.cp_assessments
-              .select { |a| regional_view? ? a.region == region : true }
-              .select { |a| a.publication_date <= assessment.publication_date }
-              .max_by(&:publication_date)&.emissions&.transform_keys(&:to_i)
-          end
-          .compact
+        @sector_all_emissions ||= CP::Assessment
+          .where(
+            sector_id: sector.id,
+            publication_date: [..assessment.publication_date],
+            cp_assessmentable_type: @category,
+            cp_assessmentable_id: @category.constantize.published.select(:id)
+          )
+        @sector_all_emissions = @sector_all_emissions.where(region: region) if regional_view?
+        @sector_all_emissions.group_by(&:cp_assessmentable_id).flat_map do |_id, cp_assessments|
+          cp_assessments.max_by(&:publication_date)&.emissions&.transform_keys(&:to_i)
+        end
       end
 
       # @return [Integer]

--- a/app/services/api/charts/cp_matrix.rb
+++ b/app/services/api/charts/cp_matrix.rb
@@ -1,0 +1,40 @@
+module Api
+  module Charts
+    class CPMatrix
+      attr_accessor :cp_assessmentable
+
+      def initialize(cp_assessmentable)
+        @cp_assessmentable = cp_assessmentable
+      end
+
+      def matrix_data
+        return [] unless cp_assessmentable.present?
+
+        %w[2025 2035 2050].each_with_object({}) do |year, result|
+          result[year] = sectors.each_with_object({}) do |sector, section|
+            cp_assessment = cp_assessments[[cp_assessmentable, sector]]&.first
+            section[sector.name] = CP::Portfolio::NAMES.each_with_object({}) do |portfolio, row|
+              value = cp_assessment&.cp_matrices&.detect { |m| m.portfolio == portfolio }
+              row[portfolio] = value&.public_send "cp_alignment_#{year}"
+            end
+          end
+        end
+      end
+
+      private
+
+      def cp_assessments
+        @cp_assessments ||= Queries::TPI::LatestCPAssessmentsQuery
+          .new(category: cp_assessmentable_type, cp_assessmentable: cp_assessmentable).call
+      end
+
+      def sectors
+        @sectors ||= TPISector.for_category(cp_assessmentable_type).order(:name)
+      end
+
+      def cp_assessmentable_type
+        cp_assessmentable.class.to_s
+      end
+    end
+  end
+end

--- a/app/services/queries/tpi/latest_cp_assessments_query.rb
+++ b/app/services/queries/tpi/latest_cp_assessments_query.rb
@@ -1,0 +1,30 @@
+module Queries
+  module TPI
+    class LatestCPAssessmentsQuery
+      attr_accessor :category, :cp_assessmentable
+
+      def initialize(category:, cp_assessmentable: nil)
+        @category = category.to_s
+        @cp_assessmentable = cp_assessmentable
+      end
+
+      def call
+        query = initial_query
+        query = query.where(cp_assessmentable_id: cp_assessmentable.id) if cp_assessmentable.present?
+        query.group_by { |a| [a.cp_assessmentable, a.sector] }
+      end
+
+      private
+
+      def initial_query
+        CP::Assessment.includes(:cp_assessmentable, :sector, :cp_matrices).joins(
+          'LEFT JOIN cp_assessments cp2 ON cp2.cp_assessmentable_id = cp_assessments.cp_assessmentable_id ' \
+          'AND cp2.cp_assessmentable_type = cp_assessments.cp_assessmentable_type ' \
+          'AND cp2.sector_id = cp_assessments.sector_id ' \
+          "AND cp2.publication_date <= '#{Date.current.strftime('%F')}'" \
+          'AND cp2.assessment_date > cp_assessments.assessment_date'
+        ).where('cp2.cp_assessmentable_id IS NULL').where(cp_assessmentable_type: category).currently_published
+      end
+    end
+  end
+end

--- a/app/views/tpi/banks/_cp_assessments.html.erb
+++ b/app/views/tpi/banks/_cp_assessments.html.erb
@@ -1,0 +1,14 @@
+<% TPISector.for_category(Bank).each do |sector| %>
+  <div style="margin: 25px 0">
+    <% cp_assessment = bank.cp_assessments.where(sector_id: sector.id).currently_published.order(assessment_date: :desc).first %>
+    <% next if cp_assessment.blank? || cp_assessment.emissions.blank? %>
+
+    <h3><%= sector.name %></h3>
+    <%= react_component('charts/cp-performance', {
+      dataUrl: emissions_chart_data_tpi_bank_path(bank, sector_id: sector.id),
+      unit: cp_assessment.unit,
+      companySelector: false,
+      sectorUrl: tpi_sector_path(sector.slug)
+    }) %>
+  </div>
+<% end %>

--- a/app/views/tpi/banks/_cp_matrix.html.erb
+++ b/app/views/tpi/banks/_cp_matrix.html.erb
@@ -1,0 +1,5 @@
+<div style="margin: 25px 0">
+  <%= react_component('charts/cp-matrix', {
+    data: cp_matrix_data_tpi_bank_path(bank),
+  }) %>
+</div>

--- a/app/views/tpi/banks/show.html.erb
+++ b/app/views/tpi/banks/show.html.erb
@@ -65,6 +65,16 @@
     </section>
   <% end %>
 
+  <% if @bank.cp_assessments.exists? %>
+    <section class="container" id="cp-matrix">
+      <%#= render "cp_matrix", bank: @bank %> <!-- TODO -->
+    </section>
+
+    <section class="container" id="cp-assessment">
+      <%#= render "cp_assessments", bank: @bank %> <!-- TODO -->
+    </section>
+  <% end %>
+
   <% if @bank.latest_information.present? %>
     <%= react_component("LatestInformation", { name: @bank.name, latestInformation: @bank.latest_information }) %>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
 
       resources :banks, only: [:show, :index] do
         member do
+          get :emissions_chart_data
           get :assessment
         end
         collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
       resources :banks, only: [:show, :index] do
         member do
           get :emissions_chart_data
+          get :cp_matrix_data
           get :assessment
         end
         collection do

--- a/spec/services/api/charts/cp_assessment_spec.rb
+++ b/spec/services/api/charts/cp_assessment_spec.rb
@@ -2,54 +2,91 @@ require 'rails_helper'
 
 RSpec.describe Api::Charts::CPAssessment do
   before_all do
-    @sector_a = create(:tpi_sector, name: 'Sector A')
-    @sector_b = create(:tpi_sector, name: 'Sector B')
+    @sector_a = create(:tpi_sector, name: 'Sector A', categories: %w[Bank Company])
+    @sector_b = create(:tpi_sector, name: 'Sector B', categories: %w[Bank Company])
     @company_sector_a_1 = create(:company, :published, sector: @sector_a)
     @company_sector_a_2 = create(:company, :published, sector: @sector_a)
     @company_sector_a_3 = create(:company, :published, sector: @sector_a)
+    @bank_sector_a_1 = create(:bank)
+    @bank_sector_a_2 = create(:bank)
+    @bank_sector_a_3 = create(:bank)
 
     @company_sector_b_1 = create(:company, :published, sector: @sector_b)
+    @bank_sector_b_1 = create(:bank)
 
     # Sector B - should be ignored
     create(:cp_assessment,
-           company: @company_sector_b_1,
+           sector: @sector_b,
+           cp_assessmentable: @company_sector_b_1,
            emissions: {'2015' => 400.0, '2016' => 500.0})
-    # Sector A
+    create(:cp_assessment,
+           sector: @sector_b,
+           cp_assessmentable: @bank_sector_b_1,
+           emissions: {'2015' => 400.0, '2016' => 500.0})
+    # Sector A Company Benchmarks
     create(:cp_benchmark,
            scenario: 'scenario',
            release_date: 12.months.ago,
            sector: @sector_a,
+           category: 'Company',
            emissions: {'2016' => 130.0, '2017' => 120.0, '2018' => 100.0})
     create(:cp_benchmark,
            scenario: 'scenario',
            release_date: 7.months.ago,
            sector: @sector_a,
+           category: 'Company',
            emissions: {'2016' => 115.5, '2017' => 122.0, '2018' => 124.0})
     create(:cp_benchmark,
            scenario: 'scenario regional',
            release_date: 12.months.ago,
            region: 'Europe',
            sector: @sector_a,
+           category: 'Company',
+           emissions: {'2016' => 100.0, '2017' => 120.0, '2018' => 124.0})
+    # Sector A Bank Benchmarks
+    create(:cp_benchmark,
+           scenario: 'scenario',
+           release_date: 12.months.ago,
+           sector: @sector_a,
+           category: 'Bank',
+           region: 'Europe',
+           emissions: {'2016' => 130.0, '2017' => 120.0, '2018' => 100.0})
+    create(:cp_benchmark,
+           scenario: 'scenario',
+           release_date: 7.months.ago,
+           sector: @sector_a,
+           category: 'Bank',
+           region: 'Europe',
+           emissions: {'2016' => 115.5, '2017' => 122.0, '2018' => 124.0})
+    create(:cp_benchmark,
+           scenario: 'scenario',
+           release_date: 12.months.ago,
+           region: 'Europe',
+           sector: @sector_a,
+           category: 'Bank',
            emissions: {'2016' => 100.0, '2017' => 120.0, '2018' => 124.0})
 
-    # create some assessment for sector A
+    # create some company assessment for sector A
     create(:cp_assessment,
            assessment_date: 10.months.ago,
            publication_date: 10.months.ago,
            last_reported_year: 2018,
-           company: @company_sector_a_1,
+           sector: @sector_a,
+           cp_assessmentable: @company_sector_a_1,
            emissions: {'2017' => 90.0, '2018' => 90.0, '2019' => 110.0})
     create(:cp_assessment,
            assessment_date: 6.months.ago,
            publication_date: 6.months.ago,
            last_reported_year: 2018,
-           company: @company_sector_a_1,
+           sector: @sector_a,
+           cp_assessmentable: @company_sector_a_1,
            emissions: {'2017' => 100.0, '2018' => 70.0, '2019' => 110.0})
     create(:cp_assessment,
            assessment_date: 11.months.ago,
            publication_date: 11.months.ago,
            last_reported_year: 2018,
-           company: @company_sector_a_2,
+           sector: @sector_a,
+           cp_assessmentable: @company_sector_a_2,
            region: 'Europe',
            emissions: {'2017' => 40.0, '2018' => 50.0})
     create(:cp_assessment,
@@ -57,86 +94,166 @@ RSpec.describe Api::Charts::CPAssessment do
            publication_date: 11.months.ago,
            last_reported_year: 2018,
            region: 'Europe',
-           company: @company_sector_a_3,
+           sector: @sector_a,
+           cp_assessmentable: @company_sector_a_3,
+           emissions: {'2017' => 30.0, '2018' => 20.0})
+    # create some bank assessment for sector A
+    create(:cp_assessment,
+           assessment_date: 10.months.ago,
+           publication_date: 10.months.ago,
+           last_reported_year: 2018,
+           sector: @sector_a,
+           region: 'Europe',
+           cp_assessmentable: @bank_sector_a_1,
+           emissions: {'2017' => 90.0, '2018' => 90.0, '2019' => 110.0})
+    create(:cp_assessment,
+           assessment_date: 6.months.ago,
+           publication_date: 6.months.ago,
+           last_reported_year: 2018,
+           sector: @sector_a,
+           region: 'Europe',
+           cp_assessmentable: @bank_sector_a_1,
+           emissions: {'2017' => 100.0, '2018' => 70.0, '2019' => 110.0})
+    create(:cp_assessment,
+           assessment_date: 11.months.ago,
+           publication_date: 11.months.ago,
+           last_reported_year: 2018,
+           sector: @sector_a,
+           cp_assessmentable: @bank_sector_a_2,
+           region: 'Europe',
+           emissions: {'2017' => 40.0, '2018' => 50.0})
+    create(:cp_assessment,
+           assessment_date: 11.months.ago,
+           publication_date: 11.months.ago,
+           last_reported_year: 2018,
+           region: 'Europe',
+           sector: @sector_a,
+           cp_assessmentable: @bank_sector_a_3,
            emissions: {'2017' => 30.0, '2018' => 20.0})
     # should be ignored as not published yet
     create(:cp_assessment,
            assessment_date: 11.months.ago,
            publication_date: 6.months.from_now,
            last_reported_year: 2018,
-           company: @company_sector_a_1,
+           sector: @sector_a,
+           cp_assessmentable: @company_sector_a_1,
            emissions: {'2017' => 80.0, '2018' => 80.0, '2019' => 110.0})
   end
 
   describe '.emissions_data' do
-    context 'when CP assessment is not nil' do
+    context 'when assessment belongs to company' do
+      context 'when CP assessment is not nil' do
+        context 'for last assessment' do
+          subject { described_class.new(@company_sector_a_1.latest_cp_assessment, 'global') }
+
+          it 'returns emissions data from: company, sector avg & sector benchmarks' do
+            company_sector_a_1_data = subject.emissions_data.find { |s| s[:name] == @company_sector_a_1.name }[:data]
+            sector_average_data = subject.emissions_data.find { |s| s[:name] == "#{@sector_a.name} sector mean" }[:data]
+            cp_benchmarks_data = subject.emissions_data.find { |s| s[:name] == 'scenario' }[:data]
+
+            avg_2017 = ((100.0 + 40.0 + 30.0) / 3).round(2)
+            avg_2018 = ((70.0 + 50.0 + 20.0) / 3).round(2)
+
+            expect(company_sector_a_1_data).to eq(2017 => 100.0, 2018 => 70.0, 2019 => 110.0)
+            # sector average_data is only up to last_reported_year
+            expect(sector_average_data).to eq(2017 => avg_2017, 2018 => avg_2018)
+            expect(cp_benchmarks_data).to eq(2016 => 115.5, 2017 => 122.0, 2018 => 124.0)
+          end
+        end
+
+        context 'for regional view' do
+          subject { described_class.new(@company_sector_a_2.latest_cp_assessment, 'regional') }
+
+          it 'return emissions data from: company, regional sector avg & regional sector benchmarks' do
+            # company a_2 and a_3 have regional assessments count only those to average
+
+            company_sector_a_2_data = subject.emissions_data.find { |s| s[:name] == @company_sector_a_2.name }[:data]
+            sector_average_data = subject.emissions_data.find { |s| s[:name] == "Europe #{@sector_a.name} sector mean" }[:data]
+            cp_benchmarks_data = subject.emissions_data.find { |s| s[:name] == 'scenario regional' }[:data]
+
+            avg_2017 = ((40.0 + 30.0) / 2).round(2)
+            avg_2018 = ((50.0 + 20.0) / 2).round(2)
+
+            expect(company_sector_a_2_data).to eq(2017 => 40.0, 2018 => 50.0)
+            # sector average_data is only up to last_reported_year
+            expect(sector_average_data).to eq(2017 => avg_2017, 2018 => avg_2018)
+            expect(cp_benchmarks_data).to eq(2016 => 100.0, 2017 => 120.0, 2018 => 124.0)
+          end
+        end
+
+        context 'for first historic assessment' do
+          subject do
+            described_class.new(
+              @company_sector_a_1.cp_assessments.currently_published.order(:assessment_date).first,
+              'global'
+            )
+          end
+
+          it 'returns emissions data from: company, sector avg & sector benchmarks' do
+            company_sector_a_1_data = subject.emissions_data.find { |s| s[:name] == @company_sector_a_1.name }[:data]
+            sector_average_data = subject.emissions_data.find { |s| s[:name] == "#{@sector_a.name} sector mean" }[:data]
+            cp_benchmarks_data = subject.emissions_data.find { |s| s[:name] == 'scenario' }[:data]
+
+            avg_2017 = ((90.0 + 40.0 + 30.0) / 3).round(2)
+            avg_2018 = ((90.0 + 50.0 + 20.0) / 3).round(2)
+
+            expect(company_sector_a_1_data).to eq(2017 => 90.0, 2018 => 90.0, 2019 => 110.0)
+            # sector average_data is only up to last_reported_year
+            expect(sector_average_data).to eq(2017 => avg_2017, 2018 => avg_2018)
+            expect(cp_benchmarks_data).to eq(2016 => 130.0, 2017 => 120.0, 2018 => 100.0)
+          end
+        end
+      end
+
+      context 'when CP assessment is nil' do
+        subject { described_class.new(nil, nil) }
+
+        it 'returns no emissions data' do
+          expect(subject.emissions_data).to eq []
+        end
+      end
+    end
+
+    context 'when assessment belongs to bank' do
       context 'for last assessment' do
-        subject { described_class.new(@company_sector_a_1.latest_cp_assessment, 'global') }
+        subject { described_class.new(@bank_sector_a_1.latest_cp_assessment, 'regional') }
 
         it 'returns emissions data from: company, sector avg & sector benchmarks' do
-          company_sector_a_1_data = subject.emissions_data.find { |s| s[:name] == @company_sector_a_1.name }[:data]
+          bank_sector_a_1_data = subject.emissions_data.find { |s| s[:name] == @bank_sector_a_1.name }[:data]
           sector_average_data = subject.emissions_data.find { |s| s[:name] == "#{@sector_a.name} sector mean" }[:data]
           cp_benchmarks_data = subject.emissions_data.find { |s| s[:name] == 'scenario' }[:data]
 
           avg_2017 = ((100.0 + 40.0 + 30.0) / 3).round(2)
           avg_2018 = ((70.0 + 50.0 + 20.0) / 3).round(2)
 
-          expect(company_sector_a_1_data).to eq(2017 => 100.0, 2018 => 70.0, 2019 => 110.0)
+          expect(bank_sector_a_1_data).to eq(2017 => 100.0, 2018 => 70.0, 2019 => 110.0)
           # sector average_data is only up to last_reported_year
           expect(sector_average_data).to eq(2017 => avg_2017, 2018 => avg_2018)
           expect(cp_benchmarks_data).to eq(2016 => 115.5, 2017 => 122.0, 2018 => 124.0)
         end
       end
 
-      context 'for regional view' do
-        subject { described_class.new(@company_sector_a_2.latest_cp_assessment, 'regional') }
-
-        it 'return emissions data from: company, regional sector avg & regional sector benchmarks' do
-          # company a_2 and a_3 have regional assessments count only those to average
-
-          company_sector_a_2_data = subject.emissions_data.find { |s| s[:name] == @company_sector_a_2.name }[:data]
-          sector_average_data = subject.emissions_data.find { |s| s[:name] == "Europe #{@sector_a.name} sector mean" }[:data]
-          cp_benchmarks_data = subject.emissions_data.find { |s| s[:name] == 'scenario regional' }[:data]
-
-          avg_2017 = ((40.0 + 30.0) / 2).round(2)
-          avg_2018 = ((50.0 + 20.0) / 2).round(2)
-
-          expect(company_sector_a_2_data).to eq(2017 => 40.0, 2018 => 50.0)
-          # sector average_data is only up to last_reported_year
-          expect(sector_average_data).to eq(2017 => avg_2017, 2018 => avg_2018)
-          expect(cp_benchmarks_data).to eq(2016 => 100.0, 2017 => 120.0, 2018 => 124.0)
-        end
-      end
-
       context 'for first historic assessment' do
         subject do
           described_class.new(
-            @company_sector_a_1.cp_assessments.currently_published.order(:assessment_date).first,
-            'global'
+            @bank_sector_a_1.cp_assessments.currently_published.order(:assessment_date).first,
+            'regional'
           )
         end
 
         it 'returns emissions data from: company, sector avg & sector benchmarks' do
-          company_sector_a_1_data = subject.emissions_data.find { |s| s[:name] == @company_sector_a_1.name }[:data]
+          bank_sector_a_1_data = subject.emissions_data.find { |s| s[:name] == @bank_sector_a_1.name }[:data]
           sector_average_data = subject.emissions_data.find { |s| s[:name] == "#{@sector_a.name} sector mean" }[:data]
           cp_benchmarks_data = subject.emissions_data.find { |s| s[:name] == 'scenario' }[:data]
 
           avg_2017 = ((90.0 + 40.0 + 30.0) / 3).round(2)
           avg_2018 = ((90.0 + 50.0 + 20.0) / 3).round(2)
 
-          expect(company_sector_a_1_data).to eq(2017 => 90.0, 2018 => 90.0, 2019 => 110.0)
+          expect(bank_sector_a_1_data).to eq(2017 => 90.0, 2018 => 90.0, 2019 => 110.0)
           # sector average_data is only up to last_reported_year
           expect(sector_average_data).to eq(2017 => avg_2017, 2018 => avg_2018)
           expect(cp_benchmarks_data).to eq(2016 => 130.0, 2017 => 120.0, 2018 => 100.0)
         end
-      end
-    end
-
-    context 'when CP assessment is nil' do
-      subject { described_class.new(nil, nil) }
-
-      it 'returns no emissions data' do
-        expect(subject.emissions_data).to eq []
       end
     end
   end

--- a/spec/services/api/charts/cp_matrix_spec.rb
+++ b/spec/services/api/charts/cp_matrix_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe Api::Charts::CPMatrix do
+  before_all do
+    @bank_sector1 = create :tpi_sector, categories: [Bank]
+    @bank_sector2 = create :tpi_sector, categories: [Bank]
+    @company_sector1 = create :tpi_sector, categories: [Company]
+
+    @bank = create :bank
+
+    @cp_assessment1 = create :cp_assessment, cp_assessmentable: @bank, sector: @bank_sector1
+    @cp_assessment2 = create :cp_assessment, cp_assessmentable: @bank, sector: @bank_sector2
+
+    @cp_matrix1 = create :cp_matrix, cp_assessment: @cp_assessment1, portfolio: 'Mortgages'
+    @cp_matrix2 = create :cp_matrix, cp_assessment: @cp_assessment1, portfolio: 'Auto Loans'
+    @cp_matrix3 = create :cp_matrix, cp_assessment: @cp_assessment2, portfolio: 'Corporate lending'
+  end
+
+  describe '#matrix_data' do
+    context 'when cp_assessmentable is provided' do
+      subject { described_class.new(@bank).matrix_data }
+
+      it 'should return all alignment years' do
+        expect(subject.keys).to contain_exactly('2025', '2035', '2050')
+      end
+
+      it 'should return all band sectors for each alignment year' do
+        expect(subject['2025'].keys).to contain_exactly(@bank_sector1.name, @bank_sector2.name)
+        expect(subject['2035'].keys).to contain_exactly(@bank_sector1.name, @bank_sector2.name)
+        expect(subject['2050'].keys).to contain_exactly(@bank_sector1.name, @bank_sector2.name)
+      end
+
+      it 'should return all portfolio for each sector' do
+        expect(subject['2025'][@bank_sector1.name].keys).to contain_exactly(*CP::Portfolio::NAMES)
+        expect(subject['2025'][@bank_sector2.name].keys).to contain_exactly(*CP::Portfolio::NAMES)
+      end
+
+      it 'should return alignment values for selected portfolio' do
+        expect(subject['2025'][@bank_sector1.name]['Mortgages']).to eq(@cp_matrix1.cp_alignment_2025)
+        expect(subject['2025'][@bank_sector1.name]['Auto Loans']).to eq(@cp_matrix2.cp_alignment_2025)
+        expect(subject['2025'][@bank_sector1.name]['Corporate lending']).to eq(nil)
+        expect(subject['2025'][@bank_sector2.name]['Mortgages']).to eq(nil)
+        expect(subject['2025'][@bank_sector2.name]['Auto Loans']).to eq(nil)
+        expect(subject['2025'][@bank_sector2.name]['Corporate lending']).to eq(@cp_matrix3.cp_alignment_2025)
+
+        expect(subject['2035'][@bank_sector1.name]['Mortgages']).to eq(@cp_matrix1.cp_alignment_2035)
+        expect(subject['2035'][@bank_sector1.name]['Auto Loans']).to eq(@cp_matrix2.cp_alignment_2035)
+        expect(subject['2035'][@bank_sector2.name]['Corporate lending']).to eq(@cp_matrix3.cp_alignment_2035)
+
+        expect(subject['2050'][@bank_sector1.name]['Mortgages']).to eq(@cp_matrix1.cp_alignment_2050)
+        expect(subject['2050'][@bank_sector1.name]['Auto Loans']).to eq(@cp_matrix2.cp_alignment_2050)
+        expect(subject['2050'][@bank_sector2.name]['Corporate lending']).to eq(@cp_matrix3.cp_alignment_2050)
+      end
+    end
+
+    context 'when cp_assessmentable is not provided' do
+      subject { described_class.new(nil).matrix_data }
+
+      it 'should return empty array' do
+        expect(subject).to eq([])
+      end
+    end
+  end
+end

--- a/spec/services/queries/tpi/latest_cp_assessments_query_spec.rb
+++ b/spec/services/queries/tpi/latest_cp_assessments_query_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe Queries::TPI::LatestCPAssessmentsQuery do
+  before_all do
+    @bank1 = create :bank
+    @bank2 = create :bank
+
+    @sector1 = create :tpi_sector, categories: [Bank]
+    @sector2 = create :tpi_sector, categories: [Bank]
+
+    @cp_assessment1 = create :cp_assessment, cp_assessmentable: @bank1, sector: @sector1, assessment_date: 1.day.ago
+    @cp_assessment2 = create :cp_assessment, cp_assessmentable: @bank1, sector: @sector1, assessment_date: 10.days.ago
+    @cp_assessment3 = create :cp_assessment, cp_assessmentable: @bank1, sector: @sector2, assessment_date: 2.days.ago
+    @cp_assessment4 = create :cp_assessment, cp_assessmentable: @bank2, sector: @sector1, assessment_date: 1.day.ago
+
+    @cp_not_published = create :cp_assessment, cp_assessmentable: @bank1, sector: @sector1,
+                                               assessment_date: 10.minutes.ago, publication_date: 1.day.from_now
+    @cp_different_category = create :cp_assessment, cp_assessmentable: create(:company), sector: @sector1
+  end
+
+  describe '#call' do
+    context 'when just category is provided' do
+      subject { described_class.new(category: Bank).call }
+
+      it 'should return the latest cp_assessments for each bank' do
+        expect(subject.keys).to contain_exactly([@bank1, @sector1], [@bank1, @sector2], [@bank2, @sector1])
+        expect(subject.values.flatten).to match_array([@cp_assessment1, @cp_assessment3, @cp_assessment4])
+      end
+    end
+
+    context 'when specific cp_assessmentable is provided' do
+      subject { described_class.new(category: Bank, cp_assessmentable: @bank1).call }
+
+      it 'should return the latest cp_assessments for the bank' do
+        expect(subject.keys).to contain_exactly([@bank1, @sector1], [@bank1, @sector2])
+        expect(subject.values.flatten).to contain_exactly(@cp_assessment1, @cp_assessment3)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Preparing all services and controller endpoints which returns Banking CP data to appropriate react components. Service responsible for preparing CP emissions data is using already existing stuff which was heavily refactored to support not just Companies, but also Banks. Service responsible for preparing data for CP matrix was developed from scratch.

https://vizzuality.atlassian.net/browse/LSE-78
https://vizzuality.atlassian.net/browse/LSE-80