### PR TITLE
Feature/bank cp finalisation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,7 +295,7 @@ GEM
     method_source (1.0.0)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.2)
+    mini_portile2 (2.8.4)
     minitest (5.18.1)
     msgpack (1.5.3)
     multi_json (1.15.0)
@@ -405,7 +405,7 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     retriable (3.1.2)
-    rexml (3.2.5)
+    rexml (3.2.6)
     roo (2.10.0)
       nokogiri (~> 1)
       rubyzip (>= 1.3.0, < 3.0.0)
@@ -466,7 +466,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.9.0)
+    selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)

--- a/app/admin/banks.rb
+++ b/app/admin/banks.rb
@@ -145,6 +145,10 @@ ActiveAdmin.register Bank do
         column { f.input :isin, as: :tags }
         column { f.input :sedol }
       end
+
+      columns do
+        column { f.input :latest_information, as: :text }
+      end
     end
 
     f.actions

--- a/app/admin/banks.rb
+++ b/app/admin/banks.rb
@@ -88,7 +88,7 @@ ActiveAdmin.register Bank do
                   row :publication_date
                   row :assessment_date
                   row :assumptions
-                  row :final_disclosure_year
+                  row :last_reported_year
                   panel 'Emissions', style: 'margin: 10px' do
                     render 'admin/cp/emissions_table', emissions: a.emissions
                   end

--- a/app/admin/cp_assessments.rb
+++ b/app/admin/cp_assessments.rb
@@ -128,9 +128,9 @@ ActiveAdmin.register CP::Assessment do
     end
     column :assumptions
     column :years_with_targets, &:years_with_targets_csv
+    column :last_reported_year
 
     if params[:cp_assessmentable_type] == 'Company'
-      column :last_reported_year
       column :cp_alignment_2025
       column :cp_alignment_2035
       column :cp_alignment_2050
@@ -138,7 +138,6 @@ ActiveAdmin.register CP::Assessment do
       column :cp_regional_alignment_2035
       column :cp_regional_alignment_2050
     elsif params[:cp_assessmentable_type] == 'Bank'
-      column :final_disclosure_year
       %w[2025 2035 2050].each do |year|
         CP::Portfolio::NAMES.each do |portfolio|
           column "#{portfolio} #{year}", humanize_name: false do |record|

--- a/app/services/api/charts/cp_matrix.rb
+++ b/app/services/api/charts/cp_matrix.rb
@@ -19,16 +19,26 @@ module Api
         %w[2025 2035 2050].each_with_object({}) do |year, result|
           result[year] = sectors.each_with_object({}) do |sector, section|
             cp_assessment = cp_assessments[[cp_assessmentable, sector]]&.first
-            portfolio_values = CP::Portfolio::NAMES.each_with_object({}) do |portfolio, row|
-              value = cp_assessment&.cp_matrices&.detect { |m| m.portfolio == portfolio }
-              row[portfolio] = value&.public_send "cp_alignment_#{year}"
-            end
+            portfolio_values = portfolio_values_from cp_assessment, year
             section[sector.name] = {
-              assumptions: cp_assessment&.assumptions,
+              assumptions: assumption_for(cp_assessment&.assumptions),
               portfolio_values: portfolio_values,
               has_emissions: cp_assessment&.emissions&.present?
             }
           end
+        end
+      end
+
+      def assumption_for(value)
+        return nil if value.blank? || value == '0'
+
+        value
+      end
+
+      def portfolio_values_from(cp_assessment, year)
+        CP::Portfolio::NAMES.each_with_object({}) do |portfolio, row|
+          value = cp_assessment&.cp_matrices&.detect { |m| m.portfolio == portfolio }
+          row[portfolio] = value&.public_send "cp_alignment_#{year}"
         end
       end
 

--- a/app/services/csv_import/bank_cp_assessments.rb
+++ b/app/services/csv_import/bank_cp_assessments.rb
@@ -14,6 +14,7 @@ module CSVImport
           assessment.assumptions = row[:assumptions].presence if row.header?(:assumptions)
           assessment.emissions = parse_emissions(row) if emission_headers?(row)
           assessment.final_disclosure_year = row[:final_disclosure_year] if row.header?(:final_disclosure_year)
