### PR TITLE
Update countries bubble chart colors and tooltip

### DIFF
--- a/app/javascript/components/tpi/charts/ascor-bubble/Chart.js
+++ b/app/javascript/components/tpi/charts/ascor-bubble/Chart.js
@@ -91,7 +91,6 @@ const getTooltipText = ({ tooltipContent }) => {
   if (tooltipContent) {
     return `
      <div class="bubble-tip-header">${tooltipContent.header}</div>
-     <div class="bubble-tip-text">${tooltipContent.value}</div>
     `;
   }
   return '';

--- a/app/javascript/components/tpi/charts/ascor-bubble/SingleCell.js
+++ b/app/javascript/components/tpi/charts/ascor-bubble/SingleCell.js
@@ -4,8 +4,6 @@ import { range } from 'd3-array';
 import { select } from 'd3-selection';
 import * as d3 from 'd3-force';
 
-import { partialGradient } from './constants';
-
 const SingleCell = ({
   width,
   height,
@@ -49,8 +47,7 @@ const SingleCell = ({
     u.enter()
       .append('circle')
       .attr('r', (d) => d.radius)
-      .style('fill', (d) => (d.value === 'Partial' ? 'url(#partial-gradient)' : d.color))
-      .style('stroke', (d) => d.color)
+      .style('fill', (d) => d.color)
       .merge(u)
       .attr('cx', (d) => d.x)
       .attr('cy', (d) => d.y)
@@ -71,22 +68,6 @@ const SingleCell = ({
         height="100%"
         viewBox={`0 0 ${width} ${height}`}
       >
-        <defs>
-          <pattern
-            id="partial-gradient"
-            patternUnits="userSpaceOnUse"
-            width="2"
-            height="8"
-            patternTransform="rotate(90)"
-          >
-            <rect
-              width="1"
-              height="8"
-              transform="translate(0,0)"
-              fill={partialGradient.color}
-            />
-          </pattern>
-        </defs>
         <g
           className="bubble-chart_circle_country"
           transform={`translate(${width / 2}, ${height / 2})`}

--- a/app/javascript/components/tpi/charts/ascor-bubble/constants.js
+++ b/app/javascript/components/tpi/charts/ascor-bubble/constants.js
@@ -5,14 +5,10 @@ export const SCORE_RANGES = [
   },
   {
     value: 'Partial',
-    color: '#17B091'
+    color: '#F9A400'
   },
   {
     value: 'Yes',
     color: '#17B091'
   }
 ];
-
-export const partialGradient = {
-  color: SCORE_RANGES[1].color
-};


### PR DESCRIPTION
This PR updates the ASCOR countries bubble chart colors and tooltip text

[Figma design](https://www.figma.com/file/ZyYNWRf3SJsJaBY4R9bmen/TPI---1280-%5BInternal%5D?type=design&node-id=1942-9091&mode=dev)