### PR TITLE
Fix bank assesment bubbles not showing

### DIFF
--- a/app/javascript/components/tpi/charts/bank-bubble/Chart.js
+++ b/app/javascript/components/tpi/charts/bank-bubble/Chart.js
@@ -155,7 +155,9 @@ const createRow = (dataRow, area, index) => (
         color: result.color
       }));
 
-      const uniqueKey = `${area.replace(/[&/\\#,+()$~%.'":*?<>{}]/g, '')}-${el.length}-${i}`;
+      // Remove special characters from the key to be able to use d3-select as it uses querySelector
+      const cleanKey = area.replace(/[^a-zA-Z0-9\-_:.]/g, '');
+      const uniqueKey = `${cleanKey}-${el.length}-${i}`;
 
       return (
         <div className="bubble-chart__cell" key={uniqueKey}>

--- a/app/javascript/components/tpi/charts/bubble/Chart.js
+++ b/app/javascript/components/tpi/charts/bubble/Chart.js
@@ -164,7 +164,9 @@ const createRow = (dataRow, title, sectors) => {
           color: LEVELS_COLORS[i]
         }));
 
-        const uniqueKey = `${title}-${el.length}-${i}`;
+        // Remove special characters from the key to be able to use d3-select as it uses querySelector
+        const cleanKey = title.replace(/[^a-zA-Z0-9\-_:.]/g, '');
+        const uniqueKey = `${cleanKey}-${el.length}-${i}`;
 
         return (
           <div className={`bubble-chart__cell ${i === dataRow.length - 1 ? 'last' : ''}`} key={uniqueKey}>


### PR DESCRIPTION
We need to clean the keys is from special characters used on the d3-select on SingleCell component

This is because is using querySelector to get the element and this method doesn't allow special characters on the ids