+          assessment.last_reported_year = row[:last_reported_year] if row.header?(:last_reported_year)
           assessment.years_with_targets = get_years_with_targets(row) if row.header?(:years_with_targets)
 
           was_new_record = assessment.new_record?

--- a/app/services/seed/tpi_data.rb
+++ b/app/services/seed/tpi_data.rb
@@ -175,7 +175,7 @@ module Seed
         ['Steel', 'Carbon intensity (tonnes of CO2 per tonne of steel)', [Company, Bank]],
         ['Electric Utilities (Global)', 'Carbon intensity (metric tonnes of CO2 per MWh electricity generation)', [Bank]],
         ['Electric Utilities (Regional)', 'Carbon intensity (metric tonnes of CO2 per MWh electricity generation)', [Bank]],
-        ['Shipping', 'Carbon intensity, TTW (grams CO2 per tonnes -km)', [Bank]],
+        ['Shipping', 'Carbon intensity, TTW (grams CO2 per tonnes -km)', [Company, Bank]],
         ['Food', 'Carbon intensity (tCO2e/tonnes agricultural input)', [Bank]],
         ['Diversified Mining', 'Emissions intensity (tCO2e / tonne of copper equivalent)', [Bank]],
         ['Chemicals', nil, [Bank]],

--- a/app/views/tpi/banks/_cp_assessments.html.erb
+++ b/app/views/tpi/banks/_cp_assessments.html.erb
@@ -1,6 +1,9 @@
-<h3 class="cp_assessments_title" style="margin: 25px 0">
+<h3 class="cp_assessments_title" style="margin: 25px 0 0 0">
   Carbon performance of <%= @bank.name %>
 </h3>
+<p>
+  The sectoral means are computed from the company data in TPI’s Carbon Performance Assessments
+</p>
 <% cp_assessments = Queries::TPI::LatestCPAssessmentsQuery.new(category: Bank, cp_assessmentable: @bank).call %>
 <% cp_sectors = TPISector.for_category(Bank).order(:name).map { |sector|
    cp_assessment = cp_assessments[[@bank, sector]]&.first

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -49,6 +49,7 @@ end
 # TODO: remove when new capybara and selenium webdriver arrive
 # https://github.com/teamcapybara/capybara/issues/2511
 Selenium::WebDriver.logger.ignore(:browser_options)
+Webdrivers::Chromedriver.required_version = '114.0.5735.90' # NOTE: remove when issues with 115 gets fixed (probably at selenium-webdriver 4.10.1)
 
 RSpec.configure do |config|
   config.request_snapshots_dir = 'spec/fixtures/snapshots'

--- a/spec/services/api/charts/cp_assessment_spec.rb
+++ b/spec/services/api/charts/cp_assessment_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Api::Charts::CPAssessment do
            sector: @sector_a,
            region: 'Europe',
            cp_assessmentable: @bank_sector_a_1,
-           emissions: {'2017' => 100.0, '2018' => 70.0, '2019' => 110.0})
+           emissions: {'2017' => 110.0, '2018' => 80.0, '2019' => 110.0})
     create(:cp_assessment,
            assessment_date: 11.months.ago,
            publication_date: 11.months.ago,
@@ -218,7 +218,7 @@ RSpec.describe Api::Charts::CPAssessment do
       context 'for last assessment' do
         subject { described_class.new(@bank_sector_a_1.latest_cp_assessment, 'regional') }
 
-        it 'returns emissions data from: company, sector avg & sector benchmarks' do
+        it 'returns emissions data from: bank, sector avg & sector benchmarks' do
           bank_sector_a_1_data = subject.emissions_data.find { |s| s[:name] == @bank_sector_a_1.name }[:data]
           sector_average_data = subject.emissions_data.find { |s| s[:name] == "#{@sector_a.name} sector mean" }[:data]
           cp_benchmarks_data = subject.emissions_data.find { |s| s[:name] == 'scenario' }[:data]
@@ -226,7 +226,7 @@ RSpec.describe Api::Charts::CPAssessment do
           avg_2017 = ((100.0 + 40.0 + 30.0) / 3).round(2)
           avg_2018 = ((70.0 + 50.0 + 20.0) / 3).round(2)
 
-          expect(bank_sector_a_1_data).to eq(2017 => 100.0, 2018 => 70.0, 2019 => 110.0)
+          expect(bank_sector_a_1_data).to eq(2017 => 110.0, 2018 => 80.0, 2019 => 110.0)
           # sector average_data is only up to last_reported_year
           expect(sector_average_data).to eq(2017 => avg_2017, 2018 => avg_2018)
           expect(cp_benchmarks_data).to eq(2016 => 115.5, 2017 => 122.0, 2018 => 124.0)

--- a/spec/services/api/charts/cp_matrix_spec.rb
+++ b/spec/services/api/charts/cp_matrix_spec.rb
@@ -4,12 +4,14 @@ RSpec.describe Api::Charts::CPMatrix do
   before_all do
     @bank_sector1 = create :tpi_sector, categories: [Bank]
     @bank_sector2 = create :tpi_sector, categories: [Bank]
+    @bank_sector3 = create :tpi_sector, categories: [Bank]
     @company_sector1 = create :tpi_sector, categories: [Company]
 
     @bank = create :bank
 
     @cp_assessment1 = create :cp_assessment, cp_assessmentable: @bank, sector: @bank_sector1
     @cp_assessment2 = create :cp_assessment, cp_assessmentable: @bank, sector: @bank_sector2
+    @cp_assessment_empty_assumption = create :cp_assessment, cp_assessmentable: @bank, sector: @bank_sector3, assumptions: '0'
 
     @cp_matrix1 = create :cp_matrix, cp_assessment: @cp_assessment1, portfolio: 'Mortgages'
     @cp_matrix2 = create :cp_matrix, cp_assessment: @cp_assessment1, portfolio: 'Auto Loans'
@@ -29,7 +31,7 @@ RSpec.describe Api::Charts::CPMatrix do
       end
 
       it 'should return all sectors inside meta' do
-        expect(subject[:meta][:sectors]).to contain_exactly(@bank_sector1.name, @bank_sector2.name)
+        expect(subject[:meta][:sectors]).to contain_exactly(@bank_sector1.name, @bank_sector2.name, @bank_sector3.name)
       end
 
       it 'should return all portfolio categories inside meta' do
@@ -37,9 +39,9 @@ RSpec.describe Api::Charts::CPMatrix do
       end
 
       it 'should return all band sectors for each alignment year' do
-        expect(subject[:data]['2025'].keys).to contain_exactly(@bank_sector1.name, @bank_sector2.name)
-        expect(subject[:data]['2035'].keys).to contain_exactly(@bank_sector1.name, @bank_sector2.name)
-        expect(subject[:data]['2050'].keys).to contain_exactly(@bank_sector1.name, @bank_sector2.name)
+        expect(subject[:data]['2025'].keys).to contain_exactly(@bank_sector1.name, @bank_sector2.name, @bank_sector3.name)
+        expect(subject[:data]['2035'].keys).to contain_exactly(@bank_sector1.name, @bank_sector2.name, @bank_sector3.name)
+        expect(subject[:data]['2050'].keys).to contain_exactly(@bank_sector1.name, @bank_sector2.name, @bank_sector3.name)
       end
 
       it 'should return all portfolio for each sector' do
@@ -50,6 +52,10 @@ RSpec.describe Api::Charts::CPMatrix do
       it 'should return assumptions for each sector' do
         expect(subject[:data]['2025'][@bank_sector1.name][:assumptions]).to eq(@cp_assessment1.assumptions)
         expect(subject[:data]['2025'][@bank_sector2.name][:assumptions]).to eq(@cp_assessment2.assumptions)
+      end
+
+      it 'should return nil if assumption is zero' do
+        expect(subject[:data]['2025'][@bank_sector3.name][:assumptions]).to be_nil
       end
 
       it 'should return alignment values for selected portfolio' do


### PR DESCRIPTION
Couple minor changes requested by client:
 - CP assumptions equal to "0" are ignored
 - always use Company CP data to count emission mean at CP graphs
 - Adding last_reported_year to Bank CP importer
 - Adding latest_information field to Bank Admin form